### PR TITLE
Add ansible.windows.win_domain_membership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,4 +391,5 @@ changelogs/.plugin-cache.yaml
 
 # ansible-test ignores
 tests/integration/inventory*
+tests/integration/targets/membership/.vagrant
 tests/output/

--- a/plugins/action/domain.py
+++ b/plugins/action/domain.py
@@ -12,8 +12,6 @@ class ActionModule(ActionModuleWithReboot):
         self._ran_once = False
 
     def _ad_should_rerun(self, result: t.Dict[str, t.Any]) -> bool:
-        result["reboot_required"] = False
-
         ran_once = self._ran_once
         self._ran_once = True
 

--- a/plugins/action/membership.py
+++ b/plugins/action/membership.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ..plugin_utils._module_with_reboot import ActionModuleWithReboot
+
+
+class ActionModule(ActionModuleWithReboot):
+    ...

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -97,10 +97,10 @@ attributes:
   bypass_host_loop:
     support: none
 seealso:
+- module: ansible.active_directory.win_domain_membership
 - module: ansible.windows.win_domain_controller
 - module: community.windows.win_domain_computer
 - module: community.windows.win_domain_group
-- module: ansible.windows.win_domain_membership
 - module: community.windows.win_domain_user
 author:
 - Matt Davis (@nitzmahone)

--- a/plugins/modules/membership.ps1
+++ b/plugins/modules/membership.ps1
@@ -1,0 +1,197 @@
+#!powershell
+
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        dns_domain_name = @{
+            type = 'str'
+        }
+        domain_admin_user = @{
+            required = $true
+            type = 'str'
+        }
+        domain_admin_password = @{
+            required = $true
+            no_log = $true
+            type = 'str'
+        }
+        domain_ou_path = @{
+            type = 'str'
+        }
+        hostname = @{
+            type = 'str'
+        }
+        log_path = @{
+            type = 'str'
+            removed_at_date = [DateTime]::ParseExact("2024-12-01", "yyyy-MM-dd", $null)
+            removed_from_collection = 'ansible.active_directory'
+        }
+        reboot = @{
+            default = $false
+            type = 'bool'
+        }
+        state = @{
+            choices = 'domain', 'workgroup'
+            required = $true
+            type = 'str'
+        }
+        workgroup_name = @{
+            type = 'str'
+        }
+    }
+    required_if = @(
+        @('state', 'domain', @(, 'dns_domain_name')),
+        @('state', 'workgroup', @(, 'workgroup_name'))
+    )
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Result.reboot_required = $false
+$module.Diff.before = @{}
+$module.Diff.after = @{}
+
+$dnsDomainName = $module.Params.dns_domain_name
+$domainCredential = if ($module.Params.domain_admin_user) {
+    New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @(
+        $module.Params.domain_admin_user,
+        (ConvertTo-SecureString -AsPlainText -Force -String $module.Params.domain_admin_password)
+    )
+}
+$domainOUPath = $module.Params.domain_ou_path
+$hostname = $module.Params.hostname
+$state = $module.Params.state
+$workgroupName = $module.Params.workgroup_name
+
+Function Get-CurrentState {
+    <#
+    .SYNOPSIS
+    Gets the current state of the host.
+    #>
+    [CmdletBinding()]
+    param ()
+
+    $cs = Get-CimInstance -ClassName Win32_ComputerSystem -Property Domain, PartOfDomain, Workgroup
+    $domainName = if ($cs.PartOfDomain) {
+        try {
+            [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name
+        }
+        catch [System.Security.Authentication.AuthenticationException] {
+            # This might happen if running as a local user on a host already
+            # joined to the domain. Just try the Win32_ComputerSystem fallback
+            # value.
+            $cs.Domain
+        }
+    }
+    else {
+        $null
+    }
+
+    [PSCustomObject]@{
+        HostName = $env:COMPUTERNAME
+        PartOfDomain = $cs.PartOfDomain
+        DnsDomainName = $domainName
+        WorkgroupName = $cs.Workgroup
+    }
+}
+
+$currentState = Get-CurrentState
+
+$module.Diff.before = @{
+    dns_domain_name = $currentState.DnsDomainName
+    hostname = $currentState.HostName
+    state = if ($currentState.PartOfDomain) { 'domain' } else { 'workgroup' }
+    workgroup_name = $currentState.WorkgroupName
+}
+if (-not $hostname) {
+    $hostname = $currentState.HostName
+}
+
+if ($state -eq 'domain') {
+    if ($dnsDomainName -ne $currentState.DnsDomainName) {
+        if ($currentState.PartOfDomain) {
+            $module.FailJson("Host is already joined to '$($currentState.DnsDomainName)', switching domains is not implemented")
+        }
+
+        $joinParams = @{
+            ComputerName = '.'
+            Credential = $domainCredential
+            DomainName = $dnsDomainName
+            Force = $true
+            WhatIf = $module.CheckMode
+        }
+        if ($hostname -ne $currentState.HostName) {
+            $joinParams.NewName = $hostname
+
+            # By setting this here, the Rename-Computer call is skipped as
+            # joining the domain will rename the host for us.
+            $hostname = $currentState.HostName
+        }
+        if ($domainOUPath) {
+            $joinParams.OUPath = $domainOUPath
+        }
+
+        Add-Computer @joinParams
+
+        $module.Result.changed = $true
+        $module.Result.reboot_required = $true
+    }
+}
+else {
+    if ($workgroupName -ne $currentState.WorkgroupName) {
+        if ($currentState.PartOfDomain) {
+            $removeParams = @{
+                UnjoinDomainCredential = $domainCredential
+                Workgroup = $workgroupName
+                Force = $true
+                WhatIf = $module.CheckMode
+            }
+
+            Remove-Computer @removeParams
+        }
+        elseif (-not $module.CheckMode) {
+            try {
+                $res = Get-CimInstance Win32_ComputerSystem | Invoke-CimMethod -MethodName JoinDomainOrWorkgroup -Arguments @{
+                    Name = $workgroupName
+                }
+            }
+            catch {
+                $module.FailJson("Failed to set workgroup as '$workgroupName': $($_.Exception.Message)", $_)
+            }
+
+            if ($res.ReturnValue -ne 0) {
+                $msg = [System.ComponentModel.Win32Exception]$res.ReturnValue
+                $module.FailJson("Failed to set workgroup as '$workgroupName', return value: $($res.ReturnValue): $msg")
+            }
+        }
+
+        $module.Result.changed = $true
+        $module.Result.reboot_required = $true
+    }
+}
+
+if ($hostname -ne $currentState.Hostname) {
+    $renameParams = @{
+        DomainCredential = $domainCredential
+        NewName = $hostname
+        WhatIf = $module.CheckMode
+        Force = $true
+    }
+    Rename-Computer @renameParams
+
+    $module.Result.changed = $true
+    $module.Result.reboot_required = $true
+}
+
+$module.Diff.after = @{
+    dns_domain_name = $dnsDomainName
+    hostname = $hostname
+    state = $state
+    workgroup_name = $workgroupName
+}
+
+$module.ExitJson()

--- a/plugins/modules/membership.py
+++ b/plugins/modules/membership.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+module: membership
+short_description: Manage domain/workgroup membership for a Windows host
+description:
+- Manages domain membership or workgroup membership for a Windows host. Also supports hostname changes.
+- This module may require subsequent use of the M(ansible.windows.win_reboot) action if changes are made.
+options:
+  dns_domain_name:
+    description:
+    - When I(state=domain), this is the DNS name of the domain to which the targeted Windows host should be joined.
+    type: str
+  domain_admin_user:
+    description:
+    - Username of a domain admin for the target domain (required to join or leave the domain).
+    required: true
+    type: str
+  domain_admin_password:
+    description:
+    - Password for the specified C(domain_admin_user).
+    required: true
+    type: str
+  domain_ou_path:
+    description:
+    - The desired OU path for adding the computer object.
+    - This is only used when adding the target host to a domain, if it is already a member then it is ignored.
+    type: str
+  hostname:
+    description:
+    - The desired hostname for the Windows host.
+    type: str
+  log_path:
+    description:
+    - This option is deprecated and is preserved for backwards compatibility.
+    - Setting it will do nothing.
+    type: str
+  reboot:
+    description:
+    - If C(true), this will reboot the host if a reboot was required to configure the domain.
+    - If C(false), this will not reboot the host if a reboot was required and instead sets the I(reboot_required) return value to C(true).
+    - If changing from a domain to workgroup, the connection account must be a local user that can connect to the host
+      after it has unjoined the domain.
+    - This cannot be used with async mode.
+    - To use this parameter, ensure the fully qualified module name is used in the task or the I(collections) keyword includes this collection.
+    type: bool
+    default: false
+  state:
+    description:
+    - Whether the target host should be a member of a domain or workgroup.
+    - When I(state=domain), I(dns_domain_name), I(domain_admin_user), and I(domain_admin_password) must be set.
+    - When I(state=workgroup), I(workgroup_name) must be set.
+    choices:
+    - domain
+    - workgroup
+    required: true
+    type: str
+  workgroup_name:
+    description:
+    - When I(state=workgroup), this is the name of the workgroup that the Windows host should be in.
+    type: str
+extends_documentation_fragment:
+- ansible.builtin.action_common_attributes
+- ansible.builtin.action_common_attributes.flow
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  platform:
+    platforms:
+    - windows
+  action:
+    support: full
+  async:
+    support: partial
+    details: Supported for all scenarios except with I(reboot=True).
+  bypass_host_loop:
+    support: none
+seealso:
+- module: ansible.active_directory.win_domain
+- module: ansible.windows.win_domain_controller
+- module: community.windows.win_domain_computer
+- module: community.windows.win_domain_group
+- module: community.windows.win_domain_user
+- module: ansible.windows.win_group
+- module: ansible.windows.win_group_membership
+- module: ansible.windows.win_user
+author:
+- Matt Davis (@nitzmahone)
+- Jordan Borean (@jborean93)
+"""
+
+EXAMPLES = r"""
+- name: join host to ansible.vagrant with automatic reboot
+  ansible.active_directory.membership:
+    dns_domain_name: ansible.vagrant
+    hostname: mydomainclient
+    domain_admin_user: testguy@ansible.vagrant
+    domain_admin_password: password123!
+    domain_ou_path: "OU=Windows,OU=Servers,DC=ansible,DC=vagrant"
+    state: domain
+    reboot: true
+
+- name: join host to workgroup with manual reboot in later task
+  ansible.active_directory.membership:
+    workgroup_name: mywg
+    domain_admin_user: '{{ win_domain_admin_user }}'
+    domain_admin_password: '{{ win_domain_admin_password }}'
+    state: workgroup
+  register: workgroup_res
+
+- name: reboot host after joining workgroup
+  ansible.windows.win_reboot:
+  when: workgroup_res.reboot_required
+"""
+
+RETURN = r"""
+reboot_required:
+  description: True if changes were made that require a reboot.
+  returned: always
+  type: bool
+  sample: true
+"""

--- a/tests/integration/targets/membership/README.md
+++ b/tests/integration/targets/membership/README.md
@@ -1,0 +1,34 @@
+# ansible.active_directory.membership tests
+
+As this cannot be run in CI this is a brief guide on how to run these tests locally.
+Run the following:
+
+```bash
+vagrant up
+
+ansible-playbook setup.yml
+```
+
+It is a good idea to create a snapshot of both hosts before running the tests.
+This allows you to reset the host back to a blank starting state if the tests need to be rerun.
+To create a snaphost do the following:
+
+```bash
+virsh snapshot-create-as --domain "membership_DC" --name "pretest"
+virsh snapshot-create-as --domain "membership_TEST" --name "pretest"
+```
+
+To restore these snapshots run the following:
+
+```bash
+virsh snapshot-revert --domain "membership_DC" --snapshotname "pretest" --running
+virsh snapshot-revert --domain "membership_TEST" --snapshotname "pretest" --running
+```
+
+Once you are ready to run the tests run the following:
+
+```bash
+ansible-playbook test.yml
+```
+
+Run `vagrant destroy` to remove the test VMs.

--- a/tests/integration/targets/membership/Vagrantfile
+++ b/tests/integration/targets/membership/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+inventory = YAML.load_file('inventory.yml')
+
+Vagrant.configure("2") do |config|
+  inventory['all']['children'].each do |group,details|
+    details['hosts'].each do |server,host_details|
+      config.vm.define server do |srv|
+        srv.vm.box = host_details['vagrant_box']
+        srv.vm.hostname = server
+        srv.vm.network :private_network,
+          :ip => host_details['ansible_host'],
+          :libvirt__network_name => 'ansible.active_directory',
+          :libvirt__domain_name => inventory['all']['vars']['domain_realm']
+
+        srv.vm.provider :libvirt do |l|
+          l.memory = 4096
+          l.cpus = 2
+        end
+      end
+    end
+  end
+end
+

--- a/tests/integration/targets/membership/aliases
+++ b/tests/integration/targets/membership/aliases
@@ -1,0 +1,2 @@
+windows
+unsupported  # can never run in CI, see README.md

--- a/tests/integration/targets/membership/ansible.cfg
+++ b/tests/integration/targets/membership/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory = inventory.yml
+retry_files_enabled = False

--- a/tests/integration/targets/membership/inventory.yml
+++ b/tests/integration/targets/membership/inventory.yml
@@ -1,0 +1,21 @@
+all:
+  children:
+    windows:
+      hosts:
+        DC:
+          ansible_host: 192.168.11.10
+          vagrant_box: jborean93/WindowsServer2022
+        TEST:
+          ansible_host: 192.168.11.11
+          vagrant_box: jborean93/WindowsServer2022
+      vars:
+        ansible_port: 5985
+        ansible_connection: psrp
+
+  vars:
+    ansible_user: vagrant
+    ansible_password: vagrant
+    domain_username: vagrant-domain
+    domain_user_upn: '{{ domain_username }}@{{ domain_realm | upper }}'
+    domain_password: VagrantPass1
+    domain_realm: ad.test

--- a/tests/integration/targets/membership/setup.yml
+++ b/tests/integration/targets/membership/setup.yml
@@ -1,0 +1,81 @@
+- name: create domain controller
+  hosts: DC
+  gather_facts: no
+
+  tasks:
+  - name: get network connection names
+    ansible.windows.win_powershell:
+      parameters:
+        IPAddress: '{{ ansible_host }}'
+      script: |
+        param ($IPAddress)
+
+        $Ansible.Changed = $false
+
+        Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'" |
+            ForEach-Object -Process {
+                $config = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "Index='$($_.Index)'"
+                if ($config.IPAddress -contains $IPAddress) {
+                    $_.NetConnectionID
+                }
+            }
+    register: connection_name
+
+  - name: set the DNS for the internal adapters to localhost
+    ansible.windows.win_dns_client:
+      adapter_names:
+      - '{{ connection_name.output[0] }}'
+      dns_servers:
+      - 127.0.0.1
+
+  - name: ensure domain exists and DC is promoted as a domain controller
+    ansible.active_directory.domain:
+      dns_domain_name: '{{ domain_realm }}'
+      safe_mode_password: '{{ domain_password }}'
+      reboot: true
+
+  - ansible.windows.win_feature:
+      name: RSAT-AD-PowerShell
+      state: present
+
+  - name: create domain username
+    community.windows.win_domain_user:
+      name: '{{ domain_username }}'
+      upn: '{{ domain_user_upn }}'
+      description: '{{ domain_username }} Domain Account'
+      password: '{{ domain_password }}'
+      password_never_expires: yes
+      update_password: when_changed
+      groups:
+      - Domain Admins
+      state: present
+
+- name: setup test host
+  hosts: TEST
+  gather_facts: no
+
+  tasks:
+  - name: get network connection names
+    ansible.windows.win_powershell:
+      parameters:
+        IPAddress: '{{ ansible_host }}'
+      script: |
+        param ($IPAddress)
+
+        $Ansible.Changed = $false
+
+        Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'" |
+            ForEach-Object -Process {
+                $config = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "Index='$($_.Index)'"
+                if ($config.IPAddress -contains $IPAddress) {
+                    $_.NetConnectionID
+                }
+            }
+    register: connection_name
+
+  - name: set DNS for the private adapter to point to the DC
+    ansible.windows.win_dns_client:
+      adapter_names:
+      - '{{ connection_name.output[0] }}'
+      dns_servers:
+      - '{{ hostvars["DC"]["ansible_host"] }}'

--- a/tests/integration/targets/membership/tasks/main.yml
+++ b/tests/integration/targets/membership/tasks/main.yml
@@ -1,0 +1,524 @@
+- set_fact:
+    get_result_script: |
+      $Ansible.Changed = $false
+      $cs = Get-CimInstance -ClassName Win32_ComputerSystem -Property Domain, PartOfDomain, Workgroup
+      $domainName = if ($cs.PartOfDomain) {
+          try {
+              [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name
+          }
+          catch [System.Security.Authentication.AuthenticationException] {
+              $cs.Domain
+          }
+      }
+      else {
+          $null
+      }
+
+      [PSCustomObject]@{
+          HostName = $env:COMPUTERNAME
+          PartOfDomain = $cs.PartOfDomain
+          DnsDomainName = $domainName
+          WorkgroupName = $cs.Workgroup
+      }
+
+    get_ad_result_script: |
+      $Ansible.Changed = $false
+      Get-ADComputer -Filter { Name -ne 'DC' } -Properties DistinguishedName, Name, Enabled |
+          Select-Object -Property DistinguishedName, Name, Enabled
+
+- name: join domain - check mode
+  membership:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: domain
+    reboot: true
+  check_mode: true
+  register: join_domain_check
+
+- name: get result of join domain - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: join_domain_check_actual
+
+- name: assert join domain - check mode
+  assert:
+    that:
+    - join_domain_check is changed
+    - join_domain_check.reboot_required == False
+    - join_domain_check_actual.output[0]["DnsDomainName"] == None
+    - join_domain_check_actual.output[0]["HostName"] == "TEST"
+    - join_domain_check_actual.output[0]["PartOfDomain"] == False
+    - join_domain_check_actual.output[0]["WorkgroupName"] == "WORKGROUP"
+
+- name: join domain with reboot
+  membership:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: domain
+    reboot: true
+  register: join_domain
+
+- name: get result of join domain with reboot
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: join_domain_actual
+
+- name: get ad result of join domain with reboot
+  ansible.windows.win_powershell:
+    script: '{{ get_ad_result_script }}'
+  delegate_to: DC
+  register: join_domain_ad_actual
+
+- name: assert join domain with reboot
+  assert:
+    that:
+    - join_domain is changed
+    - join_domain.reboot_required == False
+    - join_domain_actual.output[0]["DnsDomainName"] == domain_realm
+    - join_domain_actual.output[0]["HostName"] == "TEST"
+    - join_domain_actual.output[0]["PartOfDomain"] == True
+    - join_domain_actual.output[0]["WorkgroupName"] == None
+    - join_domain_ad_actual.output | length == 1
+    - join_domain_ad_actual.output[0]["Name"] == "TEST"
+    - join_domain_ad_actual.output[0]["Enabled"] == True
+
+- name: join domain with reboot - idempotent
+  membership:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: domain
+    reboot: true
+  register: join_domain_again
+
+- name: assert join domain with reboot - idempotent
+  assert:
+    that:
+    - not join_domain_again is changed
+    - join_domain_again.reboot_required == False
+
+- name: fail to change domain of already joined host
+  membership:
+    dns_domain_name: fake.realm
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: domain
+    reboot: true
+  register: fail_cannot_rename_domain
+  failed_when:
+  - fail_cannot_rename_domain.msg != "Host is already joined to '" ~ domain_realm ~ "', switching domains is not implemented"
+
+- name: rename hostname of domain joined host - check mode
+  membership:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    hostname: OTHER
+    state: domain
+    reboot: true
+  register: rename_host_domain_check
+  check_mode: True
+
+- name: get result of rename hostname of domain joined host - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: rename_host_domain_check_actual
+
+- name: get ad result of rename hostname of domain joined host - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_ad_result_script }}'
+  delegate_to: DC
+  register: rename_host_domain_check_ad_actual
+
+- name: assert rename hostname of domain joined host - check mode
+  assert:
+    that:
+    - rename_host_domain_check is changed
+    - rename_host_domain_check.reboot_required == False
+    - rename_host_domain_check_actual.output[0]["DnsDomainName"] == domain_realm
+    - rename_host_domain_check_actual.output[0]["HostName"] == "TEST"
+    - rename_host_domain_check_actual.output[0]["PartOfDomain"] == True
+    - rename_host_domain_check_actual.output[0]["WorkgroupName"] == None
+    - rename_host_domain_check_ad_actual.output | length == 1
+    - rename_host_domain_check_ad_actual.output[0]["Name"] == "TEST"
+    - rename_host_domain_check_ad_actual.output[0]["Enabled"] == True
+
+- name: rename hostname of domain joined host
+  membership:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    hostname: OTHER
+    state: domain
+    reboot: true
+  register: rename_host_domain
+
+- name: get result of rename hostname of domain joined host
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: rename_host_domain_actual
+
+- name: get ad result of rename hostname of domain joined host
+  ansible.windows.win_powershell:
+    script: '{{ get_ad_result_script }}'
+  delegate_to: DC
+  register: rename_host_domain_ad_actual
+
+- name: assert join domain
+  assert:
+    that:
+    - rename_host_domain is changed
+    - rename_host_domain.reboot_required == False
+    - rename_host_domain_actual.output[0]["DnsDomainName"] == domain_realm
+    - rename_host_domain_actual.output[0]["HostName"] == "OTHER"
+    - rename_host_domain_actual.output[0]["PartOfDomain"] == True
+    - rename_host_domain_actual.output[0]["WorkgroupName"] == None
+    - rename_host_domain_ad_actual.output | length == 1
+    - rename_host_domain_ad_actual.output[0]["Name"] == "OTHER"
+    - rename_host_domain_ad_actual.output[0]["Enabled"] == True
+
+- name: change domain to workgroup - check mode
+  membership:
+    workgroup_name: TEST
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: workgroup
+  register: to_workgroup_check
+  check_mode: true
+
+- name: get result of change domain to workgroup - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: to_workgroup_check_actual
+
+- name: get ad result of change domain to workgroup - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_ad_result_script }}'
+  delegate_to: DC
+  register: to_workgroup_check_ad_actual
+
+- name: assert change domain to workgroup - check mode
+  assert:
+    that:
+    - to_workgroup_check is changed
+    - to_workgroup_check.reboot_required == True
+    - to_workgroup_check_actual.output[0]["DnsDomainName"] == domain_realm
+    - to_workgroup_check_actual.output[0]["HostName"] == "OTHER"
+    - to_workgroup_check_actual.output[0]["PartOfDomain"] == True
+    - to_workgroup_check_actual.output[0]["WorkgroupName"] == None
+    - to_workgroup_check_ad_actual.output | length == 1
+    - to_workgroup_check_ad_actual.output[0]["Name"] == "OTHER"
+    - to_workgroup_check_ad_actual.output[0]["Enabled"] == True
+
+- name: change domain to workgroup
+  membership:
+    workgroup_name: TEST
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: workgroup
+  register: to_workgroup
+
+- set_fact:
+    local_user: OTHER\{{ ansible_user }}
+
+- ansible.windows.win_reboot:
+  when: to_workgroup.reboot_required
+  vars:
+    # To avoid conflicts with the domain account with the same name we
+    # explicitly prefix the user to be the local account. Failing to do so
+    # will have the connection fail as it will try to talk to the DC which
+    # ends up failing.
+    ansible_user: '{{ local_user }}'
+
+- name: get result of change domain to workgroup
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: to_workgroup_actual
+
+- name: get ad result of change domain to workgroup
+  ansible.windows.win_powershell:
+    script: '{{ get_ad_result_script }}'
+  delegate_to: DC
+  register: to_workgroup_ad_actual
+
+- name: assert change domain to workgroup
+  assert:
+    that:
+    - to_workgroup is changed
+    - to_workgroup.reboot_required == True
+    - to_workgroup_actual.output[0]["DnsDomainName"] == None
+    - to_workgroup_actual.output[0]["HostName"] == "OTHER"
+    - to_workgroup_actual.output[0]["PartOfDomain"] == False
+    - to_workgroup_actual.output[0]["WorkgroupName"] == "TEST"
+    - to_workgroup_ad_actual.output | length == 1
+    - to_workgroup_ad_actual.output[0]["Name"] == "OTHER"
+    - to_workgroup_ad_actual.output[0]["Enabled"] == False
+
+- name: remove orphaned AD account for later tests
+  ansible.windows.win_powershell:
+    script: |
+      Remove-ADComputer -Identity OTHER$ -Confirm:$false
+  delegate_to: DC
+
+- name: change domain to workgroup - idempotent
+  membership:
+    workgroup_name: TEST
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: workgroup
+    reboot: true
+  register: to_workgroup_again
+
+- name: assert change domain to workgroup - idempotent
+  assert:
+    that:
+    - not to_workgroup_again is changed
+    - to_workgroup_again.reboot_required == False
+
+- name: change workgroup - check mode
+  membership:
+    workgroup_name: TEST2
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: workgroup
+    reboot: true
+  register: change_workgroup_check
+  check_mode: true
+
+- name: get result of change workgroup - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: change_workgroup_check_actual
+
+- name: assert change workgroup - check mode
+  assert:
+    that:
+    - change_workgroup_check is changed
+    - change_workgroup_check.reboot_required == False
+    - change_workgroup_check_actual.output[0]["DnsDomainName"] == None
+    - change_workgroup_check_actual.output[0]["HostName"] == "OTHER"
+    - change_workgroup_check_actual.output[0]["PartOfDomain"] == False
+    - change_workgroup_check_actual.output[0]["WorkgroupName"] == "TEST"
+
+- name: change workgroup
+  membership:
+    workgroup_name: TEST2
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: workgroup
+    reboot: true
+  register: change_workgroup
+
+- name: get result of change workgroup
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: change_workgroup_actual
+
+- name: assert change workgroup
+  assert:
+    that:
+    - change_workgroup is changed
+    - change_workgroup.reboot_required == False
+    - change_workgroup_actual.output[0]["DnsDomainName"] == None
+    - change_workgroup_actual.output[0]["HostName"] == "OTHER"
+    - change_workgroup_actual.output[0]["PartOfDomain"] == False
+    - change_workgroup_actual.output[0]["WorkgroupName"] == "TEST2"
+
+- name: change just the hostname - check mode
+  membership:
+    workgroup_name: TEST2
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: workgroup
+    reboot: true
+    hostname: FOO
+  register: change_hostname_check
+  check_mode: true
+
+- name: get result of change just the hostname - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: change_hostname_check_actual
+
+- name: assert change just the hostname - check mode
+  assert:
+    that:
+    - change_hostname_check is changed
+    - change_hostname_check.reboot_required == False
+    - change_hostname_check_actual.output[0]["DnsDomainName"] == None
+    - change_hostname_check_actual.output[0]["HostName"] == "OTHER"
+    - change_hostname_check_actual.output[0]["PartOfDomain"] == False
+    - change_hostname_check_actual.output[0]["WorkgroupName"] == "TEST2"
+
+- name: change just the hostname
+  membership:
+    workgroup_name: TEST2
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    state: workgroup
+    reboot: true
+    hostname: FOO
+  register: change_hostname
+
+- name: get result of change just the hostname
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: change_hostname_actual
+
+- name: assert change just the hostname - check mode
+  assert:
+    that:
+    - change_hostname is changed
+    - change_hostname.reboot_required == False
+    - change_hostname_actual.output[0]["DnsDomainName"] == None
+    - change_hostname_actual.output[0]["HostName"] == "FOO"
+    - change_hostname_actual.output[0]["PartOfDomain"] == False
+    - change_hostname_actual.output[0]["WorkgroupName"] == "TEST2"
+
+- name: create custom OU
+  ansible.windows.win_powershell:
+    script: |
+      $ou = New-ADOrganizationalUnit -Name MyHosts -PassThru
+      $ou.DistinguishedName
+  delegate_to: DC
+  register: custom_ou
+
+- name: join domain with hostname and OU - check mode
+  membership:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    hostname: BAR
+    domain_ou_path: '{{ custom_ou.output[0] }}'
+    state: domain
+  register: join_ou_check
+  check_mode: true
+
+- name: get result of join domain with hostname and OU - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: join_ou_check_actual
+
+- name: assert change just the hostname - check mode
+  assert:
+    that:
+    - join_ou_check is changed
+    - join_ou_check.reboot_required == True
+    - join_ou_check_actual.output[0]["DnsDomainName"] == None
+    - join_ou_check_actual.output[0]["HostName"] == "FOO"
+    - join_ou_check_actual.output[0]["PartOfDomain"] == False
+    - join_ou_check_actual.output[0]["WorkgroupName"] == "TEST2"
+
+- name: join domain with hostname and OU
+  membership:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    hostname: BAR
+    domain_ou_path: '{{ custom_ou.output[0] }}'
+    state: domain
+  register: join_ou
+
+- ansible.windows.win_reboot:
+  when: join_ou.reboot_required
+
+- name: get result of join domain with hostname and OU
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: join_ou_actual
+
+- name: get ad result of join domain with hostname and OU
+  ansible.windows.win_powershell:
+    script: '{{ get_ad_result_script }}'
+  register: join_ou_ad_actual
+  delegate_to: DC
+
+- name: assert change just the hostname
+  assert:
+    that:
+    - join_ou is changed
+    - join_ou.reboot_required == True
+    - join_ou_actual.output[0]["DnsDomainName"] == domain_realm
+    - join_ou_actual.output[0]["HostName"] == "BAR"
+    - join_ou_actual.output[0]["PartOfDomain"] == True
+    - join_ou_actual.output[0]["WorkgroupName"] == None
+    - join_ou_ad_actual.output | length == 1
+    - join_ou_ad_actual.output[0]["Name"] == "BAR"
+    - join_ou_ad_actual.output[0]["Enabled"] == True
+    - join_ou_ad_actual.output[0]["DistinguishedName"] == "CN=BAR," ~ custom_ou.output[0]
+
+- name: change domain to workgroup with hostname change - check mode
+  membership:
+    workgroup_name: WORKGROUP
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    hostname: FOO
+    state: workgroup
+  register: to_workgroup_hostname_check
+  check_mode: true
+
+- name: get result of change domain to workgroup with hostname change - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: to_workgroup_hostname_check_actual
+
+- name: get ad result of change domain to workgroup with hostname change - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_ad_result_script }}'
+  delegate_to: DC
+  register: to_workgroup_hostname_check_ad_actual
+
+- name: assert change domain to workgroup with hostname change - check mode
+  assert:
+    that:
+    - to_workgroup_hostname_check is changed
+    - to_workgroup_hostname_check.reboot_required == True
+    - to_workgroup_hostname_check_actual.output[0]["DnsDomainName"] == domain_realm
+    - to_workgroup_hostname_check_actual.output[0]["HostName"] == "BAR"
+    - to_workgroup_hostname_check_actual.output[0]["PartOfDomain"] == True
+    - to_workgroup_hostname_check_actual.output[0]["WorkgroupName"] == None
+    - to_workgroup_hostname_check_ad_actual.output | length == 1
+    - to_workgroup_hostname_check_ad_actual.output[0]["Name"] == "BAR"
+    - to_workgroup_hostname_check_ad_actual.output[0]["Enabled"] == True
+
+- name: change domain to workgroup with hostname change
+  membership:
+    workgroup_name: WORKGROUP
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    hostname: FOO
+    state: workgroup
+    reboot: true
+  register: to_workgroup_hostname
+
+- name: get result of change domain to workgroup with hostname change
+  ansible.windows.win_powershell:
+    script: '{{ get_result_script }}'
+  register: to_workgroup_hostname_actual
+
+- name: get ad result of change domain to workgroup with hostname change
+  ansible.windows.win_powershell:
+    script: '{{ get_ad_result_script }}'
+  delegate_to: DC
+  register: to_workgroup_hostname_ad_actual
+
+- name: assert change domain to workgroup with hostname change
+  assert:
+    that:
+    - to_workgroup_hostname is changed
+    - to_workgroup_hostname.reboot_required == False
+    - to_workgroup_hostname_actual.output[0]["DnsDomainName"] == None
+    - to_workgroup_hostname_actual.output[0]["HostName"] == "FOO"
+    - to_workgroup_hostname_actual.output[0]["PartOfDomain"] == False
+    - to_workgroup_hostname_actual.output[0]["WorkgroupName"] == "WORKGROUP"
+    - to_workgroup_hostname_ad_actual.output | length == 1
+    - to_workgroup_hostname_ad_actual.output[0]["Name"] == "BAR"
+    - to_workgroup_hostname_ad_actual.output[0]["Enabled"] == False
+
+- name: remove orphaned AD account for later tests
+  ansible.windows.win_powershell:
+    script: |
+      Remove-ADComputer -Identity BAR$ -Confirm:$false
+  delegate_to: DC

--- a/tests/integration/targets/membership/test.yml
+++ b/tests/integration/targets/membership/test.yml
@@ -1,0 +1,30 @@
+- name: ensure time is in sync
+  hosts: windows
+  gather_facts: no
+  tasks:
+  - name: get current host datetime
+    command: date +%s
+    changed_when: False
+    delegate_to: localhost
+    run_once: True
+    register: local_time
+
+  - name: set datetime on Windows
+    ansible.windows.win_powershell:
+      parameters:
+        SecondsSinceEpoch: '{{ local_time.stdout | trim }}'
+      script: |
+        param($SecondsSinceEpoch)
+
+        $utc = [System.DateTimeKind]::Utc
+        $epoch = New-Object -TypeName System.DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0, $utc
+        $date = $epoch.AddSeconds($SecondsSinceEpoch)
+
+        Set-Date -Date $date
+
+- name: run ansible.active_directory.membership tests
+  hosts: TEST
+  gather_facts: no
+
+  tasks:
+  - import_tasks: tasks/main.yml


### PR DESCRIPTION
##### SUMMARY
Adds a module that is based on ansible.windows.win_domain_membership. It is designed to add a host to a domain or set the workgroup of a non-domain host.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.active_directory.membership