### PR TITLE
Add domain_controller module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,5 +391,6 @@ changelogs/.plugin-cache.yaml
 
 # ansible-test ignores
 tests/integration/inventory*
+tests/integration/targets/domain_controller/.vagrant
 tests/integration/targets/membership/.vagrant
 tests/output/

--- a/plugins/action/domain_controller.py
+++ b/plugins/action/domain_controller.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import typing as t
+
+from ..plugin_utils._module_with_reboot import ActionModuleWithReboot
+
+
+class ActionModule(ActionModuleWithReboot):
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._ran_once = False
+
+    def _ad_should_rerun(self, result: t.Dict[str, t.Any]) -> bool:
+        ran_once = self._ran_once
+        self._ran_once = True
+
+        if ran_once or not result.get("_do_action_reboot", False):
+            return False
+
+        if self._task.check_mode:
+            # Assume that on a rerun it will not have failed and that it
+            # ran successfull.
+            result["failed"] = False
+            result.pop("msg", None)
+            return False
+
+        else:
+            return True
+
+    def _ad_process_result(self, result: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+        result.pop("_do_action_reboot", None)
+
+        return result

--- a/plugins/modules/domain.ps1
+++ b/plugins/modules/domain.ps1
@@ -82,9 +82,7 @@ if ($unavailableFeatures) {
 
 $missingFeatures = $features | Where-Object InstallState -NE Installed
 if ($missingFeatures) {
-    $start = Get-Date
     $res = Install-WindowsFeature -Name $missingFeatures -WhatIf:$module.CheckMode
-    $module.Result.feature = ((Get-Date) - $start).TotalSeconds
     $module.Result.changed = $true
     $module.Result.reboot_required = [bool]$res.RestartNeeded
 
@@ -161,7 +159,6 @@ if (-not $forest) {
         $installParams.ForestMode = $forest_mode
     }
 
-    $start = Get-Date
     $res = $null
     try {
         $res = Install-ADDSForest @installParams
@@ -198,7 +195,6 @@ if (-not $forest) {
     }
 
     $module.Result.changed = $true
-    $module.Result.install = ((Get-Date) - $start).TotalSeconds
 
     if ($module.CheckMode) {
         # the return value after -WhatIf does not have RebootRequired populated

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -97,8 +97,8 @@ attributes:
   bypass_host_loop:
     support: none
 seealso:
-- module: ansible.active_directory.win_domain_membership
-- module: ansible.windows.win_domain_controller
+- module: ansible.active_directory.domain_controller
+- module: ansible.active_directory.membership
 - module: community.windows.win_domain_computer
 - module: community.windows.win_domain_group
 - module: community.windows.win_domain_user

--- a/plugins/modules/domain_controller.ps1
+++ b/plugins/modules/domain_controller.ps1
@@ -1,0 +1,276 @@
+#!powershell
+
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        database_path = @{
+            type = 'path'
+        }
+        dns_domain_name = @{
+            type = 'str'
+        }
+        domain_admin_password = @{
+            no_log = $true
+            required = $true
+            type = 'str'
+        }
+        domain_admin_user = @{
+            required = $true
+            type = 'str'
+        }
+        domain_log_path = @{
+            # FUTURE: Add alias for log_path once some time has passed
+            type = 'path'
+        }
+        install_dns = @{
+            type = 'bool'
+        }
+        install_media_path = @{
+            type = 'path'
+        }
+        local_admin_password = @{
+            no_log = $true
+            type = 'str'
+        }
+        read_only = @{
+            default = $false
+            type = 'bool'
+        }
+        reboot = @{
+            default = $false
+            type = 'bool'
+        }
+        safe_mode_password = @{
+            no_log = $true
+            type = 'str'
+        }
+        site_name = @{
+            type = 'str'
+        }
+        state = @{
+            choices = 'domain_controller', 'member_server'
+            required = $true
+            type = 'str'
+        }
+        sysvol_path = @{
+            type = 'path'
+        }
+    }
+    required_if = @(
+        , @('state', 'domain_controller', @('dns_domain_name', 'safe_mode_password'))
+        , @('state', 'member_server', @(, 'local_admin_password'))
+    )
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Result.reboot_required = $false
+$module.Result._do_action_reboot = $false  # Used by action plugin
+
+$databasePath = $module.Params.database_path
+$dnsDomainName = $module.Params.dns_domain_name
+$installDns = $module.Params.install_dns
+$installMediaPath = $module.Params.install_media_path
+$logPath = $module.Params.domain_log_path
+$readOnly = $module.Params.read_only
+$siteName = $module.Params.site_name
+$state = $module.Params.state
+$sysvolPath = $module.Params.sysvol_path
+
+$domainCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @(
+    $module.Params.domain_admin_user,
+    (ConvertTo-SecureString -AsPlainText -Force -String $module.Params.domain_admin_password)
+)
+
+if ([System.Environment]::OSVersion.Version -lt [Version]"6.2") {
+    $module.FailJson("ansible.active_directory.domain_controller requires Windows Server 2012 or higher")
+}
+
+# short-circuit "member server" check, since we don't need feature checks for this...
+# role 4/5 - backup/primary DC
+$win32CS = Get-CimInstance -ClassName Win32_ComputerSystem -Property Domain, DomainRole
+$isKdc = $win32CS.DomainRole -in @(4, 5)
+If ($state -eq "member_server" -and -not $isKdc) {
+    $module.ExitJson()
+}
+
+# all other operations will require the AD-DS and RSAT-ADDS features...
+$requiredFeatures = @("AD-Domain-Services", "RSAT-ADDS")
+$features = Get-WindowsFeature -Name $requiredFeatures
+$unavailableFeatures = Compare-Object -ReferenceObject $requiredFeatures -DifferenceObject $features.Name -PassThru
+
+if ($unavailableFeatures) {
+    $module.FailJson("The following features required for a domain controller are unavailable: $($unavailableFeatures -join ',')")
+}
+
+$missingFeatures = $features | Where-Object InstallState -NE Installed
+if ($missingFeatures) {
+    $res = Install-WindowsFeature -Name $missingFeatures -WhatIf:$module.CheckMode
+    $module.Result.changed = $true
+    $module.Result.reboot_required = [bool]$res.RestartNeeded
+
+    # When in check mode and the prereq was "installed" we need to exit early as
+    # the AD cmdlets weren't really installed
+    if ($module.CheckMode) {
+        $module.ExitJson()
+    }
+}
+
+$lastBootTime = (Get-CimInstance -ClassName Win32_OperatingSystem -Property LastBootUpTime).LastBootUpTime.ToFileTime()
+
+if ($state -eq 'domain_controller') {
+    # ensure that domain admin user is in UPN or down-level domain format (prevent hang from https://support.microsoft.com/en-us/kb/2737935)
+    If (-not $domainCredential.UserName.Contains("\") -and -not $domainCredential.UserName.Contains("@")) {
+        $module.FailJson("domain_admin_user must be in domain\user or user@domain.com format")
+    }
+
+    If ($isKdc) {
+        # FUTURE: implement managed Remove/Add to change domains?
+        If ($dnsDomainName -ne $win32CS.Domain) {
+            $msg = -join @(
+                "The host $env:COMPUTERNAME is a domain controller for the domain $($win32CS.Domain); "
+                "changing DC domains is not implemented"
+            )
+            $module.FailJson($msg)
+        }
+    }
+    else {
+        $safeModePassword = $module.Params.safe_mode_password | ConvertTo-SecureString -AsPlainText -Force
+
+        $installParams = @{
+            Confirm = $false
+            Credential = $domainCredential
+            DomainName = $dnsDomainName
+            Force = $true
+            NoRebootOnCompletion = $true
+            SafeModeAdministratorPassword = $safeModePassword
+            SkipPreChecks = $true
+            WhatIf = $module.CheckMode
+        }
+        if ($databasePath) {
+            $installParams.DatabasePath = $databasePath
+        }
+        if ($logPath) {
+            $installParams.LogPath = $logPath
+        }
+        if ($sysvolPath) {
+            $installParams.SysvolPath = $sysvolPath
+        }
+        if ($installMediaPath) {
+            $installParams.InstallationMediaPath = $installMediaPath
+        }
+        if ($readOnly) {
+            # while this is a switch value, if we set on $false site_name is required
+            # https://github.com/ansible/ansible/issues/35858
+            $installParams.ReadOnlyReplica = $true
+        }
+        if ($siteName) {
+            $installParams.SiteName = $siteName
+        }
+        if ($null -ne $installDns) {
+            $installParams.InstallDns = $installDns
+        }
+
+        try {
+            $null = Install-ADDSDomainController @installParams
+        }
+        catch [Microsoft.DirectoryServices.Deployment.DCPromoExecutionException] {
+            # ExitCode 15 == 'Role change is in progress or this computer needs to be restarted.'
+            # DCPromo exit codes details can be found at
+            # https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/troubleshooting-domain-controller-deployment
+            if ($_.Exception.ExitCode -in @(15, 19)) {
+                $module.Result.reboot_required = $true
+                $module.Result._do_action_reboot = $true
+            }
+
+            $module.FailJson("Failed to install ADDSDomainController, DCPromo exited with $($_.Exception.ExitCode): $($_.Exception.Message)", $_)
+        }
+        finally {
+            # The Netlogon service is set to auto start but is not started. This is
+            # required for Ansible to connect back to the host and reboot in a
+            # later task. Even if this fails Ansible can still connect but only
+            # with ansible_winrm_transport=basic so we just display a warning if
+            # this fails.
+            if (-not $module.CheckMode) {
+                try {
+                    Start-Service -Name Netlogon
+                }
+                catch {
+                    $msg = -join @(
+                        "Failed to start the Netlogon service after promoting the host, "
+                        "Ansible may be unable to connect until the host is manually rebooting: $($_.Exception.Message)"
+                    )
+                    $module.Warn($msg)
+                }
+            }
+        }
+
+        $module.Result.changed = $true
+        $module.Result.reboot_required = $true
+    }
+}
+else {
+    # at this point we already know we're a DC and shouldn't be (due to short circuit check)...
+    $assignedRoles = @((Get-ADDomainController -Server localhost).OperationMasterRoles)
+    $localAdminPassword = $module.Params.local_admin_password | ConvertTo-SecureString -AsPlainText -Force
+
+    # FUTURE: figure out a sane way to hand off roles automatically (designated recipient server, randomly look one up?)
+    If ($assignedRoles.Count -gt 0) {
+        $msg = -join @(
+            "This domain controller has operation master role(s) ({0}) assigned; they must be moved to other "
+            "DCs before demotion (see Move-ADDirectoryServerOperationMasterRole)" -f ($assignedRoles -join ", ")
+        )
+        $module.FailJson($msg)
+    }
+
+    # While the cmdlet has -WhatIf, it doesn't seem to work properly. Only run
+    # when not in check mode.
+    if (-not $module.CheckMode) {
+        $uninstallParams = @{
+            Confirm = $false
+            Credential = $domainCredential
+            Force = $true
+            LocalAdministratorPassword = $localAdminPassword
+            NoRebootOnCompletion = $true
+        }
+        $null = Uninstall-ADDSDomainController @uninstallParams
+    }
+
+    $module.Result.changed = $true
+    $module.Result.reboot_required = $true
+}
+
+if ($module.Result.reboot_required -and $module.Params.reboot -and -not $module.CheckMode) {
+    # Promoting or depromoting puts the server in a very funky state and it may
+    # not be possible for Ansible to connect back without a reboot is done. If
+    # the user requested the action plugin to perform the reboot then start it
+    # here and get the action plugin to continue where this left off.
+
+    $module.Result._previous_boot_time = $lastBootTime
+
+    $shutdownRegPath = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoLogonChecked'
+    Remove-Item -LiteralPath $shutdownRegPath -Force -ErrorAction SilentlyContinue
+
+    $comment = 'Reboot initiated by Ansible'
+    $stdout = $null
+    $stderr = . { shutdown.exe /r /t 10 /c $comment | Set-Variable stdout } 2>&1 | ForEach-Object ToString
+    if ($LASTEXITCODE -eq 1190) {
+        # A reboot was already scheduled, abort it and try again
+        shutdown.exe /a
+        $stdout = $null
+        $stderr = . { shutdown.exe /r /t 10 /c $comment | Set-Variable stdout } 2>&1 | ForEach-Object ToString
+    }
+
+    if ($LASTEXITCODE) {
+        $module.Result.rc = $LASTEXITCODE
+        $module.Result.stdout = $stdout
+        $module.Result.stderr = $stderr
+        $module.FailJson("Failed to initiate reboot, see rc, stdout, stderr for more information")
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/domain_controller.py
+++ b/plugins/modules/domain_controller.py
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+module: domain_controller
+short_description: Manage domain controller/member server state for a Windows host
+description:
+- Ensure that a Windows Server 2012+ host is configured as a domain controller or demoted to member server.
+- This module may require subsequent use of the M(ansible.windows.win_reboot) action if changes are made.
+options:
+  database_path:
+    description:
+    - The path to a directory on a fixed disk of the Windows host where the
+      domain database will be created..
+    - If not set then the default path is C(%SYSTEMROOT%\NTDS).
+    type: path
+  dns_domain_name:
+    description:
+    - When I(state=domain_controller), the DNS name of the domain for which the targeted Windows host should be a DC.
+    type: str
+  domain_admin_user:
+    description:
+    - Username of a domain admin for the target domain (necessary to promote or demote a domain controller).
+    type: str
+    required: true
+  domain_admin_password:
+    description:
+    - Password for the specified I(domain_admin_user).
+    type: str
+    required: true
+  domain_log_path:
+    description:
+    - Specified the fully qualified, non-UNC path to a directory on a fixed disk of the local computer that will
+      contain the domain log files.
+    type: path
+  install_dns:
+    description:
+    - Whether to install the DNS service when creating the domain controller.
+    - If not specified then the C(-InstallDns) option is not supplied to C(Install-ADDSDomainController) command,
+      see L(Install-ADDSDomainController,https://learn.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller).
+    type: bool
+  install_media_path:
+    description:
+    - The path to a directory on a fixed disk of the Windows host where the Install From Media C(IFC) data will be used.
+    - See the L(Install using IFM guide,https://social.technet.microsoft.com/wiki/contents/articles/8630.active-directory-step-by-step-guide-to-install-an-additional-domain-controller-using-ifm.aspx) for more information. # noqa
+    type: path
+  local_admin_password:
+    description:
+    - Password to be assigned to the local C(Administrator) user (required when I(state=member_server)).
+    type: str
+  read_only:
+    description:
+    - Whether to install the domain controller as a read only replica for an existing domain.
+    type: bool
+    default: no
+  reboot:
+    description:
+    - If C(true), this will reboot the host if a reboot was required to configure the server.
+    - If C(false), this will not reboot the host if a reboot was required and instead sets the I(reboot_required) return value to C(true).
+    - Multiple reboots may occur if the host required a reboot before the domain promotion.
+    - This cannot be used with async mode.
+    - To use this parameter, ensure the fully qualified module name is used in the task or the I(collections) keyword includes this collection.
+    type: bool
+    default: false
+  safe_mode_password:
+    description:
+    - Safe mode password for the domain controller (required when I(state=domain_controller)).
+    type: str
+  site_name:
+    description:
+    - Specifies the name of an existing site where you can place the new domain controller.
+    - This option is required when I(read_only=true).
+    type: str
+  state:
+    description:
+    - Whether the target host should be a domain controller or a member server.
+    type: str
+    choices:
+    - domain_controller
+    - member_server
+    required: yes
+  sysvol_path:
+    description:
+    - The path to a directory on a fixed disk of the Windows host where the
+      Sysvol folder will be created.
+    - If not set then the default path is C(%SYSTEMROOT%\SYSVOL).
+    type: path
+notes:
+- It is highly recommended to set I(reboot=true) to have Ansible manage the host reboot phase as the actions done by
+  this module puts the host in a state where it may not be possible for Ansible to reconnect in a subsequent task
+  without a reboot.
+extends_documentation_fragment:
+- ansible.builtin.action_common_attributes
+- ansible.builtin.action_common_attributes.flow
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+  platform:
+    platforms:
+    - windows
+  action:
+    support: full
+  async:
+    support: partial
+    details: Supported for all scenarios except with I(reboot=True).
+  bypass_host_loop:
+    support: none
+seealso:
+- module: ansible.active_directory.domain
+- module: ansible.active_directory.membership
+- module: community.windows.win_domain_computer
+- module: community.windows.win_domain_group
+- module: community.windows.win_domain_user
+author:
+- Matt Davis (@nitzmahone)
+- Jordan Borean (@jborean93)
+"""
+
+EXAMPLES = r"""
+- name: Ensure a server is a domain controller
+  ansible.active_directory.domain_controller:
+    dns_domain_name: ansible.vagrant
+    domain_admin_user: testguy@ansible.vagrant
+    domain_admin_password: password123!
+    safe_mode_password: password123!
+    state: domain_controller
+    reboot: true
+
+- name: Ensure a server is not a domain controller
+  ansible.active_directory.domain_controller:
+    domain_admin_user: testguy@ansible.vagrant
+    domain_admin_password: password123!
+    local_admin_password: password123!
+    state: member_server
+    reboot: true
+
+- name: Promote server as a read only domain controller
+  ansible.active_directory.domain_controller:
+    dns_domain_name: ansible.vagrant
+    domain_admin_user: testguy@ansible.vagrant
+    domain_admin_password: password123!
+    safe_mode_password: password123!
+    state: domain_controller
+    read_only: yes
+    site_name: London
+    reboot: true
+
+# This scenario is not recommended, use reboot: true when possible
+- name: Promote server with custom paths with manual reboot task
+  ansible.active_directory.domain_controller:
+    dns_domain_name: ansible.vagrant
+    domain_admin_user: testguy@ansible.vagrant
+    domain_admin_password: password123!
+    safe_mode_password: password123!
+    state: domain_controller
+    sysvol_path: D:\SYSVOL
+    database_path: D:\NTDS
+    domain_log_path: D:\NTDS
+  register: dc_promotion
+
+- name: Reboot after promotion
+  ansible.active_directory.win_reboot:
+  when: dc_promotion.reboot_required
+"""
+
+RETURN = r"""
+reboot_required:
+  description: True if changes were made that require a reboot.
+  returned: always
+  type: bool
+  sample: true
+"""

--- a/plugins/modules/membership.py
+++ b/plugins/modules/membership.py
@@ -82,8 +82,8 @@ attributes:
   bypass_host_loop:
     support: none
 seealso:
-- module: ansible.active_directory.win_domain
-- module: ansible.windows.win_domain_controller
+- module: ansible.active_directory.domain
+- module: ansible.active_directory.domain_controller
 - module: community.windows.win_domain_computer
 - module: community.windows.win_domain_group
 - module: community.windows.win_domain_user

--- a/plugins/plugin_utils/_module_with_reboot.py
+++ b/plugins/plugin_utils/_module_with_reboot.py
@@ -128,10 +128,16 @@ class ActionModuleWithReboot(ActionBase):
             invocation = module_res.pop("invocation", None)
 
             if reboot and self._ad_should_reboot(module_res):
+                previous_boot_time = module_res.pop("_previous_boot_time", None)
+
                 if self._task.check_mode:
                     reboot_res = {}
                 else:
-                    reboot_res = reboot_host(self._task.action, self._connection)
+                    reboot_res = reboot_host(
+                        self._task.action,
+                        self._connection,
+                        previous_boot_time=previous_boot_time,
+                    )
 
                 if reboot_res.get("failed", False):
                     module_res = {

--- a/tests/integration/targets/domain_controller/README.md
+++ b/tests/integration/targets/domain_controller/README.md
@@ -1,0 +1,34 @@
+# ansible.active_directory.domain_controller tests
+
+As this cannot be run in CI this is a brief guide on how to run these tests locally.
+Run the following:
+
+```bash
+vagrant up
+
+ansible-playbook setup.yml
+```
+
+It is a good idea to create a snapshot of both hosts before running the tests.
+This allows you to reset the host back to a blank starting state if the tests need to be rerun.
+To create a snaphost do the following:
+
+```bash
+virsh snapshot-create-as --domain "domain_controller_DC" --name "pretest"
+virsh snapshot-create-as --domain "domain_controller_TEST" --name "pretest"
+```
+
+To restore these snapshots run the following:
+
+```bash
+virsh snapshot-revert --domain "domain_controller_DC" --snapshotname "pretest" --running
+virsh snapshot-revert --domain "domain_controller_TEST" --snapshotname "pretest" --running
+```
+
+Once you are ready to run the tests run the following:
+
+```bash
+ansible-playbook test.yml
+```
+
+Run `vagrant destroy` to remove the test VMs.

--- a/tests/integration/targets/domain_controller/Vagrantfile
+++ b/tests/integration/targets/domain_controller/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+inventory = YAML.load_file('inventory.yml')
+
+Vagrant.configure("2") do |config|
+  inventory['all']['children'].each do |group,details|
+    details['hosts'].each do |server,host_details|
+      config.vm.define server do |srv|
+        srv.vm.box = host_details['vagrant_box']
+        srv.vm.hostname = server
+        srv.vm.network :private_network,
+          :ip => host_details['ansible_host'],
+          :libvirt__network_name => 'ansible.active_directory',
+          :libvirt__domain_name => inventory['all']['vars']['domain_realm']
+
+        srv.vm.provider :libvirt do |l|
+          l.memory = 4096
+          l.cpus = 2
+        end
+      end
+    end
+  end
+end
+

--- a/tests/integration/targets/domain_controller/aliases
+++ b/tests/integration/targets/domain_controller/aliases
@@ -1,0 +1,2 @@
+windows
+unsupported  # can never run in CI, see README.md

--- a/tests/integration/targets/domain_controller/ansible.cfg
+++ b/tests/integration/targets/domain_controller/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory = inventory.yml
+retry_files_enabled = False

--- a/tests/integration/targets/domain_controller/inventory.yml
+++ b/tests/integration/targets/domain_controller/inventory.yml
@@ -1,0 +1,21 @@
+all:
+  children:
+    windows:
+      hosts:
+        DC:
+          ansible_host: 192.168.11.10
+          vagrant_box: jborean93/WindowsServer2022
+        TEST:
+          ansible_host: 192.168.11.11
+          vagrant_box: jborean93/WindowsServer2022
+      vars:
+        ansible_port: 5985
+        ansible_connection: psrp
+
+  vars:
+    ansible_user: vagrant
+    ansible_password: vagrant
+    domain_username: vagrant-domain
+    domain_user_upn: '{{ domain_username }}@{{ domain_realm | upper }}'
+    domain_password: VagrantPass1
+    domain_realm: ad.test

--- a/tests/integration/targets/domain_controller/setup.yml
+++ b/tests/integration/targets/domain_controller/setup.yml
@@ -1,0 +1,81 @@
+- name: create domain controller
+  hosts: DC
+  gather_facts: no
+
+  tasks:
+  - name: get network connection names
+    ansible.windows.win_powershell:
+      parameters:
+        IPAddress: '{{ ansible_host }}'
+      script: |
+        param ($IPAddress)
+
+        $Ansible.Changed = $false
+
+        Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'" |
+            ForEach-Object -Process {
+                $config = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "Index='$($_.Index)'"
+                if ($config.IPAddress -contains $IPAddress) {
+                    $_.NetConnectionID
+                }
+            }
+    register: connection_name
+
+  - name: set the DNS for the internal adapters to localhost
+    ansible.windows.win_dns_client:
+      adapter_names:
+      - '{{ connection_name.output[0] }}'
+      dns_servers:
+      - 127.0.0.1
+
+  - name: ensure domain exists and DC is promoted as a domain controller
+    ansible.active_directory.domain:
+      dns_domain_name: '{{ domain_realm }}'
+      safe_mode_password: '{{ domain_password }}'
+      reboot: true
+
+  - ansible.windows.win_feature:
+      name: RSAT-AD-PowerShell
+      state: present
+
+  - name: create domain username
+    community.windows.win_domain_user:
+      name: '{{ domain_username }}'
+      upn: '{{ domain_user_upn }}'
+      description: '{{ domain_username }} Domain Account'
+      password: '{{ domain_password }}'
+      password_never_expires: yes
+      update_password: when_changed
+      groups:
+      - Domain Admins
+      state: present
+
+- name: setup test host
+  hosts: TEST
+  gather_facts: no
+
+  tasks:
+  - name: get network connection names
+    ansible.windows.win_powershell:
+      parameters:
+        IPAddress: '{{ ansible_host }}'
+      script: |
+        param ($IPAddress)
+
+        $Ansible.Changed = $false
+
+        Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'" |
+            ForEach-Object -Process {
+                $config = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "Index='$($_.Index)'"
+                if ($config.IPAddress -contains $IPAddress) {
+                    $_.NetConnectionID
+                }
+            }
+    register: connection_name
+
+  - name: set DNS for the private adapter to point to the DC
+    ansible.windows.win_dns_client:
+      adapter_names:
+      - '{{ connection_name.output[0] }}'
+      dns_servers:
+      - '{{ hostvars["DC"]["ansible_host"] }}'

--- a/tests/integration/targets/domain_controller/tasks/main.yml
+++ b/tests/integration/targets/domain_controller/tasks/main.yml
@@ -1,0 +1,232 @@
+- set_fact:
+    get_role_script: |
+      $Ansible.Changed = $false
+      Get-CimInstance -ClassName Win32_ComputerSystem -Property Domain, DomainRole, PartOfDomain |
+        Select-Object -Property @{
+            N = 'Domain'
+            E = {
+                if ($_.PartOfDomain) {
+                    $_.Domain
+                }
+                else {
+                    $null
+                }
+            }
+        }, @{
+            N = 'DomainRole'
+            E = {
+                switch ($_.DomainRole) {
+                    0 { "StandaloneWorkstation" }
+                    1 { "MemberWorkstation" }
+                    2 { "StandaloneServer" }
+                    3 { "MemberServer" }
+                    4 { "BackupDC" }
+                    5 { "PrimaryDC" }
+                }
+            }
+        }, @{
+            N = 'HostName'
+            E = { $env:COMPUTERNAME }
+        }
+
+- name: test no change when not a DC
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    local_admin_password: '{{ domain_password }}'
+    state: member_server
+    reboot: true
+  register: not_dc_no_change
+
+- name: assert test no change when not a DC
+  assert:
+    that:
+    - not not_dc_no_change is changed
+    - not_dc_no_change.reboot_required == False
+
+- name: promote to DC - check mode
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    safe_mode_password: '{{ domain_password }}'
+    state: domain_controller
+    reboot: true
+  register: to_dc_check
+  check_mode: true
+
+- name: get result of promote to DC - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_role_script }}'
+  register: to_dc_check_actual
+
+- name: assert promote to DC - check mode
+  assert:
+    that:
+    - to_dc_check is changed
+    - to_dc_check_actual.output[0]["Domain"] == None
+    - to_dc_check_actual.output[0]["DomainRole"] == "StandaloneServer"
+
+- name: change hostname to have a pending change before promotion
+  ansible.windows.win_hostname:
+    name: FOO
+
+- name: promote to DC with pending reboot
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    safe_mode_password: '{{ domain_password }}'
+    state: domain_controller
+    reboot: true
+  register: to_dc
+
+- name: get result of promote to DC with pending reboot
+  ansible.windows.win_powershell:
+    script: '{{ get_role_script }}'
+  register: to_dc_actual
+
+- name: assert promote to DC with pending reboot
+  assert:
+    that:
+    - to_dc is changed
+    - to_dc.reboot_required == False
+    - to_dc_actual.output[0]["Domain"] == domain_realm
+    - to_dc_actual.output[0]["DomainRole"] == "BackupDC"
+    - to_dc_actual.output[0]["HostName"] == "FOO"
+
+- name: promote to DC - idempotent
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    safe_mode_password: '{{ domain_password }}'
+    state: domain_controller
+    reboot: true
+  register: to_dc_again
+
+- name: assert promote to DC - idempotent
+  assert:
+    that:
+    - not to_dc_again is changed
+    - to_dc_again.reboot_required == False
+
+# The following operations will run with the domain admin account now that the
+# host is joined to the domain
+- name: change connection user and password to domain account
+  set_fact:
+    ansible_user: '{{ domain_user_upn }}'
+    ansible_password: '{{ domain_password }}'
+
+- name: fail to change domain of DC
+  domain_controller:
+    dns_domain_name: bogus.local
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    safe_mode_password: '{{ domain_password }}'
+    state: domain_controller
+    reboot: true
+  register: change_domain_fail
+  failed_when:
+  - change_domain_fail.msg != "The host FOO is a domain controller for the domain " ~ domain_realm ~ "; changing DC domains is not implemented"
+
+- name: fail with invalid username format
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_username }}'  # Must be a UPN or Netbios Name
+    domain_admin_password: '{{ domain_password }}'
+    safe_mode_password: '{{ domain_password }}'
+    state: domain_controller
+    reboot: true
+  register: invalid_user_fail
+  failed_when:
+  - invalid_user_fail.msg != "domain_admin_user must be in domain\\user or user@domain.com format"
+
+- name: set DC as member server - check mode
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    local_admin_password: '{{ domain_password }}'
+    state: member_server
+    reboot: true
+  register: member_server_check
+  check_mode: true
+
+- name: get result of set DC as member server - check mode
+  ansible.windows.win_powershell:
+    script: '{{ get_role_script }}'
+  register: member_server_check_actual
+
+- name: assert set DC as member server - check mode
+  assert:
+    that:
+    - member_server_check is changed
+    - member_server_check.reboot_required == False
+    - member_server_check_actual.output[0]["Domain"] == domain_realm
+    - member_server_check_actual.output[0]["DomainRole"] == "BackupDC"
+
+- name: set DC as member server
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    local_admin_password: '{{ domain_password }}'
+    state: member_server
+    reboot: true
+  register: member_server
+
+- name: get result of set DC as member server
+  ansible.windows.win_powershell:
+    script: '{{ get_role_script }}'
+  register: member_server_actual
+
+- name: assert set DC as member server
+  assert:
+    that:
+    - member_server is changed
+    - member_server.reboot_required == False
+    - member_server_actual.output[0]["Domain"] == domain_realm
+    - member_server_actual.output[0]["DomainRole"] == "MemberServer"
+
+- name: set DC as member server - idempotent
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    local_admin_password: '{{ domain_password }}'
+    state: member_server
+    reboot: true
+  register: member_server_again
+
+- name: assert set DC as member server - idempotent
+  assert:
+    that:
+    - not member_server_again is changed
+    - member_server_again.reboot_required == False
+
+# Promote it once more to a DC to test an edge case where Ansible is unable to
+# connect back until a reboot has occurred.
+- name: promote to DC again
+  domain_controller:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    safe_mode_password: '{{ domain_password }}'
+    state: domain_controller
+    reboot: true
+  register: to_dc_manual_reboot
+
+- name: get result of promote to DC with manual reboot
+  ansible.windows.win_powershell:
+    script: '{{ get_role_script }}'
+  register: to_dc_manual_reboot_actual
+
+- name: assert promote to DC with manual reboot
+  assert:
+    that:
+    - to_dc_manual_reboot is changed
+    - to_dc_manual_reboot.reboot_required == False
+    - to_dc_manual_reboot_actual.output[0]["Domain"] == domain_realm
+    - to_dc_manual_reboot_actual.output[0]["DomainRole"] == "BackupDC"

--- a/tests/integration/targets/domain_controller/test.yml
+++ b/tests/integration/targets/domain_controller/test.yml
@@ -1,0 +1,30 @@
+- name: ensure time is in sync
+  hosts: windows
+  gather_facts: no
+  tasks:
+  - name: get current host datetime
+    command: date +%s
+    changed_when: False
+    delegate_to: localhost
+    run_once: True
+    register: local_time
+
+  - name: set datetime on Windows
+    ansible.windows.win_powershell:
+      parameters:
+        SecondsSinceEpoch: '{{ local_time.stdout | trim }}'
+      script: |
+        param($SecondsSinceEpoch)
+
+        $utc = [System.DateTimeKind]::Utc
+        $epoch = New-Object -TypeName System.DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0, $utc
+        $date = $epoch.AddSeconds($SecondsSinceEpoch)
+
+        Set-Date -Date $date
+
+- name: run ansible.active_directory.domain_controller tests
+  hosts: TEST
+  gather_facts: no
+
+  tasks:
+  - import_tasks: tasks/main.yml


### PR DESCRIPTION
##### SUMMARY
Adds a module that is based on ansible.windows.win_domain_controller. It is designed to promote a server to a domain controller of an existing domain or de promote it back to a member server.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
domain_controller