### PR TITLE
Added group module and object_info groupType handler

### DIFF
--- a/docs/docsite/rst/guide_migration.rst
+++ b/docs/docsite/rst/guide_migration.rst
@@ -21,6 +21,8 @@ The following modules have been migrated in some shape or form into this collect
 * ``ansible.windows.win_domain_controller`` -> ``microsoft.ad.domain_controller`` - :ref:`details <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_controller>`
 * ``ansible.windows.win_domain_membership`` -> ``microsoft.ad.membership`` - :ref:`details <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_membership>`
 * ``community.windows.win_domain_computer`` -> ``microsoft.ad.computer`` - :ref:`details <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_computer>`
+* ``community.windows.win_domain_group`` -> ``microsoft.ad.group`` - :ref:`details <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_group>`
+* ``community.windows.win_domain_group_membership`` -> ``microsoft.ad.group`` - :ref:`details <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_group_membership>`
 * ``community.windows.win_domain_object_info`` -> ``microsoft.ad.object_info`` - :ref:`details <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_object_info>`
 * ``community.windows.win_domain_ou`` -> ``microsoft.ad.ou`` - :ref:`details <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_ou>`
 * ``community.windows.win_domain_user`` -> ``microsoft.ad.user`` - :ref:`details <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_user>`
@@ -95,6 +97,37 @@ The options ``offline_domain_join`` and ``odj_blob_path`` has been removed. Use 
     debug:
       var: offline_blob.blob
     when: computer_obj is changed
+
+.. _ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_group:
+
+Module ``win_domain_group``
+---------------------------
+
+Migrated to :ref:`microsoft.ad.group <ansible_collections.microsoft.ad.group_module>`.
+
+The following options have changed:
+
+* ``attributes`` - changed format as outlined in :ref:`Attributes guid <ansible_collections.microsoft.ad.docsite.guide_attributes>`
+* ``ignore_protection`` - Has been removed and ``state: absent`` will also remove objects regardless of the protection status
+* ``organizational_unit`` and ``ou`` - Have been removed, use ``path`` instead
+* ``protect`` - Has been renamed to ``protect_from_deletion`` and is now not needed to be unset for ``state: absent`` to remove the group
+
+The return values for ``win_domain_group`` have also been simplified to only return:
+
+* ``distinguished_name`` - The Distinguished Name (``DN``) of the managed OU
+* ``object_guid`` - The Object GUID of the managed OU
+* ``sid`` - The Security Identifier of the managed user
+
+All other return values have been removed, use ``microsoft.ad.object_info`` to get extra values if needed.
+
+.. _ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_group_membership:
+
+Module ``win_domain_group_membership``
+--------------------------------------
+
+Migrated to :ref:`microsoft.ad.group <ansible_collections.microsoft.ad.group_module>`.
+
+The functionality of this module has been merged with ``microsoft.ad.group``. Use the ``members`` option to ``add``, ``remove``, or ``set`` to add, remove, or set group members respectively.
 
 .. _ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_object_info:
 

--- a/plugins/doc_fragments/ad_object.py
+++ b/plugins/doc_fragments/ad_object.py
@@ -121,8 +121,8 @@ options:
     - The path of the OU or the container where the new object should exist in.
     - If no path is specified, the default is the C(defaultNamingContext) of
       domain for most objects.
-    - The default path for M(microsoft.ad.computer) and
-      M(microsoft.ad.user) have their own default path that is
+    - The modules M(microsoft.ad.computer), M(microsoft.ad.user), and
+      M(microsoft.ad.group) have their own default path that is
       configured on the Active Directory domain controller.
     type: str
   protect_from_deletion:

--- a/plugins/modules/computer.py
+++ b/plugins/modules/computer.py
@@ -41,7 +41,8 @@ options:
     type: str
 notes:
 - See R(win_domain_computer migration,ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_computer)
-  for help on migrating from M(microsoft.ad.computer) to this module.
+  for help on migrating from M(community.windows.win_domain_computer) to this
+  module.
 extends_documentation_fragment:
 - microsoft.ad.ad_object
 - ansible.builtin.action_common_attributes
@@ -60,6 +61,7 @@ seealso:
 - module: microsoft.ad.object_info
 - module: microsoft.ad.object
 - module: microsoft.ad.offline_join
+- module: microsoft.ad.group
 - ref: Migration guide <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_computer>
   description: This module replaces C(community.windows.win_domain_computer). See the migration guide for details.
 - module: community.windows.win_domain_computer

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -98,6 +98,7 @@ attributes:
     support: none
 seealso:
 - module: microsoft.ad.domain_controller
+- module: microsoft.ad.group
 - module: microsoft.ad.membership
 - module: microsoft.ad.user
 - module: microsoft.ad.computer

--- a/plugins/modules/domain_controller.py
+++ b/plugins/modules/domain_controller.py
@@ -111,10 +111,11 @@ attributes:
   bypass_host_loop:
     support: none
 seealso:
+- module: microsoft.ad.computer
 - module: microsoft.ad.domain
+- module: microsoft.ad.group
 - module: microsoft.ad.membership
 - module: microsoft.ad.user
-- module: microsoft.ad.computer
 - ref: Migration guide <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_controller>
   description: This module replaces C(ansible.windows.win_domain_controller). See the migration guide for details.
 - module: ansible.windows.win_domain_controller

--- a/plugins/modules/group.ps1
+++ b/plugins/modules/group.ps1
@@ -1,0 +1,209 @@
+#!powershell
+
+# Copyright: (c) 2023, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ..module_utils._ADObject
+
+$setParams = @{
+    PropertyInfo = @(
+        [PSCustomObject]@{
+            Name = 'category'
+            Option = @{
+                choices = 'distribution', 'security'
+                type = 'str'
+            }
+            Attribute = 'GroupCategory'
+        }
+        [PSCustomObject]@{
+            Name = 'homepage'
+            Option = @{ type = 'str' }
+            Attribute = 'Homepage'
+        }
+        [PSCustomObject]@{
+            Name = 'managed_by'
+            Option = @{ type = 'str' }
+            Attribute = 'ManagedBy'
+        }
+        [PSCustomObject]@{
+            Name = 'members'
+            Option = @{
+                type = 'dict'
+                options = @{
+                    add = @{
+                        type = 'list'
+                        elements = 'str'
+                    }
+                    remove = @{
+                        type = 'list'
+                        elements = 'str'
+                    }
+                    set = @{
+                        type = 'list'
+                        elements = 'str'
+                    }
+                }
+            }
+            Attribute = 'member'
+            New = {
+                param($Module, $ADParams, $NewParams)
+
+                $newMembers = @(
+                    foreach ($actionKvp in $Module.Params.members.GetEnumerator()) {
+                        if ($null -eq $actionKvp.Value -or $actionKvp.Key -eq 'remove') { continue }
+
+                        $invalidMembers = [System.Collections.Generic.List[string]]@()
+
+                        foreach ($m in $actionKvp.Value) {
+                            $obj = Get-AnsibleADObject -Identity $m @ADParams |
+                                Select-Object -ExpandProperty DistinguishedName
+                            if ($obj) {
+                                $obj
+                            }
+                            else {
+                                $invalidMembers.Add($m)
+                            }
+                        }
+
+                        if ($invalidMembers) {
+                            $module.FailJson("Failed to find the following ad objects for group members: '$($invalidMembers -join "', '")'")
+                        }
+                    }
+                )
+
+                if ($newMembers) {
+                    if (-not $NewParams.ContainsKey('OtherAttributes')) {
+                        $NewParams.OtherAttributes = @{}
+                    }
+                    # The AD cmdlets don't like explicitly casted arrays, use
+                    # ForEach-Object to get back a vanilla object[] to set.
+                    $NewParams.OtherAttributes.member = $newMembers | ForEach-Object { "$_" }
+                }
+                $Module.Diff.after.members = @($newMembers | Sort-Object)
+            }
+            Set = {
+                param($Module, $ADParams, $SetParams, $ADObject)
+
+                [string[]]$existingMembers = $ADObject.member
+
+                $desiredState = @{}
+                foreach ($actionKvp in $Module.Params.members.GetEnumerator()) {
+                    if ($null -eq $actionKvp.Value) { continue }
+
+                    $invalidMembers = [System.Collections.Generic.List[string]]@()
+
+                    $dns = foreach ($m in $actionKvp.Value) {
+                        $obj = Get-AnsibleADObject -Identity $m @ADParams |
+                            Select-Object -ExpandProperty DistinguishedName
+                        if ($obj) {
+                            $obj
+                        }
+                        else {
+                            $invalidMembers.Add($m)
+                        }
+                    }
+
+                    if ($invalidMembers) {
+                        $module.FailJson("Failed to find the following ad objects for group members: '$($invalidMembers -join "', '")'")
+                    }
+
+                    $desiredState[$actionKvp.Key] = @($dns)
+                }
+
+                $ignoreCase = [System.StringComparer]::OrdinalIgnoreCase
+                [string[]]$diffAfter = @()
+                if ($desiredState.ContainsKey('set')) {
+                    [string[]]$desiredMembers = $desiredState.set
+                    $diffAfter = $desiredMembers
+
+                    $toAdd = [string[]][System.Linq.Enumerable]::Except($desiredMembers, $existingMembers, $ignoreCase)
+                    $toRemove = [string[]][System.Linq.Enumerable]::Except($existingMembers, $desiredMembers, $ignoreCase)
+
+                    if ($toAdd -or $toRemove) {
+                        if (-not $SetParams.ContainsKey('Replace')) {
+                            $SetParams.Replace = @{}
+                        }
+                        $SetParams.Replace.member = $desiredMembers
+                    }
+                }
+                else {
+                    [string[]]$toAdd = @()
+                    [string[]]$toRemove = @()
+                    $diffAfter = $existingMembers
+
+                    if ($desiredState.ContainsKey('add') -and $desiredState.add) {
+                        [string[]]$desiredMembers = $desiredState.add
+                        $toAdd = [string[]][System.Linq.Enumerable]::Except($desiredMembers, $existingMembers, $ignoreCase)
+                        $diffAfter = [System.Linq.Enumerable]::Union($desiredMembers, $diffAfter, $ignoreCase)
+                    }
+                    if ($desiredState.ContainsKey('remove') -and $desiredState.remove) {
+
+                        [string[]]$desiredMembers = $desiredState.remove
+                        $toRemove = [string[]][System.Linq.Enumerable]::Intersect($desiredMembers, $existingMembers, $ignoreCase)
+                        $diffAfter = [System.Linq.Enumerable]::Except($diffAfter, $desiredMembers, $ignoreCase)
+                    }
+
+                    if ($toAdd) {
+                        if (-not $SetParams.ContainsKey('Add')) {
+                            $SetParams.Add = @{}
+                        }
+                        $SetParams.Add.member = $toAdd
+                    }
+                    if ($toRemove) {
+                        if (-not $SetParams.ContainsKey('Remove')) {
+                            $SetParams.Remove = @{}
+                        }
+                        $SetParams.Remove.member = $toRemove
+                    }
+                }
+
+                $Module.Diff.after.members = ($diffAfter | Sort-Object)
+            }
+        }
+        [PSCustomObject]@{
+            Name = 'sam_account_name'
+            Option = @{ type = 'str' }
+            Attribute = 'sAMAccountName'
+        }
+        [PSCustomObject]@{
+            Name = 'scope'
+            Option = @{
+                choices = 'domainlocal', 'global', 'universal'
+                type = 'str'
+            }
+            Attribute = 'GroupScope'
+        }
+    )
+    ModuleNoun = 'ADGroup'
+    DefaultPath = {
+        param($Module, $ADParams)
+
+        $GUID_USERS_CONTAINER_W = 'A9D1CA15768811D1ADED00C04FD8D5CD'
+        $defaultNamingContext = (Get-ADRootDSE @ADParams -Properties defaultNamingContext).defaultNamingContext
+
+        Get-ADObject @ADParams -Identity $defaultNamingContext -Properties wellKnownObjects |
+            Select-Object -ExpandProperty wellKnownObjects |
+            Where-Object { $_.StartsWith("B:32:$($GUID_USERS_CONTAINER_W):") } |
+            ForEach-Object Substring 38
+    }
+    PreAction = {
+        param ($Module, $ADParams, $ADObject)
+
+        if ($Module.Params.state -eq 'present' -and (-not $Module.Params.scope) -and (-not $ADObject)) {
+            $Module.FailJson("scope must be set when state=present and the group does not exist")
+        }
+    }
+    PostAction = {
+        param($Module, $ADParams, $ADObject)
+
+        if ($ADObject) {
+            $Module.Result.sid = $ADObject.SID.Value
+        }
+        elseif ($Module.Params.state -eq 'present') {
+            # Use dummy value for check mode when creating a new user
+            $Module.Result.sid = 'S-1-5-0000'
+        }
+    }
+}
+Invoke-AnsibleADObject @setParams

--- a/plugins/modules/group.py
+++ b/plugins/modules/group.py
@@ -1,0 +1,223 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: group
+short_description: Manage Active Directory group objects
+description:
+- Manages Active Directory group objects and their attributes.
+options:
+  category:
+    description:
+    - The category of the group.
+    - If a new group is created then C(security) will be used by default.
+    - A C(security) group can be associated with access control lists whereas
+      C(distibution) groups are typically associated with mailing distribution
+      lists.
+    - This is the value set on the C(groupType) LDAP attributes.
+    choices:
+    - distribution
+    - security
+    type: str
+  homepage:
+    description:
+    - The homepage of the group.
+    - This is the value set on the C(wWWHomePage) LDAP attribute.
+    type: str
+  managed_by:
+    description:
+    - The user or group that manages the group.
+    - The value can be in the form of a C(distinguishedName), C(objectGUID),
+      C(objectSid), or C(sAMAccountName).
+    - This is the value set on the C(managedBy) LDAP attribute.
+    type: str
+  members:
+    description:
+    - The members of the group to set.
+    - The value is a dictionary that contains 3 keys, I(add), I(remove), and
+      I(set).
+    - Each subkey is set to a list of AD principal objects to add, remove or
+      set as the members of this AD group respectively. A principal can be in
+      the form of a C(distinguishedName), C(objectGUID), C(objectSid), or
+      C(sAMAccountName).
+    - The module will fail if it cannot find any of the members referenced.
+    type: dict
+    suboptions:
+      add:
+        description:
+        - Adds the principals specified as members of the group, keeping the
+          existing membership if they are not specified.
+        type: list
+        elements: str
+      remove:
+        description:
+        - Removes the principals specified as members of the group, keeping the
+          existing membership if they are not specified.
+        type: list
+        elements: str
+      set:
+        description:
+        - Sets only the principals specified as members of the group.
+        - Any other existing member will be removed from the group membership
+          if not specified in this list.
+        - Set this to an empty list to remove all members from a group.
+        type: list
+        elements: str
+  sam_account_name:
+    description:
+    - The C(sAMAccountName) value to set for the group.
+    - If omitted, the I(name) value is used when creating a new group.
+    type: str
+  scope:
+    description:
+    - The scope of the group.
+    - This is required when I(state=present) and the group does not already
+      exist.
+    - See
+      L(Group scope,https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc755692%28v=ws.10%29)
+      for more information on the various domain group scopes.
+    - This is the value set on the C(groupType) LDAP attributes.
+    choices:
+    - domainlocal
+    - global
+    - universal
+    type: str
+notes:
+- See R(win_group migration,ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_group)
+  for help on migrating from M(community.windows.win_domain_group) to this
+  module.
+extends_documentation_fragment:
+- microsoft.ad.ad_object
+- ansible.builtin.action_common_attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  platform:
+    platforms:
+    - windows
+seealso:
+- module: microsoft.ad.domain
+- module: microsoft.ad.domain_controller
+- module: microsoft.ad.membership
+- module: microsoft.ad.object_info
+- module: microsoft.ad.object
+- module: microsoft.ad.user
+- ref: Migration guide <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_group>
+  description: This module replaces C(community.windows.win_domain_group). See the migration guide for details.
+- module: community.windows.win_domain_group
+author:
+- Jordan Borean (@jborean93)
+"""
+
+EXAMPLES = r"""
+- name: Ensure a group exists
+  microsoft.ad.group:
+    name: Cow
+    scope: global
+
+- name: Remove a group
+  microsoft.ad.group:
+    name: Cow
+    state: absent
+
+- name: Create a group in a custom path
+  microsoft.ad.group:
+    name: Cow
+    scope: global
+    path: OU=groups,DC=ansible,DC=local
+    state: present
+
+- name: Remove a group in a custom path
+  microsoft.ad.group:
+    name: Cow
+    path: OU=groups,DC=ansible,DC=local
+    state: absent
+
+- name: Create group with delete protection enabled and custom attributes
+  microsoft.ad.group:
+    name: Ansible Users
+    scope: domainlocal
+    category: security
+    homepage: www.ansible.com
+    attributes:
+      set:
+        mail: helpdesk@ansible.com
+    protect_from_deletion: true
+
+- name: Change the path of a group
+  microsoft.ad.group:
+    name: MyGroup
+    scope: global
+    identity: S-1-5-21-2171456218-3732823212-122182344-1189
+    path: OU=groups,DC=ansible,DC=local
+
+- name: Add managed_by user
+  microsoft.ad.group:
+    name: Group Name Here
+    scope: global
+    managed_by: Domain Admins
+
+- name: Add group and specify the AD domain services to use for the create
+  microsoft.ad.group:
+    name: Test Group
+    domain_username: user@CORP.ANSIBLE.COM
+    domain_password: Password01!
+    domain_server: corp-DC12.corp.ansible.com
+    scope: domainlocal
+
+- name: Add members to the group, preserving existing membership
+  microsoft.ad.group:
+    name: Test Group
+    scope: domainlocal
+    members:
+      add:
+      - Domain Admins
+      - Domain Users
+
+- name: Remove members from the group, preserving existing membership
+  microsoft.ad.group:
+    name: Test Group
+    scope: domainlocal
+    members:
+      remove:
+      - Domain Admins
+      - Domain Users
+
+- name: Replace entire membership of group
+  microsoft.ad.group:
+    name: Test Group
+    scope: domainlocal
+    members:
+      set:
+      - Domain Admins
+      - Domain Users
+"""
+
+RETURN = r"""
+object_guid:
+  description:
+  - The C(objectGUID) of the AD object that was created, removed, or edited.
+  - If a new object was created in check mode, a GUID of 0s will be returned.
+  returned: always
+  type: str
+  sample: d84a141f-2b99-4f08-9da0-ed2d26864ba1
+distinguished_name:
+  description:
+  - The C(distinguishedName) of the AD object that was created, removed, or edited.
+  returned: always
+  type: str
+  sample: CN=MyGroup,CN=Users,,DC=domain,DC=test
+sid:
+  description:
+  - The Security Identifier (SID) of the group managed.
+  - If a new group was created in check mode, the SID will be C(S-1-5-0000).
+  returned: always
+  type: str
+  sample: S-1-5-21-4151808797-3430561092-2843464588-1104
+"""

--- a/plugins/modules/membership.py
+++ b/plugins/modules/membership.py
@@ -93,9 +93,13 @@ attributes:
 seealso:
 - module: microsoft.ad.domain
 - module: microsoft.ad.domain_controller
+- module: microsoft.ad.group
 - module: microsoft.ad.offline_join
 - module: microsoft.ad.user
 - module: microsoft.ad.computer
+- module: ansible.windows.win_group
+- module: ansible.windows.win_group_membership
+- module: ansible.windows.win_user
 - ref: Migration guide <ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_membership>
   description: This module replaces C(ansible.windows.win_domain_membership). See the migration guide for details.
 - module: ansible.windows.win_domain_membership

--- a/plugins/modules/object.py
+++ b/plugins/modules/object.py
@@ -41,7 +41,7 @@ seealso:
 - module: microsoft.ad.object_info
 - module: microsoft.ad.user
 - module: microsoft.ad.computer
-- module: community.windows.win_domain_group
+- module: microsoft.ad.group
 author:
 - Jordan Borean (@jborean93)
 """

--- a/plugins/modules/object_info.py
+++ b/plugins/modules/object_info.py
@@ -84,9 +84,9 @@ options:
     - subtree
     type: str
 notes:
-- The C(sAMAccountType_AnsibleFlags) and C(userAccountControl_AnsibleFlags) return property is something set by the
-  module itself as an easy way to view what those flags represent. These properties cannot be used as part of the
-  I(filter) or I(ldap_filter) and are automatically added if those properties were requested.
+- The C(groupType_AnsibleFlags), C(sAMAccountType_AnsibleFlags), and C(userAccountControl_AnsibleFlags) return property
+  is something set by the module itself as an easy way to view what those flags represent. These properties cannot be
+  used as part of the I(filter) or I(ldap_filter) and are automatically added if those properties were requested.
 extends_documentation_fragment:
 - ansible.builtin.action_common_attributes
 attributes:
@@ -100,6 +100,7 @@ attributes:
 seealso:
 - module: microsoft.ad.domain
 - module: microsoft.ad.domain_controller
+- module: microsoft.ad.group
 - module: microsoft.ad.object
 - module: microsoft.ad.user
 - module: microsoft.ad.computer

--- a/plugins/modules/ou.py
+++ b/plugins/modules/ou.py
@@ -63,6 +63,7 @@ attributes:
 seealso:
 - module: microsoft.ad.domain
 - module: microsoft.ad.domain_controller
+- module: microsoft.ad.group
 - module: microsoft.ad.object_info
 - module: microsoft.ad.user
 - module: microsoft.ad.computer

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -213,6 +213,7 @@ attributes:
 seealso:
 - module: microsoft.ad.domain
 - module: microsoft.ad.domain_controller
+- module: microsoft.ad.group
 - module: microsoft.ad.object
 - module: microsoft.ad.object_info
 - module: microsoft.ad.computer

--- a/tests/integration/targets/group/aliases
+++ b/tests/integration/targets/group/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/group/meta/main.yml
+++ b/tests/integration/targets/group/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_domain

--- a/tests/integration/targets/group/tasks/main.yml
+++ b/tests/integration/targets/group/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: remove temp group
+  group:
+    name: MyGroup
+    state: absent
+
+- block:
+  - import_tasks: tests.yml
+
+  always:
+  - name: remove temp group
+    group:
+      name: MyGroup
+      identity: '{{ object_identity | default(omit) }}'
+      state: absent

--- a/tests/integration/targets/group/tasks/tests.yml
+++ b/tests/integration/targets/group/tasks/tests.yml
@@ -1,0 +1,491 @@
+- name: fail to create group without scope
+  group:
+    name: MyGroup
+    state: present
+  register: fail_no_scope
+  failed_when: fail_no_scope.msg != "scope must be set when state=present and the group does not exist"
+
+- name: create group - check
+  group:
+    name: MyGroup
+    state: present
+    scope: global
+  register: create_group_check
+  check_mode: true
+
+- name: get result of create group - check
+  object_info:
+    identity: '{{ create_group_check.distinguished_name }}'
+  register: create_group_check_actual
+
+- name: assert create group - check
+  assert:
+    that:
+    - create_group_check is changed
+    - create_group_check.distinguished_name == 'CN=MyGroup,CN=Users,' ~ setup_domain_info.output[0].defaultNamingContext
+    - create_group_check.object_guid == '00000000-0000-0000-0000-000000000000'
+    - create_group_check.sid == 'S-1-5-0000'
+    - create_group_check_actual.objects == []
+
+- name: create group
+  group:
+    name: MyGroup
+    state: present
+    scope: global
+  register: create_group
+
+- set_fact:
+    object_identity: '{{ create_group.object_guid }}'
+
+- name: get result of create group
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - groupType
+    - objectSid
+  register: create_group_actual
+
+- name: assert create group
+  assert:
+    that:
+    - create_group is changed
+    - create_group.distinguished_name == 'CN=MyGroup,CN=Users,' ~ setup_domain_info.output[0].defaultNamingContext
+    - create_group_actual.objects | length == 1
+    - create_group.object_guid == create_group_actual.objects[0].ObjectGUID
+    - create_group.sid == create_group_actual.objects[0].objectSid.Sid
+    - create_group_actual.objects[0].groupType_AnsibleFlags == ["GROUP_TYPE_ACCOUNT_GROUP", "GROUP_TYPE_SECURITY_ENABLED"]
+
+- name: create group - idempotent
+  group:
+    name: MyGroup
+    state: present
+  register: create_group_again
+
+- name: assert create group - idempotent
+  assert:
+    that:
+    - not create_group_again is changed
+
+- name: create ou to store group members
+  ou:
+    name: MyOU
+    state: present
+  register: ou_info
+
+- block:
+  - name: create test users
+    user:
+      name: My User {{ item }}
+      sam_account_name: my_user_{{ item }}
+      upn: user_{{ item }}@{{ domain_realm }}
+      state: present
+      path: '{{ ou_info.distinguished_name }}'
+    register: test_users
+    loop:
+    - 1
+    - 2
+    - 3
+    - 4
+
+  - name: fail to find members to add to a group
+    group:
+      name: MyGroup
+      state: present
+      members:
+        add:
+        - my_user_1
+        - fake-user
+        - my_user_2
+        - another-user
+    register: fail_invalid_members
+    failed_when: 'fail_invalid_members.msg != "Failed to find the following ad objects for group members: ''fake-user'', ''another-user''"'
+
+  - name: add members to a group - check
+    group:
+      name: MyGroup
+      state: present
+      members:
+        add:
+        - my_user_1
+        - '{{ test_users.results[2].sid }}'
+    register: add_member_check
+    check_mode: true
+
+  - name: get result of add members to a group - check
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - member
+    register: add_member_check_actual
+
+  - name: assert add members to a group - check
+    assert:
+      that:
+      - add_member_check is changed
+      - add_member_check_actual.objects[0].member == None
+
+  - name: add members to a group
+    group:
+      name: MyGroup
+      state: present
+      members:
+        add:
+        - my_user_1
+        - '{{ test_users.results[2].sid }}'
+    register: add_member
+
+  - name: get result of add members to a group
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - member
+    register: add_member_actual
+
+  - name: assert add members to a group
+    assert:
+      that:
+      - add_member is changed
+      - add_member_actual.objects[0].member | length == 2
+      - test_users.results[0].distinguished_name in add_member_actual.objects[0].member
+      - test_users.results[2].distinguished_name in add_member_actual.objects[0].member
+
+  - name: add members to a group - idempotent
+    group:
+      name: MyGroup
+      state: present
+      members:
+        add:
+        - user_1@{{ domain_realm }}
+        - '{{ test_users.results[2].object_guid }}'
+    register: add_member_again
+
+  - name: assert add members to a group - idempotent
+    assert:
+      that:
+      - not add_member_again is changed
+
+  - name: remove member from a group
+    group:
+      name: MyGroup
+      state: present
+      members:
+        remove:
+        - '{{ test_users.results[0].distinguished_name | upper }}'
+        - my_user_2
+    register: remove_member
+
+  - name: get result of remove member from a group
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - member
+    register: remove_member_actual
+
+  - name: assert remove member from a group
+    assert:
+      that:
+      - remove_member is changed
+      - remove_member_actual.objects[0].member == test_users.results[2].distinguished_name
+
+  - name: remove member from a group - idempotent
+    group:
+      name: MyGroup
+      state: present
+      members:
+        remove:
+        - '{{ test_users.results[0].object_guid }}'
+    register: remove_member_again
+
+  - name: assert remove member from a group - idempotent
+    assert:
+      that:
+      - not remove_member_again is changed
+
+  - name: add and remove members from a group
+    group:
+      name: MyGroup
+      state: present
+      members:
+        add:
+        - my_user_1
+        - user_2@{{ domain_realm }}
+        remove:
+        - my_user_3
+        - my_user_4
+    register: add_remove_member
+
+  - name: get result of add and remove members from a group
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - member
+    register: add_remove_member_actual
+
+  - name: assert add and remove members from a group
+    assert:
+      that:
+      - add_remove_member is changed
+      - add_remove_member_actual.objects[0].member | length == 2
+      - test_users.results[0].distinguished_name in add_remove_member_actual.objects[0].member
+      - test_users.results[1].distinguished_name in add_remove_member_actual.objects[0].member
+
+  - name: set members
+    group:
+      name: MyGroup
+      state: present
+      members:
+        set:
+        - my_user_1
+        - my_user_3
+    register: set_member
+
+  - name: get result of set members
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - member
+    register: set_member_actual
+
+  - name: assert set members
+    assert:
+      that:
+      - set_member is changed
+      - set_member_actual.objects[0].member | length == 2
+      - test_users.results[0].distinguished_name in set_member_actual.objects[0].member
+      - test_users.results[2].distinguished_name in set_member_actual.objects[0].member
+
+  - name: set members - idempotent
+    group:
+      name: MyGroup
+      state: present
+      members:
+        set:
+        - My_user_1
+        - '{{ test_users.results[2].sid }}'
+    register: set_member_again
+
+  - name: assert set members - idempotent
+    assert:
+      that:
+      - not set_member_again is changed
+
+  - name: unset all members
+    group:
+      name: MyGroup
+      state: present
+      members:
+        set: []
+    register: unset_member
+
+  - name: get result of unset all members
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - member
+    register: unset_member_actual
+
+  - name: assert unset all members
+    assert:
+      that:
+      - unset_member is changed
+      - unset_member_actual.objects[0].member == None
+
+  - name: unset all members - idempotent
+    group:
+      name: MyGroup
+      state: present
+      members:
+        set: []
+    register: unset_member_again
+
+  - name: assert unset all members - idempotent
+    assert:
+      that:
+      - not unset_member_again is changed
+
+  - name: remove group - check
+    group:
+      name: MyGroup
+      state: absent
+    register: remove_group_check
+    check_mode: true
+
+  - name: get result of remove group - check
+    object_info:
+      identity: '{{ object_identity }}'
+    register: remove_group_check_actual
+
+  - name: assert remove group - check
+    assert:
+      that:
+      - remove_group_check is changed
+      - remove_group_check_actual.objects | length == 1
+
+  - name: remove group
+    group:
+      name: MyGroup
+      state: absent
+    register: remove_group
+
+  - name: get result of remove group
+    object_info:
+      identity: '{{ object_identity }}'
+    register: remove_group_actual
+
+  - name: assert remove group
+    assert:
+      that:
+      - remove_group is changed
+      - remove_group_actual.objects == []
+
+  - name: remove group - idempotent
+    group:
+      name: MyGroup
+      state: absent
+    register: remove_group_again
+
+  - name: assert remove group - idempotent
+    assert:
+      that:
+      - not remove_group_again is changed
+
+  - name: fail to create group with invalid members
+    group:
+      name: MyGroup
+      state: present
+      scope: domainlocal
+      members:
+        add:
+        - my_user_1
+        - fake-user
+        - my_user_2
+        - another-user
+    register: fail_invalid_members
+    failed_when: 'fail_invalid_members.msg != "Failed to find the following ad objects for group members: ''fake-user'', ''another-user''"'
+
+  - name: create group with custom options
+    group:
+      name: MyGroup
+      state: present
+      path: '{{ ou_info.distinguished_name }}'
+      display_name: My Display Name
+      description: My Description
+      scope: domainlocal
+      category: distribution
+      homepage: www.ansible.com
+      managed_by: Domain Admins
+      members:
+        add:
+        - my_user_1
+        - '{{ test_users.results[1].object_guid }}'
+        set:
+        - '{{ test_users.results[2].sid }}'
+      sam_account_name: GroupSAM
+    register: group_custom
+
+  - set_fact:
+      object_identity: '{{ group_custom.object_guid }}'
+
+  - name: get result of create group with custom options
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - Description
+      - DisplayName
+      - groupType
+      - managedBy
+      - member
+      - objectSid
+      - wWWHomePage
+      - sAMAccountName
+    register: group_custom_actual
+
+  - name: assert create group with custom options
+    assert:
+      that:
+      - group_custom is changed
+      - group_custom.distinguished_name == "CN=MyGroup," ~ ou_info.distinguished_name
+      - group_custom_actual.objects[0].DistinguishedName == group_custom.distinguished_name
+      - group_custom_actual.objects[0].ObjectGUID == group_custom.object_guid
+      - group_custom_actual.objects[0].objectSid.Sid == group_custom.sid
+      - group_custom_actual.objects[0].Description == 'My Description'
+      - group_custom_actual.objects[0].DisplayName == 'My Display Name'
+      - group_custom_actual.objects[0].Name == 'MyGroup'
+      - group_custom_actual.objects[0].groupType_AnsibleFlags == ["GROUP_TYPE_RESOURCE_GROUP"]
+      - group_custom_actual.objects[0].managedBy == "CN=Domain Admins,CN=Users," ~ setup_domain_info.output[0].defaultNamingContext
+      - group_custom_actual.objects[0].member | length == 3
+      - test_users.results[0].distinguished_name in group_custom_actual.objects[0].member
+      - test_users.results[1].distinguished_name in group_custom_actual.objects[0].member
+      - test_users.results[2].distinguished_name in group_custom_actual.objects[0].member
+      - group_custom_actual.objects[0].sAMAccountName == "GroupSAM"
+      - group_custom_actual.objects[0].wWWHomePage == "www.ansible.com"
+
+  - name: edit group
+    group:
+      name: MyGroup
+      state: present
+      path: '{{ ou_info.distinguished_name }}'
+      display_name: my display name
+      description: ''
+      homepage: www.Ansible.com
+      members:
+        set: []
+      sam_account_name: MyGroup
+    register: group_edit
+
+  - name: get result of edit group
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - Description
+      - DisplayName
+      - groupType
+      - member
+      - objectSid
+      - wWWHomePage
+      - sAMAccountName
+    register: group_edit_actual
+
+  - name: assert edit group
+    assert:
+      that:
+      - group_edit is changed
+      - group_edit_actual.objects[0].DistinguishedName == group_edit.distinguished_name
+      - group_edit_actual.objects[0].ObjectGUID == group_edit.object_guid
+      - group_edit_actual.objects[0].objectSid.Sid == group_edit.sid
+      - group_edit_actual.objects[0].Description == None
+      - group_edit_actual.objects[0].DisplayName == 'my display name'
+      - group_edit_actual.objects[0].Name == 'MyGroup'
+      - group_edit_actual.objects[0].groupType_AnsibleFlags == ["GROUP_TYPE_RESOURCE_GROUP"]
+      - group_edit_actual.objects[0].member == None
+      - group_edit_actual.objects[0].sAMAccountName == "MyGroup"
+      - group_edit_actual.objects[0].wWWHomePage == "www.Ansible.com"
+
+  - name: edit group scope and category
+    group:
+      name: MyGroup
+      state: present
+      path: '{{ ou_info.distinguished_name }}'
+      scope: universal
+      category: security
+    register: edit_scope
+
+  - name: get result of edit group scope and category
+    object_info:
+      identity: '{{ object_identity }}'
+      properties:
+      - groupType
+    register: edit_scope_actual
+
+  - name: assert edit group scope and category
+    assert:
+      that:
+      - edit_scope is changed
+      - edit_scope_actual.objects[0].groupType_AnsibleFlags == ["GROUP_TYPE_UNIVERSAL_GROUP", "GROUP_TYPE_SECURITY_ENABLED"]
+
+  always:
+  - name: remove test ou
+    ou:
+      name: MyOU
+      state: absent
+      identity: '{{ ou_info.object_guid }}'

--- a/tests/integration/targets/object_info/tasks/main.yml
+++ b/tests/integration/targets/object_info/tasks/main.yml
@@ -91,6 +91,18 @@
     - by_guid_custom_props.objects[0].userAccountControl == 66050
     - by_guid_custom_props.objects[0].userAccountControl_AnsibleFlags == ['ADS_UF_ACCOUNTDISABLE', 'ADS_UF_NORMAL_ACCOUNT', 'ADS_UF_DONT_EXPIRE_PASSWD']
 
+- name: get the groupType attribute
+  object_info:
+    filter: sAMAccountName -eq 'Domain Admins'
+    properties:
+    - groupType
+  register: group_type_prop
+
+- name: assert get the groupType attribute
+  assert:
+    that:
+    - group_type_prop.objects[0].groupType_AnsibleFlags == ["GROUP_TYPE_ACCOUNT_GROUP", "GROUP_TYPE_SECURITY_ENABLED"]
+
 - name: get invalid property
   object_info:
     filter: sAMAccountName -eq 'Ansible Test'


### PR DESCRIPTION
##### SUMMARY
Adds the `microsoft.ad.group` module which implements the same functionality of `community.windows.win_domain_group` and `community.windows.win_domain_group_membership`. Also adds the `groupType_AnsibleFlags` return value for `microsoft.ad.object_info` to more easily parse the `groupType` values it can return.

##### ISSUE TYPE
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
group
object_info