### PR TITLE
Add extra options for computer and enc types to object_info

### DIFF
--- a/plugins/modules/computer.ps1
+++ b/plugins/modules/computer.ps1
@@ -9,6 +9,16 @@
 $setParams = @{
     PropertyInfo = @(
         [PSCustomObject]@{
+            Name = 'delegates'
+            Option = @{
+                aliases = 'principals_allowed_to_delegate'
+                type = 'list'
+                elements = 'str'
+            }
+            Attribute = 'PrincipalsAllowedToDelegateToAccount'
+            CaseInsensitive = $true
+        }
+        [PSCustomObject]@{
             Name = 'dns_hostname'
             Option = @{ type = 'str' }
             Attribute = 'DNSHostName'
@@ -19,6 +29,21 @@ $setParams = @{
             Attribute = 'Enabled'
         }
         [PSCustomObject]@{
+            Name = 'kerberos_encryption_types'
+            Option = @{
+                choices = 'aes128', 'aes256', 'des', 'none', 'rc4'
+                type = 'list'
+                elements = 'str'
+            }
+            Attribute = 'KerberosEncryptionType'
+            CaseInsensitive = $true
+        }
+        [PSCustomObject]@{
+            Name = 'location'
+            Option = @{ type = 'str' }
+            Attribute = 'Location'
+        }
+        [PSCustomObject]@{
             Name = 'managed_by'
             Option = @{ type = 'str' }
             Attribute = 'ManagedBy'
@@ -27,6 +52,77 @@ $setParams = @{
             Name = 'sam_account_name'
             Option = @{ type = 'str' }
             Attribute = 'sAMAccountName'
+        }
+        [PSCustomObject]@{
+            Name = 'spn'
+            Option = @{
+                type = 'list'
+                elements = 'str'
+                aliases = 'spns'
+            }
+            Attribute = 'servicePrincipalNames'
+            Set = {
+                param($Module, $ADParams, $SetParams, $ADObject)
+
+                [string[]]$existing = @($ADObject.servicePrincipalNames.Value)
+                [string[]]$desired = @($Module.Params.spn)
+
+                $ignoreCase = [System.StringComparer]::OrdinalIgnoreCase
+
+                [string[]]$toAdd = @()
+                [string[]]$toRemove = @()
+                [string[]]$diffAfter = @()
+                switch ($Module.Params.spn_action) {
+                    add {
+                        $toAdd = [System.Linq.Enumerable]::Except($desired, $existing, $ignoreCase)
+                        $diffAfter = [System.Linq.Enumerable]::Union($desired, $existing, $ignoreCase)
+                    }
+                    remove {
+                        $toRemove = [System.Linq.Enumerable]::Intersect($desired, $existing, $ignoreCase)
+                        $diffAfter = [System.Linq.Enumerable]::Except($existing, $desired, $ignoreCase)
+                    }
+                    set {
+                        $toAdd = [System.Linq.Enumerable]::Except($desired, $existing, $ignoreCase)
+                        $toRemove = [System.Linq.Enumerable]::Except($existing, $desired, $ignoreCase)
+                        $diffAfter = $desired
+                    }
+                }
+
+                $spnValue = @{}
+                if ($toAdd) {
+                    # For whatever reason the Set-ADComputer doesn't like a
+                    # tainted [string[]] typed array, use ForEach-Object to
+                    # bypass this
+                    $spnValue.Add = $toAdd | ForEach-Object { "$_" }
+                }
+                if ($toRemove) {
+                    $spnValue.Remove = $toRemove | ForEach-Object { "$_" }
+                }
+
+                if ($spnValue.Count) {
+                    $SetParams.ServicePrincipalNames = $spnValue
+                }
+
+                $Module.Diff.after.spn = @($diffAfter | Sort-Object)
+            }
+        }
+        [PSCustomObject]@{
+            Name = 'spn_action'
+            Option = @{
+                choices = 'add', 'remove', 'set'
+                default = 'set'
+                type = 'str'
+            }
+        }
+        [PSCustomObject]@{
+            Name = 'trusted_for_delegation'
+            Option = @{ type = 'bool' }
+            Attribute = 'TrustedForDelegation'
+        }
+        [PSCustomObject]@{
+            Name = 'upn'
+            Option = @{ type = 'str' }
+            Attribute = 'userPrincipalName'
         }
     )
     ModuleNoun = 'ADComputer'

--- a/plugins/modules/computer.py
+++ b/plugins/modules/computer.py
@@ -11,6 +11,21 @@ short_description: Manage Active Directory computer objects
 description:
 - Manages Active Directory computer objects and their attributes.
 options:
+  delegates:
+    description:
+    - Specifies an array of principal objects that the current AD object can
+      trust for delegation.
+    - Must be specified as a distinguished name
+      C(CN=shenetworks,CN=Users,DC=ansible,DC=test)
+    - This is the value set on the C(msDS-AllowedToActOnBehalfOfOtherIdentity)
+      LDAP attribute.
+    - This is a highly sensitive attribute as it allows the principals
+      specified to impersonate any account when authenticating with the AD
+      computer object being managed.
+    aliases:
+    - principals_allowed_to_delegate
+    type: list
+    elements: str
   dns_hostname:
     description:
     - Specifies the fully qualified domain name (FQDN) of the computer.
@@ -21,6 +36,28 @@ options:
     - C(yes) will enable the group.
     - C(no) will disable the group.
     type: bool
+  kerberos_encryption_types:
+    description:
+    - Specifies the Kerberos encryption types supported the AD computer
+      account.
+    - This is the value set on the C(msDS-SupportedEncryptionTypes) LDAP
+      attribute.
+    - Use C(none) to remove all encryption types from the account.
+    - Avoid using C(rc4) or C(des) as they are older an insecure encryption
+      protocols.
+    choices:
+    - aes128
+    - aes256
+    - des
+    - none
+    - rc4
+    type: list
+    elements: str
+  location:
+    description:
+    - Sets the location of the computer account.
+    - This is the value set on the C(location) LDAP attribute.
+    type: str
   managed_by:
     description:
     - The user or group that manages the object.
@@ -38,6 +75,39 @@ options:
       created.
     - Note that all computer C(sAMAccountName) values need to end with a C($).
     - If C($) is omitted, it will be added to the end.
+    type: str
+  spn:
+    description:
+    - Specifies the service principal name(s) for the account. This parameter
+      sets the ServicePrincipalNames property of the account.
+    - This is the value set on the C(servicePrincipalName) LDAP attribute.
+    aliases:
+    - spns
+    type: list
+    elements: str
+  spn_action:
+    description:
+    - If C(add), the SPNs are added to the user.
+    - If C(remove), the SPNs are removed from the user.
+    - If C(set), the defined set of SPN's overwrite the current set of SPNs.
+    choices:
+    - add
+    - remove
+    - set
+    default: set
+    type: str
+  trusted_for_delegation:
+    description:
+    - Specifies whether an account is trusted for Kerberos delegation.
+    - This is also known as unconstrained Kerberos delegation.
+    - This sets the C(ADS_UF_TRUSTED_FOR_DELEGATION) flag in the
+      C(userAccountControl) LDAP attribute.
+    type: bool
+  upn:
+    description:
+    - Configures the User Principal Name (UPN) for the account.
+    - The format is C(<username>@<domain>).
+    - This is the value set on the C(userPrincipalName) LDAP attribute.
     type: str
 notes:
 - See R(win_domain_computer migration,ansible_collections.microsoft.ad.docsite.guide_migration.migrated_modules.win_domain_computer)

--- a/plugins/modules/object_info.ps1
+++ b/plugins/modules/object_info.ps1
@@ -97,6 +97,17 @@ namespace Ansible.WinDomainObjectInfo
         ADS_UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION = 0x01000000,
     }
 
+    [Flags]
+    public enum SupportedEncryptionTypes : int
+    {
+        None = 0x00,
+        DES_CBC_CRC = 0x01,
+        DES_CBC_MD5 = 0x02,
+        RC4_HMAC = 0x04,
+        AES128_CTS_HMAC_SHA1_96 = 0x08,
+        AES256_CTS_HMAC_SHA1_96 = 0x10,
+    }
+
     public enum sAMAccountType : int
     {
         SAM_DOMAIN_OBJECT = 0x00000000,
@@ -290,6 +301,9 @@ $module.Result.objects = @(foreach ($adId in $foundGuids) {
             $enumValue = switch ($name) {
                 groupType {
                     [Ansible.WinDomainObjectInfo.GroupType]$value
+                }
+                'msDS-SupportedEncryptionTypes' {
+                    [Ansible.WinDomainObjectInfo.SupportedEncryptionTypes]$value
                 }
                 sAMAccountType {
                     [Ansible.WinDomainObjectInfo.sAMAccountType]$value

--- a/plugins/modules/object_info.py
+++ b/plugins/modules/object_info.py
@@ -84,9 +84,10 @@ options:
     - subtree
     type: str
 notes:
-- The C(groupType_AnsibleFlags), C(sAMAccountType_AnsibleFlags), and C(userAccountControl_AnsibleFlags) return property
-  is something set by the module itself as an easy way to view what those flags represent. These properties cannot be
-  used as part of the I(filter) or I(ldap_filter) and are automatically added if those properties were requested.
+- The C(groupType_AnsibleFlags), C(msDS-SupportedEncryptionTypes_AnsibleFlags), C(sAMAccountType_AnsibleFlags),
+  and C(userAccountControl_AnsibleFlags) return property is something set by the module itself as an easy way to view
+  what those flags represent. These properties cannot be used as part of the I(filter) or I(ldap_filter) and are
+  automatically added if those properties were requested.
 extends_documentation_fragment:
 - ansible.builtin.action_common_attributes
 attributes:

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -38,12 +38,15 @@ options:
     type: str
   delegates:
     description:
-    - Specifies an array of principal objects the user is allowed to act on
-      behalf for delegation.
-    - Must be specified as a distinguished name C(CN=shenetworks,CN=Users,DC=ansible,DC=test)
+    - Specifies an array of principal objects that the current AD object can
+      trust for delegation.
+    - Must be specified as a distinguished name
+      C(CN=shenetworks,CN=Users,DC=ansible,DC=test)
     - This is the value set on the C(msDS-AllowedToActOnBehalfOfOtherIdentity)
       LDAP attribute.
-    - This is a highly sensitive attribute.
+    - This is a highly sensitive attribute as it allows the principals
+      specified to impersonate any account when authenticating with the AD
+      user object being managed.
     aliases:
     - principals_allowed_to_delegate
     type: list

--- a/tests/integration/targets/computer/tasks/tests.yml
+++ b/tests/integration/targets/computer/tasks/tests.yml
@@ -103,10 +103,21 @@
   computer:
     name: MyComputer
     state: present
+    delegates:
+    - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    kerberos_encryption_types:
+    - aes128
+    - aes256
+    location: Comp Location
     dns_hostname: MyComputer.domain.com
     enabled: false
     managed_by: Domain Admins
     sam_account_name: SamMyComputer
+    spn:
+    - HTTP/MyComputer
+    trusted_for_delegation: true
+    upn: MyComputer@{{ domain_realm }}
     path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
   register: custom_comp
 
@@ -118,11 +129,31 @@
     identity: '{{ object_identity }}'
     properties:
     - dnsHostName
+    - location
     - managedBy
+    - msDS-AllowedToActOnBehalfOfOtherIdentity
+    - msDS-SupportedEncryptionTypes
     - objectSid
     - sAMAccountName
+    - servicePrincipalName
     - userAccountControl
+    - userPrincipalName
   register: custom_comp_actual
+
+- name: convert delegate SDDL to human readable string
+  ansible.windows.win_powershell:
+    parameters:
+      SDDL: '{{ custom_comp_actual.objects[0]["msDS-AllowedToActOnBehalfOfOtherIdentity"] }}'
+    script: |
+      param($SDDL)
+
+      $sd = New-Object -TypeName System.DirectoryServices.ActiveDirectorySecurity
+      $sd.SetSecurityDescriptorSddlForm($SDDL, 'All')
+      $sd.GetAccessRules($true, $false, [Type][System.Security.Principal.NTAccount]
+      ).IdentityReference.Value | ForEach-Object {
+          ($_ -split '\\', 2)[-1]
+      } | Sort-Object
+  register: custom_comp_delegates
 
 - name: assert create computer with custom options
   assert:
@@ -134,18 +165,33 @@
     - custom_comp_actual.objects[0].DistinguishedName == custom_comp.distinguished_name
     - custom_comp_actual.objects[0].Name == 'MyComputer'
     - custom_comp_actual.objects[0].dnsHostName == 'MyComputer.domain.com'
+    - custom_comp_actual.objects[0].location == 'Comp Location'
     - custom_comp_actual.objects[0].managedBy == 'CN=Domain Admins,CN=Users,' ~ setup_domain_info.output[0].defaultNamingContext
+    - custom_comp_actual.objects[0]['msDS-SupportedEncryptionTypes'] == 24
+    - custom_comp_actual.objects[0]['msDS-SupportedEncryptionTypes_AnsibleFlags'] == ["AES128_CTS_HMAC_SHA1_96", "AES256_CTS_HMAC_SHA1_96"]
     - custom_comp_actual.objects[0].sAMAccountName == 'SamMyComputer$'
     - custom_comp_actual.objects[0].ObjectClass == 'computer'
+    - custom_comp_actual.objects[0].servicePrincipalName == 'HTTP/MyComputer'
+    - custom_comp_actual.objects[0].userPrincipalName == 'MyComputer@' ~ domain_realm
     - '"ADS_UF_ACCOUNTDISABLE" in custom_comp_actual.objects[0].userAccountControl_AnsibleFlags'
+    - '"ADS_UF_TRUSTED_FOR_DELEGATION" in custom_comp_actual.objects[0].userAccountControl_AnsibleFlags'
+    - custom_comp_delegates.output == ["Administrator", "krbtgt"]
 
 - name: change computer with custom options
   computer:
     name: MyComputer
     path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    delegates:
+    - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     dns_hostname: other.domain.com
+    kerberos_encryption_types:
+    - aes256
+    - rc4
+    location: comp location
     enabled: true
     sam_account_name: MyComputer2$
+    trusted_for_delegation: false
+    upn: mycomputer@{{ domain_realm }}
   register: change_comp
 
 - name: get result of change computer with custom options
@@ -153,14 +199,108 @@
     identity: '{{ object_identity }}'
     properties:
     - dnsHostName
+    - location
+    - msDS-AllowedToActOnBehalfOfOtherIdentity
+    - msDS-SupportedEncryptionTypes
     - sAMAccountName
     - userAccountControl
+    - userPrincipalName
   register: change_comp_actual
+
+- name: convert delegate SDDL to human readable string
+  ansible.windows.win_powershell:
+    parameters:
+      SDDL: '{{ change_comp_actual.objects[0]["msDS-AllowedToActOnBehalfOfOtherIdentity"] }}'
+    script: |
+      param($SDDL)
+
+      $sd = New-Object -TypeName System.DirectoryServices.ActiveDirectorySecurity
+      $sd.SetSecurityDescriptorSddlForm($SDDL, 'All')
+      $sd.GetAccessRules($true, $false, [Type][System.Security.Principal.NTAccount]
+      ).IdentityReference.Value | ForEach-Object {
+          ($_ -split '\\', 2)[-1]
+      } | Sort-Object
+  register: change_comp_delegates
 
 - name: assert change computer with custom options
   assert:
     that:
     - change_comp is changed
     - change_comp_actual.objects[0].dnsHostName == 'other.domain.com'
+    - change_comp_actual.objects[0].location == 'comp location'
+    - change_comp_actual.objects[0]['msDS-SupportedEncryptionTypes'] == 20
+    - change_comp_actual.objects[0]['msDS-SupportedEncryptionTypes_AnsibleFlags'] == ["RC4_HMAC", "AES256_CTS_HMAC_SHA1_96"]
     - change_comp_actual.objects[0].sAMAccountName == 'MyComputer2$'
+    - change_comp_actual.objects[0].userPrincipalName == 'mycomputer@' ~ domain_realm
     - '"ADS_UF_ACCOUNTDISABLE" not in change_comp_actual.objects[0].userAccountControl_AnsibleFlags'
+    - '"ADS_UF_TRUSTED_FOR_DELEGATION" not in change_comp_actual.objects[0].userAccountControl_AnsibleFlags'
+    - change_comp_delegates.output == ["krbtgt"]
+
+- name: set spns
+  computer:
+    name: MyComputer
+    path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    spn:
+    - HTTP/host
+    - HTTP/host.domain
+    - HTTP/host.domain:8080
+  register: spn_set
+
+- name: get result of set spns
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - servicePrincipalName
+  register: spn_set_actual
+
+- name: assert set spns
+  assert:
+    that:
+    - spn_set is changed
+    - spn_set_actual.objects[0].servicePrincipalName == ['HTTP/host.domain:8080', 'HTTP/host.domain', 'HTTP/host']
+
+- name: remove spns
+  computer:
+    name: MyComputer
+    path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    spn:
+    - HTTP/fake
+    - HTTP/Host.domain
+    spn_action: remove
+  register: spn_remove
+
+- name: get result of remove spns
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - servicePrincipalName
+  register: spn_remove_actual
+
+- name: assert remove spns
+  assert:
+    that:
+    - spn_remove is changed
+    - spn_remove_actual.objects[0].servicePrincipalName == ['HTTP/host.domain:8080', 'HTTP/host']
+
+- name: add spns
+  computer:
+    name: MyComputer
+    path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    spn:
+    - HTTP/Host.domain:8080
+    - HTTP/fake
+    spn_action: add
+  register: spn_add
+
+- name: get result of add spns
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - servicePrincipalName
+  register: spn_add_actual
+
+- name: assert add spns
+  assert:
+    that:
+    - spn_add is changed
+    - spn_add_actual.objects[0].servicePrincipalName == ['HTTP/fake', 'HTTP/host.domain:8080', 'HTTP/host']

--- a/tests/integration/targets/object_info/tasks/main.yml
+++ b/tests/integration/targets/object_info/tasks/main.yml
@@ -103,6 +103,38 @@
     that:
     - group_type_prop.objects[0].groupType_AnsibleFlags == ["GROUP_TYPE_ACCOUNT_GROUP", "GROUP_TYPE_SECURITY_ENABLED"]
 
+- name: create computer object for enc type test
+  computer:
+    name: MyComputer
+    state: present
+    kerberos_encryption_types:
+    - des
+    - rc4
+    - aes128
+    - aes256
+  register: comp_info
+
+- block:
+  - name: get the supported encryption type attribute
+    object_info:
+      identity: '{{ comp_info.object_guid }}'
+      properties:
+      - msDS-SupportedEncryptionTypes
+    register: enc_type_prop
+
+  - name: assert get the supported encryption type attribute
+    assert:
+      that:
+      - enc_type_prop.objects[0]["msDS-SupportedEncryptionTypes"] == 31
+      - enc_type_prop.objects[0]["msDS-SupportedEncryptionTypes_AnsibleFlags"] == ["DES_CBC_CRC", "DES_CBC_MD5", "RC4_HMAC", "AES128_CTS_HMAC_SHA1_96", "AES256_CTS_HMAC_SHA1_96"]
+
+  always:
+  - name: remove computer object
+    computer:
+      name: MyComputer
+      identity: '{{ comp_info.object_guid }}'
+      state: absent
+
 - name: get invalid property
   object_info:
     filter: sAMAccountName -eq 'Ansible Test'


### PR DESCRIPTION
##### SUMMARY
Adds a few more common options to `microsoft.ad.computer`. Also adds user friendly flags when retrieving the `msDS-SupportedEncryptionTypes` attribute with `microsoft.ad.object_info`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad.computer
microsoft.ad.object_info