### PR TITLE
Create common list option style

### DIFF
--- a/docs/docsite/extra-docs.yml
+++ b/docs/docsite/extra-docs.yml
@@ -7,4 +7,5 @@ sections:
 - title: Scenario Guides
   toctree:
   - guide_attributes
+  - guide_list_values
   - guide_migration

--- a/docs/docsite/rst/guide_list_values.rst
+++ b/docs/docsite/rst/guide_list_values.rst
@@ -1,0 +1,118 @@
+.. _ansible_collections.microsoft.ad.docsite.guide_list_values:
+
+********************************
+Setting list option values guide
+********************************
+
+Some AD options accept multiple values which require special rules when it comes to checking for idempotency in Ansible. This collection has been designed so that each of the modules which manage AD objects follow the same style when it comes to their options. In particular, they should all follow the style documented in this guide when it comes to options that contain multiple values like ``spn``, ``delegates``, etc.
+
+.. contents::
+  :local:
+  :depth: 1
+
+.. _ansible_collections.microsoft.ad.docsite.guide_list_values.something:
+
+Add, remove, and set
+====================
+
+For each module option that manage a multi valued LDAP attribute there exists three actions:
+
+* ``add``
+* ``remove``
+* ``set``
+
+The ``add`` and ``remove`` option will add or remove the specified value(s) from the existing value. The ``set`` option will replace the existing values with what was specified in the task.
+Using an example of an AD object with the following ``servicePrincipalNames`` values:
+
+* ``HTTP/host1``
+* ``HTTP/host1.domain.com``
+* ``HTTP/host1.domain.com:443``
+
+Doing ``add: ['HTTP/host1','HTTP/host2']`` will add ``HTTP/host2`` to the existing values bringing it to:
+
+* ``HTTP/host1``
+* ``HTTP/host1.domain.com``
+* ``HTTP/host1.domain.com:443``
+* ``HTTP/host2``
+
+Doing ``remove: ['HTTP/host1','HTTP/host3']`` will remove ``HTTP/host1`` from the existing values bringing it to:
+
+* ``HTTP/host1.domain.com``
+* ``HTTP/host1.domain.com:443``
+
+Doing ``set: ['HTTP/host1', 'HTTP/host2']`` will remove any values not in that list and add values in that list but not set bringing it to:
+
+* ``HTTP/host1``
+* ``HTTP/host2``
+
+It is possible to use ``add`` and ``remove`` together but setting ``set`` will always take precedence over the others.
+It is also possible to clear all the existing values by setting the ``set`` value to an empty list, for example ``set: []``.
+
+Examples
+========
+
+The ``add``, ``remove``, and ``set`` options are subkeys of the module option it controls. For example the :ref:`microsoft.ad.user <ansible_collections.microsoft.ad.user_module>` has an option called ``groups`` which control the list of groups the user is a member of. To add a group to the user, simply use the ``add`` key like so:
+
+.. code-block:: yaml
+
+  - name: add a user to a group
+    microsoft.ad.user:
+      name: MyUser
+      groups:
+        add:
+        - Group 1
+        - Group 2
+
+This will ensure the user is added to the groups ``Group 1`` and ``Group 2`` while also preserving the existing membership. To remove a user from a user, simple use the ``remove`` key like so:
+
+.. code-block:: yaml
+
+  - name: remove a user from a group
+    microsoft.ad.user:
+      name: MyUser
+      groups:
+        remove:
+        - Group 1
+        - Group 2
+
+This does the opposite to add and will remove the user from ``Group 1`` and ``Group 2`` but it will still preserve any existing group memberships of that user. It is also possible to combine ``add`` and ``remove`` together:
+
+.. code-block:: yaml
+
+  - name: add and remove user groups
+    microsoft.ad.user:
+      name: MyUser
+      groups:
+        add:
+        - Group 1
+        remove:
+        - Group 2
+
+This will ensure the user is a member of ``Group 1`` and is not a member of ``Group 2``. Like before it will not touch the existing group membership if they are not specified.
+
+The set option following the same format like so:
+
+.. code-block:: yaml
+
+  - name: set user groups
+    microsoft.ad.user:
+      name: MyUser
+      groups:
+        set:
+        - Group 1
+        - Group 2
+
+This will ensure the user is only members of ``Group 1`` and ``Group 2``, removing any other group not in that list. While it is possible to combine ``set`` with either ``add`` or ``remove``, the module will completely ignore the values in ``add`` or ``remove``.
+
+Finally to remove a user from all groups, use an empty list for the ``set`` option like so:
+
+.. code-block:: yaml
+
+  - name: remove user groups
+    microsoft.ad.user:
+      name: MyUser
+      groups:
+        set: []
+
+.. note::
+  This is not actually possible for user groups as it will always be a member of its primary group, it is just used for demonstration purposes.

--- a/docs/docsite/rst/guide_migration.rst
+++ b/docs/docsite/rst/guide_migration.rst
@@ -169,8 +169,12 @@ Migrated to :ref:`microsoft.ad.user <ansible_collections.microsoft.ad.user_modul
 The following options have changed:
 
 * ``attributes`` - changed format as outlined in :ref:`Attributes guid <ansible_collections.microsoft.ad.docsite.guide_attributes>`
-* ``groups_action`` - ``replace`` has been renamed to ``set``
-* ``spn_action`` - ``replace`` has been renamed to ``set``
+* ``delegates`` - changed format as outlined in :ref:`Setting list values <ansible_collections.microsoft.ad.docsite.guide_list_values>`
+* ``groups`` - changed format as outlined in :ref:`Setting list values <ansible_collections.microsoft.ad.docsite.guide_list_values>`
+* ``groups_action`` - has been removed in favour of the new ``groups`` format
+* ``groups_missing_behaviour`` - has been moved into the ``group`` dictionary value as ``missing_behaviour``
+* ``spn``- changed format as outlined in :ref:`Setting list values <ansible_collections.microsoft.ad.docsite.guide_list_values>`
+* ``spn_action`` - has been removed in favour of the new ``spn`` format
 * ``state`` - No query option - use ``microsoft.ad.object_info`` instead
 * ``enabled`` - Does not default to ``true``. Creating a new user without a password will use ``enabled=false`` but setting a password will use ``enabled=true``
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: '>=2.12'

--- a/tests/integration/targets/computer/tasks/tests.yml
+++ b/tests/integration/targets/computer/tasks/tests.yml
@@ -104,18 +104,21 @@
     name: MyComputer
     state: present
     delegates:
-    - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
-    - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     kerberos_encryption_types:
-    - aes128
-    - aes256
+      set:
+      - aes128
+      - aes256
     location: Comp Location
     dns_hostname: MyComputer.domain.com
     enabled: false
     managed_by: Domain Admins
     sam_account_name: SamMyComputer
     spn:
-    - HTTP/MyComputer
+      set:
+      - HTTP/MyComputer
     trusted_for_delegation: true
     upn: MyComputer@{{ domain_realm }}
     path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
@@ -151,7 +154,7 @@
       $sd.SetSecurityDescriptorSddlForm($SDDL, 'All')
       $sd.GetAccessRules($true, $false, [Type][System.Security.Principal.NTAccount]
       ).IdentityReference.Value | ForEach-Object {
-          ($_ -split '\\', 2)[-1]
+          ($_ -split '\\', 2)[-1].ToLowerInvariant()
       } | Sort-Object
   register: custom_comp_delegates
 
@@ -175,18 +178,20 @@
     - custom_comp_actual.objects[0].userPrincipalName == 'MyComputer@' ~ domain_realm
     - '"ADS_UF_ACCOUNTDISABLE" in custom_comp_actual.objects[0].userAccountControl_AnsibleFlags'
     - '"ADS_UF_TRUSTED_FOR_DELEGATION" in custom_comp_actual.objects[0].userAccountControl_AnsibleFlags'
-    - custom_comp_delegates.output == ["Administrator", "krbtgt"]
+    - custom_comp_delegates.output == ["administrator", "krbtgt"]
 
 - name: change computer with custom options
   computer:
     name: MyComputer
     path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     delegates:
-    - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     dns_hostname: other.domain.com
     kerberos_encryption_types:
-    - aes256
-    - rc4
+      set:
+      - aes256
+      - rc4
     location: comp location
     enabled: true
     sam_account_name: MyComputer2$
@@ -218,7 +223,7 @@
       $sd.SetSecurityDescriptorSddlForm($SDDL, 'All')
       $sd.GetAccessRules($true, $false, [Type][System.Security.Principal.NTAccount]
       ).IdentityReference.Value | ForEach-Object {
-          ($_ -split '\\', 2)[-1]
+          ($_ -split '\\', 2)[-1].ToLowerInvariant()
       } | Sort-Object
   register: change_comp_delegates
 
@@ -236,14 +241,128 @@
     - '"ADS_UF_TRUSTED_FOR_DELEGATION" not in change_comp_actual.objects[0].userAccountControl_AnsibleFlags'
     - change_comp_delegates.output == ["krbtgt"]
 
+- name: add and remove list options
+  computer:
+    name: MyComputer
+    path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    delegates:
+      add:
+      - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      remove:
+      - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      - CN=Missing,{{ setup_domain_info.output[0].defaultNamingContext }}
+    kerberos_encryption_types:
+      add:
+      - aes128
+      - aes256
+      remove:
+      - rc4
+  register: add_remove_list
+
+- name: get result of add and remove list options
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - msDS-AllowedToActOnBehalfOfOtherIdentity
+    - msDS-SupportedEncryptionTypes
+  register: add_remove_list_actual
+
+- name: convert delegate SDDL to human readable string
+  ansible.windows.win_powershell:
+    parameters:
+      SDDL: '{{ add_remove_list_actual.objects[0]["msDS-AllowedToActOnBehalfOfOtherIdentity"] }}'
+    script: |
+      param($SDDL)
+
+      $sd = New-Object -TypeName System.DirectoryServices.ActiveDirectorySecurity
+      $sd.SetSecurityDescriptorSddlForm($SDDL, 'All')
+      $sd.GetAccessRules($true, $false, [Type][System.Security.Principal.NTAccount]
+      ).IdentityReference.Value | ForEach-Object {
+          ($_ -split '\\', 2)[-1].ToLowerInvariant()
+      } | Sort-Object
+  register: add_remove_list_delegation
+
+- name: assert add and remove list options
+  assert:
+    that:
+    - add_remove_list is changed
+    - add_remove_list_actual.objects[0]['msDS-SupportedEncryptionTypes'] == 24
+    - add_remove_list_actual.objects[0]['msDS-SupportedEncryptionTypes_AnsibleFlags'] == ["AES128_CTS_HMAC_SHA1_96", "AES256_CTS_HMAC_SHA1_96"]
+    - add_remove_list_delegation.output == ["administrator"]
+
+- name: add and remove list options - idempotent
+  computer:
+    name: MyComputer
+    path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    delegates:
+      add:
+      - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      remove:
+      - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      - CN=Missing,{{ setup_domain_info.output[0].defaultNamingContext }}
+    kerberos_encryption_types:
+      add:
+      - aes128
+      - aes256
+      remove:
+      - rc4
+  register: add_remove_list_again
+
+- name: assert add and remove list options - idempotent
+  assert:
+    that:
+    - not add_remove_list_again is changed
+
+- name: unset list options
+  computer:
+    name: MyComputer
+    path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    delegates:
+      set: []
+    kerberos_encryption_types:
+      set: []
+  register: unset_list_options
+
+- name: get result of unset list options
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - msDS-AllowedToActOnBehalfOfOtherIdentity
+    - msDS-SupportedEncryptionTypes
+  register: unset_list_options_actual
+
+- name: assert unset list options
+  assert:
+    that:
+    - unset_list_options is changed
+    - unset_list_options_actual.objects[0]['msDS-AllowedToActOnBehalfOfOtherIdentity'] == None
+    - unset_list_options_actual.objects[0]['msDS-SupportedEncryptionTypes'] == 0
+    - unset_list_options_actual.objects[0]['msDS-SupportedEncryptionTypes_AnsibleFlags'] == ["None"]
+
+- name: unset list options - idempotent
+  computer:
+    name: MyComputer
+    path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    delegates:
+      set: []
+    kerberos_encryption_types:
+      set: []
+  register: unset_list_options_again
+
+- name: assert unset list options - idempotent
+  assert:
+    that:
+    - not unset_list_options_again is changed
+
 - name: set spns
   computer:
     name: MyComputer
     path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     spn:
-    - HTTP/host
-    - HTTP/host.domain
-    - HTTP/host.domain:8080
+      set:
+      - HTTP/host
+      - HTTP/host.domain
+      - HTTP/host.domain:8080
   register: spn_set
 
 - name: get result of set spns
@@ -264,9 +383,9 @@
     name: MyComputer
     path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     spn:
-    - HTTP/fake
-    - HTTP/Host.domain
-    spn_action: remove
+      remove:
+      - HTTP/fake
+      - HTTP/Host.domain
   register: spn_remove
 
 - name: get result of remove spns
@@ -286,10 +405,10 @@
   computer:
     name: MyComputer
     path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
-    spn:
-    - HTTP/Host.domain:8080
-    - HTTP/fake
-    spn_action: add
+    spns:
+      add:
+      - HTTP/Host.domain:8080
+      - HTTP/fake
   register: spn_add
 
 - name: get result of add spns

--- a/tests/integration/targets/domain_controller/setup.yml
+++ b/tests/integration/targets/domain_controller/setup.yml
@@ -47,8 +47,8 @@
       password_never_expires: yes
       update_password: when_changed
       groups:
-      - Domain Admins
-      - Domain Users
+        add:
+        - Domain Admins
       state: present
 
 - name: setup test host

--- a/tests/integration/targets/membership/setup.yml
+++ b/tests/integration/targets/membership/setup.yml
@@ -47,8 +47,8 @@
       password_never_expires: yes
       update_password: when_changed
       groups:
-      - Domain Admins
-      - Domain Users
+        add:
+        - Domain Admins
       state: present
 
 - name: setup test host

--- a/tests/integration/targets/object/tasks/tests.yml
+++ b/tests/integration/targets/object/tasks/tests.yml
@@ -96,7 +96,7 @@
     - rename_check_actual.objects[0].DistinguishedName == object_dn
     - rename_check_actual.objects[0].Name == object_name
 
-- name: rename and set display name of object[]
+- name: rename and set display name of object
   object:
     name: My, Contact 2
     identity: '{{ object_identity }}'

--- a/tests/integration/targets/object_info/tasks/main.yml
+++ b/tests/integration/targets/object_info/tasks/main.yml
@@ -8,7 +8,8 @@
     state: present
     password_never_expires: yes
     groups:
-    - Domain Users
+      set:
+      - Domain Users
     enabled: false
   register: test_user
   notify: remove test domain user
@@ -108,10 +109,11 @@
     name: MyComputer
     state: present
     kerberos_encryption_types:
-    - des
-    - rc4
-    - aes128
-    - aes256
+      set:
+      - des
+      - rc4
+      - aes128
+      - aes256
   register: comp_info
 
 - block:

--- a/tests/integration/targets/user/tasks/tests.yml
+++ b/tests/integration/targets/user/tasks/tests.yml
@@ -328,22 +328,25 @@
     company: Red Hat
     country: au
     delegates:
-    - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
-    - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     description: User Description
     display_name: User Name
     email: user@EMAIL.COM
     firstname: FirstName
     groups:
-    - Domain Admins
-    - Domain Users
+      set:
+      - Domain Admins
+      - Domain Users
     password: Password123!
     password_never_expires: true
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     postal_code: 4000
     sam_account_name: MyUserSam
     spn:
-    - HTTP/MyUser
+      set:
+      - HTTP/MyUser
     state_province: QLD
     street: Main
     surname: LastName
@@ -374,22 +377,25 @@
     company: Red Hat
     country: au
     delegates:
-    - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
-    - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     description: User Description
     display_name: User Name
     email: user@EMAIL.COM
     firstname: FirstName
     groups:
-    - Domain Admins
-    - Domain Users
+      set:
+      - Domain Admins
+      - Domain Users
     password: Password123!
     password_never_expires: true
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     postal_code: 4000
     sam_account_name: MyUserSam
     spn:
-    - HTTP/MyUser
+      set:
+      - HTTP/MyUser
     state_province: QLD
     street: Main
     surname: LastName
@@ -442,7 +448,7 @@
       $sd.SetSecurityDescriptorSddlForm($SDDL, 'All')
       $sd.GetAccessRules($true, $false, [Type][System.Security.Principal.NTAccount]
       ).IdentityReference.Value | ForEach-Object {
-          ($_ -split '\\', 2)[-1]
+          ($_ -split '\\', 2)[-1].ToLowerInvariant()
       } | Sort-Object
   register: create_user_delegates
 
@@ -475,7 +481,7 @@
     - create_user_actual.objects[0].streetaddress == 'Main'
     - create_user_actual.objects[0].userPrincipalName == 'User@' ~ domain_realm
     - create_user_actual.objects[0].userAccountControl_AnsibleFlags == ["ADS_UF_NORMAL_ACCOUNT", "ADS_UF_DONT_EXPIRE_PASSWD"]
-    - create_user_delegates.output == ["Administrator", "krbtgt"]
+    - create_user_delegates.output == ["administrator", "krbtgt"]
 
 - name: create user with extra info - idempotent
   user:
@@ -485,22 +491,25 @@
     company: Red Hat
     country: au
     delegates:
-    - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
-    - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=krbtgt,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     description: User Description
     display_name: User Name
     email: user@EMAIL.COM
     firstname: FirstName
     groups:
-    - Domain Admins
-    - Domain Users
+      set:
+      - Domain Admins
+      - Domain Users
     password: Password123!
     password_never_expires: true
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     postal_code: 4000
     sam_account_name: MyUserSam
     spn:
-    - HTTP/MyUser
+      set:
+      - HTTP/MyUser
     state_province: QLD
     street: Main
     surname: LastName
@@ -525,20 +534,23 @@
     company: Ansible
     country: us
     delegates:
-    - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     description: User description
     display_name: User name
     email: User@EMAIL.COM
     firstname: firstName
     groups:
-    - Domain Users
+      set:
+      - Domain Users
     password: Password123!
     password_never_expires: false
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     postal_code: 10001
     sam_account_name: myUserSam
     spn:
-    - HTTP/myUser
+      set:
+      - HTTP/myUser
     state_province: NY
     street: main
     surname: lastName
@@ -616,20 +628,23 @@
     company: Ansible
     country: us
     delegates:
-    - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=KRBTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
     description: User description
     display_name: User name
     email: User@EMAIL.COM
     firstname: firstName
     groups:
-    - Domain Users
+      set:
+      - Domain Users
     password: Password123!
     password_never_expires: false
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     postal_code: 10001
     sam_account_name: myUserSam
     spn:
-    - HTTP/myUser
+      set:
+      - HTTP/myUser
     state_province: NY
     street: main
     surname: lastName
@@ -679,7 +694,7 @@
       $sd.SetSecurityDescriptorSddlForm($SDDL, 'All')
       $sd.GetAccessRules($true, $false, [Type][System.Security.Principal.NTAccount]
       ).IdentityReference.Value | ForEach-Object {
-          ($_ -split '\\', 2)[-1]
+          ($_ -split '\\', 2)[-1].ToLowerInvariant()
       } | Sort-Object
   register: update_user_delegates
 
@@ -718,7 +733,8 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     delegates:
-    - CN=KrbTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=KrbTGT,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
   register: update_delegates_insensitive
 
 - name: assert update delegates case insensitive
@@ -731,8 +747,9 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     delegates:
-    - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
-    - CN=Enterprise Admins,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      set:
+      - CN=Administrator,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+      - CN=Enterprise Admins,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
   register: update_delegates
 
 - name: get result of update delegates
@@ -753,7 +770,7 @@
       $sd.SetSecurityDescriptorSddlForm($SDDL, 'All')
       $sd.GetAccessRules($true, $false, [Type][System.Security.Principal.NTAccount]
       ).IdentityReference.Value | ForEach-Object {
-          ($_ -split '\\', 2)[-1]
+          ($_ -split '\\', 2)[-1].ToLowerInvariant()
       } | Sort-Object
   register: update_delegates_actual
 
@@ -761,7 +778,7 @@
   assert:
     that:
     - update_delegates is changed
-    - update_delegates_actual.output == ["Administrator", "Enterprise Admins"]
+    - update_delegates_actual.output == ["administrator", "enterprise admins"]
 
 - name: unset string option
   user:
@@ -788,7 +805,8 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
-    - Domain Admins
+      set:
+      - Domain Admins
   register: set_groups_check
   check_mode: true
 
@@ -812,7 +830,8 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
-    - Domain Admins
+      set:
+      - Domain Admins
   register: set_groups
 
 - name: get result of set groups
@@ -837,8 +856,8 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
-    - Invalid
-    groups_action: add
+      add:
+      - Invalid
   register: fail_missing_group
   failed_when:
   - '"Failed to locate group Invalid: Cannot find an object with identity" not in fail_missing_group.msg'
@@ -848,9 +867,9 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
-    - Invalid
-    groups_action: add
-    groups_missing_behaviour: warn
+      add:
+      - Invalid
+      missing_behaviour: warn
   register: warn_missing_group
 
 - name: assert warn on group that is missing
@@ -865,9 +884,9 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
-    - Invalid
-    groups_action: add
-    groups_missing_behaviour: ignore
+      add:
+      - Invalid
+      missing_behaviour: ignore
   register: ignore_missing_group
 
 - name: assert ignore on group that is missing
@@ -881,9 +900,9 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
-    - domain admins
-    - Enterprise Admins
-    groups_action: remove
+      remove:
+      - domain admins
+      - Enterprise Admins
   register: groups_remove
 
 - name: get result of remove groups
@@ -906,9 +925,9 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
-    - domain users
-    - domain admins
-    groups_action: add
+      add:
+      - domain users
+      - domain admins
   register: groups_add
 
 - name: get result of add groups
@@ -931,9 +950,10 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     spn:
-    - HTTP/host
-    - HTTP/host.domain
-    - HTTP/host.domain:8080
+      set:
+      - HTTP/host
+      - HTTP/host.domain
+      - HTTP/host.domain:8080
   register: spn_set
 
 - name: get result of set spns
@@ -954,9 +974,9 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     spn:
-    - HTTP/fake
-    - HTTP/Host.domain
-    spn_action: remove
+      remove:
+      - HTTP/fake
+      - HTTP/Host.domain
   register: spn_remove
 
 - name: get result of remove spns
@@ -977,9 +997,9 @@
     name: MyUser
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     spn:
-    - HTTP/Host.domain:8080
-    - HTTP/fake
-    spn_action: add
+      add:
+      - HTTP/Host.domain:8080
+      - HTTP/fake
   register: spn_add
 
 - name: get result of add spns


### PR DESCRIPTION
##### SUMMARY
This PR makes sure all module options that manage LDAP attributes with multiple values use the subdict with add, remove, or set keys. It also adds a simple guide on how these values work and updates the migration page where it affected older modules.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad