### PR TITLE
Fix up incorrect datetime tz offset example

### DIFF
--- a/docs/docsite/rst/guide_attributes.rst
+++ b/docs/docsite/rst/guide_attributes.rst
@@ -266,7 +266,7 @@ Attributes with datetime values are technically integer values but represent a p
           set:
             dateAttributeSingleValue:
               type: date_time
-              value: '2019-09-07T15:50:00+00'
+              value: '2019-09-07T15:50:00+00:00'
             dateAttributeMultipleValue:
             - type: date_time
               value: '2019-09-07T15:50:00Z'


### PR DESCRIPTION
##### SUMMARY
The datetime value here is missing the minute offset portion needed.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/24

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
microsoft.ad