### PR TITLE
Fix up password_expired on new user

### DIFF
--- a/changelogs/fragments/user-password-expired.yml
+++ b/changelogs/fragments/user-password-expired.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- microsoft.ad.user - Fix setting ``password_expired`` when creating a new user - https://github.com/ansible-collections/microsoft.ad/issues/25

--- a/plugins/modules/user.ps1
+++ b/plugins/modules/user.ps1
@@ -202,6 +202,12 @@ $setParams = @{
             Name = 'password_expired'
             Option = @{ type = 'bool' }
             Attribute = 'PasswordExpired'
+            New = {
+                param($Module, $ADParams, $NewParams)
+
+                $NewParams.ChangePasswordAtLogon = $module.Params.password_expired
+                $Module.Diff.after.password_expired = $module.Params.password_expired
+            }
             Set = {
                 param($Module, $ADParams, $SetParams, $ADObject)
 

--- a/tests/integration/targets/user/tasks/tests.yml
+++ b/tests/integration/targets/user/tasks/tests.yml
@@ -320,6 +320,55 @@
     that:
     - not remove_user_again is changed
 
+# https://github.com/ansible-collections/microsoft.ad/issues/25
+- name: create user with expired password
+  user:
+    name: MyUser
+    password: Password123!
+    password_expired: true
+    state: present
+  register: create_user_pass_expired
+
+- set_fact:
+    object_identity: '{{ create_user_pass_expired.object_guid }}'
+    object_sid: '{{ create_user_pass_expired.sid }}'
+
+- name: get result of create user with expired password
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - pwdLastSet
+  register: create_user_pass_expired_actual
+
+- name: assert create user with expired password
+  assert:
+    that:
+    - create_user_pass_expired_actual.objects[0].pwdLastSet == 0
+
+- name: remove expired password flag on existing user
+  user:
+    name: MyUser
+    password_expired: false
+    state: present
+  register: remove_password_expiry
+
+- name: get result of remove expired password flag on existing user
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - pwdLastSet
+  register: remove_password_expiry_actual
+
+- name: assert remove expired password flag on existing user
+  assert:
+    that:
+    - remove_password_expiry_actual.objects[0].pwdLastSet > 0
+
+- name: remove user
+  user:
+    name: MyUser
+    state: absent
+
 - name: create user with extra info - check
   user:
     name: MyUser


### PR DESCRIPTION
##### SUMMARY
The `password_expired` for the `user` module did not have a custom action for when a user was being created. This fixes up that behaviour so the flag is set properly and adds a test for this scenario.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/25

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
microsoft.ad.user