### PR TITLE
group - check scope and category with a case insensitive check

### DIFF
--- a/changelogs/fragments/group-case-sensitivity-check.yml
+++ b/changelogs/fragments/group-case-sensitivity-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- microsoft.ad.group - ensure the ``scope`` and ``category`` values are checked as case insensitive to avoid changes when not needed - https://github.com/ansible-collections/microsoft.ad/issues/31

--- a/plugins/modules/group.ps1
+++ b/plugins/modules/group.ps1
@@ -15,6 +15,7 @@ $setParams = @{
                 type = 'str'
             }
             Attribute = 'GroupCategory'
+            CaseInsensitive = $true
         }
         [PSCustomObject]@{
             Name = 'homepage'
@@ -173,6 +174,7 @@ $setParams = @{
                 type = 'str'
             }
             Attribute = 'GroupScope'
+            CaseInsensitive = $true
         }
     )
     ModuleNoun = 'ADGroup'

--- a/tests/integration/targets/group/tasks/tests.yml
+++ b/tests/integration/targets/group/tasks/tests.yml
@@ -59,6 +59,7 @@
   group:
     name: MyGroup
     state: present
+    scope: global
   register: create_group_again
 
 - name: assert create group - idempotent


### PR DESCRIPTION
##### SUMMARY
Check the `category` and `group` options with a case insensitive match as they are enum values and not literal attribute values.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/31

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
microsoft.ad.group