### PR TITLE
Fix up AD attribute checks for falsey values

### DIFF
--- a/changelogs/fragments/group-domainlocal-scopeinfo.yml
+++ b/changelogs/fragments/group-domainlocal-scopeinfo.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >-
+  group - Fix idempotency check when ``scope: domainlocal`` is set - https://github.com/ansible-collections/microsoft.ad/issues/31

--- a/plugins/module_utils/_ADObject.psm1
+++ b/plugins/module_utils/_ADObject.psm1
@@ -425,7 +425,7 @@ Function Compare-AnsibleADIdempotentList {
     )
 
     # It's easier to compare with strings.
-    $existingString = [string[]]@(if ($Existing) { $Existing | ForEach-Object ToString })
+    $existingString = [string[]]@(if ($null -ne $Existing) { $Existing | ForEach-Object ToString })
     $comparer = if ($CaseInsensitive) {
         [System.StringComparer]::OrdinalIgnoreCase
     }

--- a/tests/integration/targets/group/tasks/tests.yml
+++ b/tests/integration/targets/group/tasks/tests.yml
@@ -421,6 +421,31 @@
       - group_custom_actual.objects[0].sAMAccountName == "GroupSAM"
       - group_custom_actual.objects[0].wWWHomePage == "www.ansible.com"
 
+  - name: create group with custom options - idempotent
+    group:
+      name: MyGroup
+      state: present
+      path: '{{ ou_info.distinguished_name }}'
+      display_name: My Display Name
+      description: My Description
+      scope: domainlocal
+      category: distribution
+      homepage: www.ansible.com
+      managed_by: Domain Admins
+      members:
+        add:
+        - my_user_1
+        - '{{ test_users.results[1].object_guid }}'
+        set:
+        - '{{ test_users.results[2].sid }}'
+      sam_account_name: GroupSAM
+    register: group_custom_again
+
+  - name: assert create group with custom options - idempotent
+    assert:
+      that:
+      - group_custom_again is not changed
+
   - name: edit group
     group:
       name: MyGroup

--- a/tests/integration/targets/group/tasks/tests.yml
+++ b/tests/integration/targets/group/tasks/tests.yml
@@ -431,12 +431,11 @@
       scope: domainlocal
       category: distribution
       homepage: www.ansible.com
-      managed_by: Domain Admins
+      managed_by: CN=Domain Admins,CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
       members:
         add:
         - my_user_1
         - '{{ test_users.results[1].object_guid }}'
-        set:
         - '{{ test_users.results[2].sid }}'
       sam_account_name: GroupSAM
     register: group_custom_again


### PR DESCRIPTION
##### SUMMARY
Fix up the generic ADObject check for attributes with falsey values like 0, empty string, empty array/list. This was easily seen by using group with scope: domainlocal as the enum value for that scope is 0.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/31

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
_ADObject.psm1