### PR TITLE
Remove 2012 and 2012 R2 from CI tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -142,8 +142,6 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}
           targets:
-            - test: 2012
-            - test: 2012-R2
             - test: 2016
             - test: 2019
             - test: 2022

--- a/changelogs/fragments/server2012.yml
+++ b/changelogs/fragments/server2012.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+- >-
+  Deprecating support for Server 2012 and Server 2012 R2. These OS versions are reaching End of Life status from
+  Microsoft and support for using them in Ansible are nearing its end.


### PR DESCRIPTION
##### SUMMARY
Remove 2012 and 2012 R2 from CI tests. This lines up with the removal of 2012 and 2012 R2 in the `ansible.windows` and `community.windows` collections and the dropping of support in Ansible 2.16.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad