### PR TITLE
Add dpapi-ng to Python requirements file

### DIFF
--- a/changelogs/fragments/dpapi-req.yml
+++ b/changelogs/fragments/dpapi-req.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Added the missing dependency ``dpapi-ng`` to Ansible Execution Environments requirements file for LAPS decryption support

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ cryptography >= 3.1
 # For LDAP SRV lookups. 2.0.0 is when the new API used was introduced.
 dnspython >= 2.0.0
 
+# For LDAP LAPS decryption support
+dpapi-ng
+
 # For krb5 default_realm lookups
 krb5
 


### PR DESCRIPTION
##### SUMMARY
The `dpapi-ng` optional requirement was added in 1.2.0 but the dependency wasn't declared in the EE requirements.txt file. This PR adds this requirement so people who build an EE image will get this feature by default.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
microsoft.ad