### PR TITLE
Fix up protect from accidental deletion on new objects

### DIFF
--- a/changelogs/fragments/protect-from-deletion.yml
+++ b/changelogs/fragments/protect-from-deletion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix up ``protect_from_deletion`` when creating new AD objects - https://github.com/ansible-collections/microsoft.ad/issues/47

--- a/tests/integration/targets/computer/tasks/tests.yml
+++ b/tests/integration/targets/computer/tasks/tests.yml
@@ -122,6 +122,7 @@
     trusted_for_delegation: true
     upn: MyComputer@{{ domain_realm }}
     path: CN=Users,{{ setup_domain_info.output[0].defaultNamingContext }}
+    protect_from_deletion: true
   register: custom_comp
 
 - set_fact:
@@ -137,6 +138,7 @@
     - msDS-AllowedToActOnBehalfOfOtherIdentity
     - msDS-SupportedEncryptionTypes
     - objectSid
+    - ProtectedFromAccidentalDeletion
     - sAMAccountName
     - servicePrincipalName
     - userAccountControl
@@ -174,6 +176,7 @@
     - custom_comp_actual.objects[0]['msDS-SupportedEncryptionTypes_AnsibleFlags'] == ["AES128_CTS_HMAC_SHA1_96", "AES256_CTS_HMAC_SHA1_96"]
     - custom_comp_actual.objects[0].sAMAccountName == 'SamMyComputer$'
     - custom_comp_actual.objects[0].ObjectClass == 'computer'
+    - custom_comp_actual.objects[0].ProtectedFromAccidentalDeletion == true
     - custom_comp_actual.objects[0].servicePrincipalName == 'HTTP/MyComputer'
     - custom_comp_actual.objects[0].userPrincipalName == 'MyComputer@' ~ domain_realm
     - '"ADS_UF_ACCOUNTDISABLE" in custom_comp_actual.objects[0].userAccountControl_AnsibleFlags'
@@ -197,6 +200,7 @@
     sam_account_name: MyComputer2$
     trusted_for_delegation: false
     upn: mycomputer@{{ domain_realm }}
+    protect_from_deletion: false
   register: change_comp
 
 - name: get result of change computer with custom options
@@ -207,6 +211,7 @@
     - location
     - msDS-AllowedToActOnBehalfOfOtherIdentity
     - msDS-SupportedEncryptionTypes
+    - ProtectedFromAccidentalDeletion
     - sAMAccountName
     - userAccountControl
     - userPrincipalName
@@ -235,6 +240,7 @@
     - change_comp_actual.objects[0].location == 'comp location'
     - change_comp_actual.objects[0]['msDS-SupportedEncryptionTypes'] == 20
     - change_comp_actual.objects[0]['msDS-SupportedEncryptionTypes_AnsibleFlags'] == ["RC4_HMAC", "AES256_CTS_HMAC_SHA1_96"]
+    - change_comp_actual.objects[0].ProtectedFromAccidentalDeletion == false
     - change_comp_actual.objects[0].sAMAccountName == 'MyComputer2$'
     - change_comp_actual.objects[0].userPrincipalName == 'mycomputer@' ~ domain_realm
     - '"ADS_UF_ACCOUNTDISABLE" not in change_comp_actual.objects[0].userAccountControl_AnsibleFlags'

--- a/tests/integration/targets/user/tasks/tests.yml
+++ b/tests/integration/targets/user/tasks/tests.yml
@@ -392,6 +392,7 @@
     password_never_expires: true
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     postal_code: 4000
+    protect_from_deletion: false
     sam_account_name: MyUserSam
     spn:
       set:
@@ -441,6 +442,7 @@
     password_never_expires: true
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     postal_code: 4000
+    protect_from_deletion: false
     sam_account_name: MyUserSam
     spn:
       set:
@@ -476,6 +478,7 @@
     - objectSid
     - postalcode
     - primaryGroupID
+    - ProtectedFromAccidentalDeletion
     - pwdLastSet
     - sAMAccountName
     - servicePrincipalName
@@ -522,6 +525,7 @@
     - create_user_actual.objects[0].memberOf == 'CN=Domain Admins,CN=Users,' ~ setup_domain_info.output[0].defaultNamingContext
     - create_user_actual.objects[0].postalcode == '4000'
     - create_user_actual.objects[0].primaryGroupID == 513  # Domain Users
+    - create_user_actual.objects[0].ProtectedFromAccidentalDeletion == false
     - create_user_actual.objects[0].pwdLastSet > 0
     - create_user_actual.objects[0].sAMAccountName == 'MyUserSam'
     - create_user_actual.objects[0].servicePrincipalName == 'HTTP/MyUser'
@@ -555,6 +559,7 @@
     password_never_expires: true
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     postal_code: 4000
+    protect_from_deletion: false
     sam_account_name: MyUserSam
     spn:
       set:
@@ -629,6 +634,7 @@
     - objectSid
     - postalcode
     - primaryGroupID
+    - ProtectedFromAccidentalDeletion
     - pwdLastSet
     - sAMAccountName
     - servicePrincipalName
@@ -659,6 +665,7 @@
     - update_user_check_actual.objects[0].memberOf == 'CN=Domain Admins,CN=Users,' ~ setup_domain_info.output[0].defaultNamingContext
     - update_user_check_actual.objects[0].postalcode == '4000'
     - update_user_check_actual.objects[0].primaryGroupID == 513  # Domain Users
+    - update_user_check_actual.objects[0].ProtectedFromAccidentalDeletion == false
     - update_user_check_actual.objects[0].pwdLastSet > 0
     - update_user_check_actual.objects[0].sAMAccountName == 'MyUserSam'
     - update_user_check_actual.objects[0].servicePrincipalName == 'HTTP/MyUser'


### PR DESCRIPTION
##### SUMMARY
The code for handling `protect_from_deletion` when creating new objects would only work if the cmdlet used contained the `-ProtectedFromAccidentalDeletion` parameter. Cmdlets like `New-ADUser`, `New-ADGroup`, `New-ADComputer` do not have this parameter so handling for this needed to happen after the object is created with the `Set-ADObject` cmdlet.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/47

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/_ADObject.psm1