### PR TITLE
ldap inventory add filter_without_computer

### DIFF
--- a/changelogs/fragments/ldap-filter-raw.yml
+++ b/changelogs/fragments/ldap-filter-raw.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- >-
+  microsoft.ad.ldap - Added the option ``filter_without_computer`` to not add the AND clause ``objectClass=computer``
+  to the final filter used - https://github.com/ansible-collections/microsoft.ad/issues/55

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: microsoft
 name: ad
-version: 1.2.0
+version: 1.3.0
 readme: README.md
 authors:
 - Jordan Borean @jborean93


### PR DESCRIPTION
##### SUMMARY
Adds the new option filter_without_computer to control whether the AND clause objectClass=computer is added to the final filter used or not. While not needed for normal Active Directory environments this does allow different environments to be used as the LDAP source.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/55

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad.ldap