### PR TITLE
Fix up missing common AD parameters on some cmdlets

### DIFF
--- a/changelogs/fragments/move-adparams.yml
+++ b/changelogs/fragments/move-adparams.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  Ensure renaming and moving an object will be done with the ``domain_server`` and ``domain_username`` credentials
+  specified - https://github.com/ansible-collections/microsoft.ad/issues/54

--- a/plugins/module_utils/_ADObject.psm1
+++ b/plugins/module_utils/_ADObject.psm1
@@ -883,7 +883,7 @@ Function Invoke-AnsibleADObject {
 
             # Remove-ADObject -Recursive fails with access is denied, use this
             # instead to remove the child objects manually
-            Get-ADObject -Filter * -Properties ProtectedFromAccidentalDeletion -Searchbase $adObject.DistinguishedName |
+            Get-ADObject -Filter * -Properties ProtectedFromAccidentalDeletion -Searchbase $adObject.DistinguishedName @adParams |
                 Sort-Object -Property { $_.DistinguishedName.Length } -Descending |
                 ForEach-Object -Process {
                     if ($_.ProtectedFromAccidentalDeletion) {
@@ -1077,7 +1077,7 @@ Function Invoke-AnsibleADObject {
                 $objectName = $module.Params.name
                 $module.Diff.after.name = $objectName
 
-                $finalADObject = Rename-ADObject @commonParams -NewName $objectName
+                $finalADObject = Rename-ADObject @commonParams @adParams -NewName $objectName
                 $module.Result.changed = $true
             }
 
@@ -1092,7 +1092,7 @@ Function Invoke-AnsibleADObject {
                 }
 
                 try {
-                    $finalADObject = Move-ADObject @commonParams -TargetPath $objectPath
+                    $finalADObject = Move-ADObject @commonParams @adParams -TargetPath $objectPath
                 }
                 finally {
                     if ($addProtection) {


### PR DESCRIPTION
##### SUMMARY
Two cmdlets were missing the `@adParams` splat which contained the `domain_server` and `domain_username/password` values. This PR adds that splatted variable to those calls.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/54

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
microsoft.ad._ADObject