### PR TITLE
feat(object_info): add activedirectory module import

### DIFF
--- a/changelogs/fragments/73-import-activedirectory-module.yml
+++ b/changelogs/fragments/73-import-activedirectory-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- object_info - Add ActiveDirectory module import

--- a/plugins/modules/object_info.ps1
+++ b/plugins/modules/object_info.ps1
@@ -46,6 +46,14 @@ $properties = $module.Params.properties
 $searchBase = $module.Params.search_base
 $searchScope = $module.Params.search_scope
 
+# Attempt import of ActiveDirectory module
+try {
+    Import-Module -Name ActiveDirectory
+}
+catch {
+    $module.FailJson("The ActiveDirectory module failed to load properly: $($_.Exception.Message)", $_)
+}
+
 $credential = $null
 if ($domainUsername) {
     $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @(
@@ -223,7 +231,9 @@ try {
     # We run this in a custom PowerShell pipeline so that users of this module can't use any of the variables defined
     # above in their filter. While the cmdlet won't execute sub expressions we don't want anyone implicitly relying on
     # a defined variable in this module in case we ever change the name or remove it.
-    $ps = [PowerShell]::Create()
+    $iss = [InitialSessionState]::CreateDefault()
+    $iss.ImportPSModule("ActiveDirectory")
+    $ps = [PowerShell]::Create($iss)
     $null = $ps.AddCommand('Get-ADObject').AddParameters($commonParams).AddParameters($getParams)
     $null = $ps.AddCommand('Select-Object').AddParameter('Property', @('DistinguishedName', 'ObjectGUID'))
 

--- a/plugins/modules/object_info.py
+++ b/plugins/modules/object_info.py
@@ -88,6 +88,7 @@ notes:
   and C(userAccountControl_AnsibleFlags) return property is something set by the module itself as an easy way to view
   what those flags represent. These properties cannot be used as part of the I(filter) or I(ldap_filter) and are
   automatically added if those properties were requested.
+- This must be run on a host that has the ActiveDirectory powershell module installed.
 extends_documentation_fragment:
 - ansible.builtin.action_common_attributes
 attributes:


### PR DESCRIPTION
##### SUMMARY

This proposed change, add explicit import of ActiveDirectory module in object_info.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

object_info

##### ADDITIONAL INFORMATION

This change allow this module to run on server with automatic import of modules disabled. And improve error message when ActiveDirectory module is missing.