### PR TITLE
Add dn_escape and parse_dn filters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,4 +27,7 @@
     "[powershell]": {
         "editor.formatOnSave": true,
     },
+    "[python]": {
+        "editor.formatOnSave": false
+    }
 }

--- a/docs/docsite/rst/guide_ldap_inventory.rst
+++ b/docs/docsite/rst/guide_ldap_inventory.rst
@@ -225,6 +225,7 @@ The following filters can be used as an easy way to further convert the coerced 
 * :ref:`microsoft.ad.as_datetime <ansible_collections.microsoft.ad.as_datetime_filter>`
 * :ref:`microsoft.ad.as_guid <ansible_collections.microsoft.ad.as_guid_filter>`
 * :ref:`microsoft.ad.as_sid <ansible_collections.microsoft.ad.as_sid_filter>`
+* :ref:`microsoft.ad.parse_dn <ansible_collections.microsoft.ad.parse_dn_filter>`
 
 An example of these filters being used in the ``attributes`` option can be seen below:
 
@@ -409,7 +410,7 @@ The ``raw`` value contains the raw base64 encoded value as stored in AD. The ``t
 
 * ``encrypted_value``: The encrypted password blob as a base64 string
 * ``flags``: The flags set as a bitwise int value, currently these are undocumented by Microsoft
-* ``update_timestamp``: The FILETIME value of when the 
+* ``update_timestamp``: The FILETIME value of when the
 * ``value``: The decrypted value containing the username and password as a JSON string
 * ``debug``: Debug information that indicates why it failed to decrypt the value
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: microsoft
 name: ad
-version: 1.4.1
+version: 1.5.0
 readme: README.md
 authors:
 - Jordan Borean @jborean93

--- a/plugins/filter/dn_escape.yml
+++ b/plugins/filter/dn_escape.yml
@@ -1,0 +1,46 @@
+# Copyright (c) 2023 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  name: dn_escape
+  author:
+  - Jordan Borean (@jborean93)
+  short_description: Escape an LDAP DistinguishedName value string.
+  version_added: 1.5.0
+  seealso:
+  - ref: microsoft.ad.parse_dn <ansible_collections.microsoft.ad.parse_dn_filter>
+    description: microsoft.ad.parse_dn filter
+  - ref: microsoft.ad.ldap <ansible_collections.microsoft.ad.ldap_inventory>
+    description: microsoft.ad.ldap inventory
+  description:
+  - Escapes a string value for use in an LDAP DistinguishedName.
+  - This can be used to escape special characters when building a
+    DistinguishedName value.
+  positional: _input
+  options:
+    _input:
+      description:
+      - The string value to escape.
+      - This should be just the RDN value not including the attribute type
+        that prefixes the value, for example C(MyValue) and not C(CN=MyValue).
+      type: str
+      required: true
+
+EXAMPLES: |
+  # This is an example used in the microsoft.ad.ldap plugin
+
+  search_base: OU={{ my_ou_variable | microsoft.ad.dn_escape }},DC=domain,DC=com
+
+  # This is an example with the microsoft.ad.user module
+
+  - microsoft.ad.user:
+      name: MyUser
+      password: MyPassword123
+      state: present
+      path: OU={{ my_ou_variable | microsoft.ad.dn_escape }},DC=domain,DC=com
+
+RETURN:
+  _value:
+    description:
+    - The escaped RDN attribute value.
+    type: string

--- a/plugins/filter/ldap_converters.py
+++ b/plugins/filter/ldap_converters.py
@@ -3,12 +3,161 @@
 
 import base64
 import datetime
+import re
 import struct
 import typing as t
 import uuid
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.common.collections import is_sequence
+
+
+_RDN_TYPE_PATTERN = re.compile(
+    r"""
+[\ ]*  # Ignore leading spaces
+(
+    (
+        # Lead char is a letter, subsequent chars can be numbers or -
+        [a-zA-Z][a-zA-Z0-9-]*
+    )
+    |
+    (
+        # First number must a decimal without a leading 0 unless 0.
+        # Must also contain at least another entry separated by '.'.
+        ([0-9]|[1-9][0-9]+)
+        (
+            \.([0-9]|[1-9][0-9]+)
+        )+
+    )
+)
+[\ ]*=  # Ignore trailing spaces before the =
+""".encode(
+        "utf-8"
+    ),
+    re.VERBOSE,
+)
+
+_RDN_VALUE_HEXSTRING_PATTERN = re.compile(
+    r"""
+[\ ]*  # Ignore leading spaces
+\#  # Starts with '#'
+(
+    ([0-9a-fA-F]{2})+
+)
+[\ ]*  # Ignore trailing spaces
+(?:[+,]|$)  # Terminated by '+', ',', or the end of the string
+""".encode(
+        "utf-8"
+    ),
+    re.VERBOSE,
+)
+
+_RDN_VALUE_ESCAPE_PATTERN = re.compile(
+    r"""
+(
+    (?P<literal>
+        [+,;<>#=\\\"\ ]
+    )
+    |
+    (?P<hex>
+        ([0-9a-fA-F]{2})
+    )
+)
+""".encode(
+        "utf-8"
+    ),
+    re.VERBOSE,
+)
+
+
+def _parse_rdn_type(value: memoryview) -> t.Optional[t.Tuple[bytes, int]]:
+    if match := _RDN_TYPE_PATTERN.match(value):
+        return match.group(1), len(match.group(0))
+
+    return None
+
+
+def _parse_rdn_value(value: memoryview) -> t.Optional[t.Tuple[bytes, int, bool]]:
+    if hex_match := _RDN_VALUE_HEXSTRING_PATTERN.match(value):
+        full_value = hex_match.group(0)
+        more_rdns = full_value.endswith(b"+")
+
+        b_value = base64.b16decode(hex_match.group(1).upper())
+        return b_value, len(full_value), more_rdns
+
+    # Parsing the string value variant as regex is too complicated due to the
+    # myriad of rules and escaping so it is done manually.
+    read = 0
+    new_value = bytearray()
+    found_spaces = 0
+
+    total_len = len(value)
+    while read < total_len:
+        current_value = value[read]
+        current_char = chr(current_value)
+        read += 1
+
+        # We only count the spaces in the middle of the string so we need to
+        # keep track of how many have been found until the next character.
+        if current_char == " ":
+            if new_value:
+                found_spaces += 1
+
+            continue
+
+        if current_char in [",", "+"]:
+            break
+
+        # We can add any spaces we are still tentatively collecting as there's
+        # a real value after it.
+        if found_spaces:
+            new_value += b" " * found_spaces
+            found_spaces = 0
+
+        if current_char == "#" and not new_value:
+            remaining = (
+                value[read - 1:].tobytes().decode("utf-8", errors="surrogateescape")
+            )
+            raise AnsibleFilterError(
+                f"Found leading # for attribute value but does not match hexstring format at '{remaining}'"
+            )
+
+        elif current_char in ["\00", '"', ";", "<", ">"]:
+            remaining = (
+                value[read - 1:].tobytes().decode("utf-8", errors="surrogateescape")
+            )
+            raise AnsibleFilterError(
+                f"Found unescaped character '{current_char}' in attribute value at '{remaining}'"
+            )
+
+        elif current_char == "\\":
+            if escape_match := _RDN_VALUE_ESCAPE_PATTERN.match(value, pos=read):
+                if literal_value := escape_match.group("literal"):
+                    new_value += literal_value
+                    read += 1
+
+                else:
+                    new_value += base64.b16decode(escape_match.group("hex").upper())
+                    read += 2
+
+            else:
+                remaining = (
+                    value[read - 1:]
+                    .tobytes()
+                    .decode("utf-8", errors="surrogateescape")
+                )
+                raise AnsibleFilterError(
+                    f"Found invalid escape sequence in attribute value at '{remaining}"
+                )
+
+        else:
+            new_value.append(current_value)
+
+    if new_value:
+        return bytes(new_value), read, current_char == "+"
+
+    else:
+        return None
 
 
 def per_sequence(func: t.Callable[[t.Any], t.Any]) -> t.Any:
@@ -22,7 +171,10 @@ def per_sequence(func: t.Callable[[t.Any], t.Any]) -> t.Any:
 
 
 @per_sequence
-def as_datetime(value: t.Any, format: str = "%Y-%m-%dT%H:%M:%S.%f%z") -> str:
+def as_datetime(
+    value: t.Any,
+    format: str = "%Y-%m-%dT%H:%M:%S.%f%z",
+) -> str:
     if isinstance(value, bytes):
         value = value.decode("utf-8")
 
@@ -31,8 +183,14 @@ def as_datetime(value: t.Any, format: str = "%Y-%m-%dT%H:%M:%S.%f%z") -> str:
 
     # FILETIME is 100s of nanoseconds since 1601-01-01. As Python does not
     # support nanoseconds the delta is number of microseconds.
+    ft_epoch = datetime.datetime(
+        year=1601,
+        month=1,
+        day=1,
+        tzinfo=datetime.timezone.utc,
+    )
     delta = datetime.timedelta(microseconds=value // 10)
-    dt = datetime.datetime(year=1601, month=1, day=1, tzinfo=datetime.timezone.utc) + delta
+    dt = ft_epoch + delta
 
     return dt.strftime(format)
 
@@ -77,10 +235,95 @@ def as_sid(value: t.Any) -> str:
     return f"S-{revision}-{authority}-{'-'.join(sub_authorities)}"
 
 
+@per_sequence
+def dn_escape(value: str) -> str:
+    """Escapes a DistinguisedName attribute value."""
+    escaped_value = []
+
+    end_idx = len(value) - 1
+    for idx, c in enumerate(value):
+        if (
+            # Starting char cannot be ' ' or #
+            (idx == 0 and c in [" ", "#"])
+            # Ending char cannot be ' '
+            or (idx == end_idx and c == " ")
+            # Any of these chars need to be escaped
+            # These are documented in RFC 4514
+            or (c in ['"', "+", ",", ";", "<", ">", "\\"])
+        ):
+            escaped_value.append(rf"\{c}")
+
+        elif c in ["\00", "\n", "\r", "=", "/"]:
+            # These are extra chars MS says to escape, it must be done using
+            # the hex syntax
+            # https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ldap/distinguished-names
+            escaped_int = ord(c)
+            escaped_value.append(rf"\{escaped_int:02X}")
+
+        else:
+            escaped_value.append(c)
+
+    return "".join(escaped_value)
+
+
+@per_sequence
+def parse_dn(value: str) -> t.List[t.List[str]]:
+    """Parses a DistinguishedName and emits a structured object."""
+
+    # This behaviour is defined in RFC 4514 and while not defined in that RFC
+    # this will also remove any extra spaces before and after , = and +.
+    dn: t.List[t.List[str]] = []
+
+    # This operates on bytes for 2 reasons:
+    #   1. We can use a memoryview for more efficient slicing
+    #   2. Attribute value hex escaping is done per byte, we cannot decode
+    #      back to a string until we have the final value.
+    # surrogateescape is used for all conversions to ensure non-unicode bytes
+    # are preserved using the escape behaviour in UTF-8.
+    b_value = value.encode("utf-8", errors="surrogateescape")
+    b_view = memoryview(b_value)
+
+    while b_view:
+        rdns: t.List[str] = []
+
+        while True:
+            attr_type = _parse_rdn_type(b_view)
+            if not attr_type:
+                remaining = b_view.tobytes().decode("utf-8", errors="surrogateescape")
+                raise AnsibleFilterError(
+                    f"Expecting attribute type in RDN entry from '{remaining}'"
+                )
+
+            rdns.append(attr_type[0].decode("utf-8", errors="surrogateescape"))
+            b_view = b_view[attr_type[1]:]
+
+            attr_value = _parse_rdn_value(b_view)
+            if not attr_value:
+                remaining = b_view.tobytes().decode("utf-8", errors="surrogateescape")
+                raise AnsibleFilterError(
+                    f"Expecting attribute value in RDN entry from '{remaining}'"
+                )
+
+            rdns.append(attr_value[0].decode("utf-8", errors="surrogateescape"))
+            b_view = b_view[attr_value[1]:]
+
+            # If ended with + we want to continue parsing the AVA values
+            if attr_value[2]:
+                continue
+            else:
+                break
+
+        dn.append(rdns)
+
+    return dn
+
+
 class FilterModule:
     def filters(self) -> t.Dict[str, t.Callable]:
         return {
             "as_datetime": as_datetime,
             "as_guid": as_guid,
             "as_sid": as_sid,
+            "dn_escape": dn_escape,
+            "parse_dn": parse_dn,
         }

--- a/plugins/filter/parse_dn.yml
+++ b/plugins/filter/parse_dn.yml
@@ -1,0 +1,82 @@
+# Copyright (c) 2023 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  name: parse_dn
+  author:
+  - Jordan Borean (@jborean93)
+  short_description: Parses an LDAP DistinguishedName string into an object.
+  version_added: 1.5.0
+  seealso:
+  - ref: microsoft.ad.dn_escape <ansible_collections.microsoft.ad.dn_escape_filter>
+    description: microsoft.ad.dn_escape filter
+  - ref: microsoft.ad.ldap <ansible_collections.microsoft.ad.ldap_inventory>
+    description: microsoft.ad.ldap inventory
+  description:
+  - Parses the provided LDAP DistinguishedName (C(DN)) string value into a
+    structured object.
+  - The rules for parsing as defined in
+    L(RFC 4514,https://www.ietf.org/rfc/rfc4514.txt).
+  - Each DN contains Relative DistinguishedNames (C(RDN)) separated by C(,) and
+    each RDN can contain multiple attribute type values also known as an
+    C(AVA). While Microsoft Active Directory DNs can only contain 1 AVA in an
+    RDN this parser supports multiple AVAs.
+  - The returned object for each DN will be provided as a list of lists where
+    the outer list is each RDN component separated by C(,) and the inner list
+    is each AVA separated by C(=) and C(+). Each RDN entry is guaranteed to
+    have 2 string values for the AVA type and value but can contain more if the
+    RDN contains multiple AVAs separated by C(+).
+  - The parsed RDN attribute values will be unescaped to represent the actual
+    value rather than the raw string in the DN.
+  - A DN that is invalid will raise a filter error.
+  positional: _input
+  options:
+    _input:
+      description:
+      - The LDAP DistinguishedName string to parse.
+      type: str
+      required: true
+
+EXAMPLES: |
+  - name: Parses a simple DN
+    set_fact:
+      my_dn: '{{ "CN=Foo,DC=domain,DC=com" | microsoft.ad.parse_dn }}'
+
+  # [
+  #   ["CN", "Foo"],
+  #   ["DC", "domain"],
+  #   ["DC", "com"],
+  # ]
+
+  - name: Parses a DN with an escaped and multi attribute values
+    set_fact:
+      my_dn: '{{ "CN=CA,O=Acme\, Inc.,C=AU+ST=Queensland" | microsoft.ad.parse_dn }}'
+
+  # [
+  #   ["CN", "CA"],
+  #   ["O", "Acme, Inc."],
+  #   ["C", "AU", "ST", "Queensland"]
+  # ]
+
+  # Extract the group names the computer is a member of in the ldap inventory
+  # plugin, for example gets the first RDN value inside the parsed DN.
+  attributes:
+    memberOf:
+      computer_membership: this | microsoft.ad.parse_dn | map(attribute="0.1")
+
+RETURN:
+  _value:
+    description:
+    - The parsed LDAP DN values.
+    type: list
+    elements: list
+    sample:
+    -
+      - CN
+      - Foo
+    -
+      - DC
+      - domain
+    -
+      - DC
+      - com

--- a/tests/integration/targets/inventory_ldap/roles/test/tasks/main.yml
+++ b/tests/integration/targets/inventory_ldap/roles/test/tasks/main.yml
@@ -434,7 +434,7 @@
             nothing_member:
             this_member: this
             raw_member: raw
-            computer_membership: this | map("regex_search", '^CN=(?P<name>.+?)((?<!\\),)', '\g<name>') | flatten
+            computer_membership: this | microsoft.ad.parse_dn | map(attribute="0.1")
         compose:
           host_var: computer_sid
         groups:

--- a/tests/unit/plugins/filter/test_ldap_converters.py
+++ b/tests/unit/plugins/filter/test_ldap_converters.py
@@ -8,7 +8,13 @@ import uuid
 import pytest
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.microsoft.ad.plugins.filter.ldap_converters import as_sid, as_guid, as_datetime
+from ansible_collections.microsoft.ad.plugins.filter.ldap_converters import (
+    as_sid,
+    as_guid,
+    as_datetime,
+    dn_escape,
+    parse_dn,
+)
 
 
 @pytest.mark.parametrize("type", ["int", "str", "bytes"])
@@ -37,7 +43,10 @@ def test_as_datetime_with_format() -> None:
 
 def test_as_datetime_from_list() -> None:
     actual = as_datetime([133220025750000000, 133220025751000020])
-    assert actual == ["2023-02-27T20:16:15.000000+0000", "2023-02-27T20:16:15.100002+0000"]
+    assert actual == [
+        "2023-02-27T20:16:15.000000+0000",
+        "2023-02-27T20:16:15.100002+0000",
+    ]
 
 
 @pytest.mark.parametrize("type", ["str", "bytes"])
@@ -83,10 +92,147 @@ def test_as_sid_from_list() -> None:
 
 
 def test_as_sid_too_little_data_auth_count() -> None:
-    with pytest.raises(AnsibleFilterError, match="Raw SID bytes must be at least 8 bytes long"):
+    with pytest.raises(
+        AnsibleFilterError, match="Raw SID bytes must be at least 8 bytes long"
+    ):
         as_sid(b"\x00\x00\x00\x00")
 
 
 def test_as_sid_too_little_data_sub_authorities() -> None:
     with pytest.raises(AnsibleFilterError, match="Not enough data to unpack SID"):
         as_sid(b"\x01\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("Sue, Grabbit and Runn", "Sue\\, Grabbit and Runn"),
+        ("Before\rAfter", "Before\\0DAfter"),
+        ("Docs, Adatum", "Docs\\, Adatum"),
+        ("foo,bar", "foo\\,bar"),
+        ("foo+bar", "foo\\+bar"),
+        ('foo"bar', 'foo\\"bar'),
+        ("foo\\bar", "foo\\\\bar"),
+        ("foo<bar", "foo\\<bar"),
+        ("foo>bar", "foo\\>bar"),
+        ("foo;bar", "foo\\;bar"),
+        (" foo bar", "\\ foo bar"),
+        ("#foo bar", "\\#foo bar"),
+        ("# foo bar", "\\# foo bar"),
+        ("foo bar ", "foo bar\\ "),
+        ("foo bar  ", "foo bar \\ "),
+        ("foo bar #", "foo bar #"),
+        ("foo\00bar", "foo\\00bar"),
+        ("foo\nbar", "foo\\0Abar"),
+        ("foo\rbar", "foo\\0Dbar"),
+        ("foo=bar", "foo\\3Dbar"),
+        ("foo/bar", "foo\\2Fbar"),
+    ],
+)
+def test_dn_escape(value: str, expected: str) -> None:
+    actual = dn_escape(value)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (
+            "",
+            [],
+        ),
+        (
+            "CN=foo",
+            [["CN", "foo"]],
+        ),
+        (
+            r"CN=foo,DC=bar",
+            [["CN", "foo"], ["DC", "bar"]],
+        ),
+        (
+            r"CN=foo, DC=bar",
+            [["CN", "foo"], ["DC", "bar"]],
+        ),
+        (
+            r"CN=foo , DC=bar",
+            [["CN", "foo"], ["DC", "bar"]],
+        ),
+        (
+            r"CN=foo  ,  DC=bar",
+            [["CN", "foo"], ["DC", "bar"]],
+        ),
+        (
+            r"UID=jsmith,DC=example,DC=net",
+            [["UID", "jsmith"], ["DC", "example"], ["DC", "net"]],
+        ),
+        (
+            r"OU=Sales+CN=J.  Smith,DC=example,DC=net",
+            [["OU", "Sales", "CN", "J.  Smith"], ["DC", "example"], ["DC", "net"]],
+        ),
+        (
+            r"OU=Sales + CN=J.  Smith,DC=example,DC=net",
+            [["OU", "Sales", "CN", "J.  Smith"], ["DC", "example"], ["DC", "net"]],
+        ),
+        (
+            r"CN=James \"Jim\" Smith\, III,DC=example,DC=net",
+            [["CN", 'James "Jim" Smith, III'], ["DC", "example"], ["DC", "net"]],
+        ),
+        (
+            r"CN=Before\0dAfter,DC=example,DC=net",
+            [["CN", "Before\rAfter"], ["DC", "example"], ["DC", "net"]],
+        ),
+        (
+            r"1.3.6.1.4.1.1466.0=#FE04024869",
+            [["1.3.6.1.4.1.1466.0", "\udcfe\x04\x02Hi"]],
+        ),
+        (
+            r"1.3.6.1.4.1.1466.0 = #FE04024869",
+            [["1.3.6.1.4.1.1466.0", "\udcfe\x04\x02Hi"]],
+        ),
+        (
+            r"CN=Lu\C4\8Di\C4\87",
+            [["CN", "Lučić"]],
+        ),
+    ],
+)
+def test_parse_dn(value: str, expected: t.List[str]) -> None:
+    actual = parse_dn(value)
+
+    assert actual == expected
+
+
+def test_parse_dn_invalid_attribute_type() -> None:
+    expected = "Expecting attribute type in RDN entry from 'foo_invalid=test'"
+    with pytest.raises(AnsibleFilterError, match=expected):
+        parse_dn("foo_invalid=test")
+
+
+def test_parse_dn_no_attribute_value() -> None:
+    expected = "Expecting attribute value in RDN entry from ''"
+    with pytest.raises(AnsibleFilterError, match=expected):
+        parse_dn("foo=")
+
+
+def test_parse_dn_no_value_after_ava_delimiter() -> None:
+    expected = "Expecting attribute type in RDN entry from ''"
+    with pytest.raises(AnsibleFilterError, match=expected):
+        parse_dn("foo=bar+")
+
+
+def test_parse_dn_unescaped_hash() -> None:
+    expected = "Found leading # for attribute value but does not match hexstring format at '#bar'"
+    with pytest.raises(AnsibleFilterError, match=expected):
+        parse_dn("foo=#bar")
+
+
+@pytest.mark.parametrize("c", ["\00", '"', ";", "<", ">"])
+def test_parse_dn_unescaped_special_char(c: str) -> None:
+    expected = f"Found unescaped character '{c}' in attribute value at '{c}value'"
+    with pytest.raises(AnsibleFilterError, match=expected):
+        parse_dn(f"foo=test{c}value")
+
+
+def test_parse_dn_invalid_attr_value_escape() -> None:
+    expected = r"Found invalid escape sequence in attribute value at '\\1z"
+    with pytest.raises(AnsibleFilterError, match=expected):
+        parse_dn("foo=bar \\1z")


### PR DESCRIPTION
##### SUMMARY
Adds filters that can be used to escape values for use inside a DN attribute value and to parse a DN string into a more structured object. These filters are useful with the `microsoft.ad.ldap` inventory plugin as well as when forming values like the `path` or other DN attributes.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad.dn_escape
microsoft.ad.parse_dn