### PR TITLE
Add error message for invalid domain_ou_path

### DIFF
--- a/changelogs/fragments/membership-invalid-ou.yml
+++ b/changelogs/fragments/membership-invalid-ou.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    microsoft.ad.membership - Add helpful hint when the failure was due to a missing/invalid ``domain_ou_path``
+    - https://github.com/ansible-collections/microsoft.ad/issues/88

--- a/tests/integration/targets/membership/ansible.cfg
+++ b/tests/integration/targets/membership/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 inventory = inventory.yml
 retry_files_enabled = False
+callback_result_format = yaml

--- a/tests/integration/targets/membership/tasks/main.yml
+++ b/tests/integration/targets/membership/tasks/main.yml
@@ -26,6 +26,23 @@
       Get-ADComputer -Filter { Name -ne 'DC' } -Properties DistinguishedName, Name, Enabled |
           Select-Object -Property DistinguishedName, Name, Enabled
 
+- name: join domain invalid OU
+  membership:
+    dns_domain_name: '{{ domain_realm }}'
+    domain_admin_user: '{{ domain_user_upn }}'
+    domain_admin_password: '{{ domain_password }}'
+    domain_ou_path: CN=Invalid,{{ domain_dn_base }}
+    state: domain
+    reboot: true
+  ignore_errors: true
+  register: join_domain_invalid_ou
+
+- name: assert join domain invalid OU
+  assert:
+    that:
+    - join_domain_invalid_ou is failed
+    - join_domain_invalid_ou.msg.endswith('Check domain_ou_path is pointing to a valid OU in the target domain.')
+
 - name: join domain - check mode
   membership:
     dns_domain_name: '{{ domain_realm }}'


### PR DESCRIPTION
##### SUMMARY
Adds a helpful hint to the end of the error message when failing to join a domain due to an invalid/missing domain_ou_path.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/88

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
microsoft.ad.membership