### PR TITLE
Add module defaults group

### DIFF
--- a/changelogs/fragments/default_options.yml
+++ b/changelogs/fragments/default_options.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - >-
+    Added ``group/microsoft.ad.domain`` module defaults group for the ``computer``, ``group``, ``object_info``,
+    ``object``, ``ou``, and ``user`` module. Users can use this defaults group to set common connection options
+    for these modules such as the ``domain_server``, ``domain_username``, and ``domain_password`` options.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,9 @@
 requires_ansible: '>=2.14'
+action_groups:
+  domain:
+    - computer
+    - group
+    - object_info
+    - object
+    - ou
+    - user

--- a/plugins/doc_fragments/ad_object.py
+++ b/plugins/doc_fragments/ad_object.py
@@ -79,12 +79,16 @@ options:
   domain_password:
     description:
     - The password for I(domain_username).
+    - This can be set under the R(play's module defaults,module_defaults_groups)
+      under the C(group/microsoft.ad.domain) group.
     type: str
   domain_server:
     description:
     - Specified the Active Directory Domain Services instance to connect to.
     - Can be in the form of an FQDN or NetBIOS name.
     - If not specified then the value is based on the default domain of the computer running PowerShell.
+    - This can be set under the R(play's module defaults,module_defaults_groups)
+      under the C(group/microsoft.ad.domain) group.
     type: str
   domain_username:
     description:
@@ -92,6 +96,8 @@ options:
     - If this is not set then the user that is used for authentication will be the connection user.
     - Ansible will be unable to use the connection user unless auth is Kerberos with credential delegation or CredSSP,
       or become is used on the task.
+    - This can be set under the R(play's module defaults,module_defaults_groups)
+      under the C(group/microsoft.ad.domain) group.
     type: str
   identity:
     description:

--- a/plugins/modules/object_info.py
+++ b/plugins/modules/object_info.py
@@ -16,12 +16,16 @@ options:
   domain_password:
     description:
     - The password for I(domain_username).
+    - This can be set under the R(play's module defaults,module_defaults_groups)
+      under the C(group/microsoft.ad.domain) group.
     type: str
   domain_server:
     description:
     - Specified the Active Directory Domain Services instance to connect to.
     - Can be in the form of an FQDN or NetBIOS name.
     - If not specified then the value is based on the default domain of the computer running PowerShell.
+    - This can be set under the R(play's module defaults,module_defaults_groups)
+      under the C(group/microsoft.ad.domain) group.
     type: str
   domain_username:
     description:
@@ -29,6 +33,8 @@ options:
     - If this is not set then the user that is used for authentication will be the connection user.
     - Ansible will be unable to use the connection user unless auth is Kerberos with credential delegation or CredSSP,
       or become is used on the task.
+    - This can be set under the R(play's module defaults,module_defaults_groups)
+      under the C(group/microsoft.ad.domain) group.
     type: str
   filter:
     description:


### PR DESCRIPTION
##### SUMMARY
Adds the module defaults group microsoft.ad.domain to allow setting common connection parameters for module that communicate with the domain controller.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/93

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad