### PR TITLE
Jinja2 templating support in inventory

### DIFF
--- a/changelogs/fragments/templating_support.yml
+++ b/changelogs/fragments/templating_support.yml
@@ -1,5 +1,3 @@
 minor_changes:
   - >-
     Added support for Jinja2 templating in ldap inventory. 
-    Supported fields are 'username', 'password', 'server', 'tls_mode', 'auth_protocol', 'ca_cert', 'cert_validation', 'certificate', 
-    'certificate_key', 'certificate_key', 'encrypt'.

--- a/changelogs/fragments/templating_support.yml
+++ b/changelogs/fragments/templating_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added support for Jinja2 templating in ldap inventory. Supported fields are 'username', 'password', 'server', 'tls_mode', 'auth_protocol', 'ca_cert', 'cert_validation', 'certificate', 'certificate_key', 'certificate_key', 'encrypt'.

--- a/changelogs/fragments/templating_support.yml
+++ b/changelogs/fragments/templating_support.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - >-
-    Added support for Jinja2 templating in ldap inventory. 
+    Added support for Jinja2 templating in ldap inventory.

--- a/changelogs/fragments/templating_support.yml
+++ b/changelogs/fragments/templating_support.yml
@@ -1,2 +1,5 @@
 minor_changes:
-  - Added support for Jinja2 templating in ldap inventory. Supported fields are 'username', 'password', 'server', 'tls_mode', 'auth_protocol', 'ca_cert', 'cert_validation', 'certificate', 'certificate_key', 'certificate_key', 'encrypt'.
+  - >-
+    Added support for Jinja2 templating in ldap inventory. 
+    Supported fields are 'username', 'password', 'server', 'tls_mode', 'auth_protocol', 'ca_cert', 'cert_validation', 'certificate', 
+    'certificate_key', 'certificate_key', 'encrypt'.

--- a/plugins/doc_fragments/ldap_connection.py
+++ b/plugins/doc_fragments/ldap_connection.py
@@ -31,6 +31,7 @@ options:
       installed.
     - See R(LDAP authentication,ansible_collections.microsoft.ad.docsite.guide_ldap_connection.authentication)
       for more information.
+    - This option can be set using a Jinja2 template value.
     choices:
     - simple
     - certificate
@@ -47,6 +48,7 @@ options:
       certificate validation.
     - If omitted, the default CA store used for validation is dependent on
       the current Python settings.
+    - This option can be set using a Jinja2 template value.
     type: str
     env:
     - name: MICROSOFT_AD_LDAP_CA_CERT
@@ -60,6 +62,7 @@ options:
       hostname checks performed by TLS.
     - See R(Certificate validation,ansible_collections.microsoft.ad.docsite.guide_ldap_connection.cert_validation)
       for more information.
+    - This option can be set using a Jinja2 template value.
     choices:
     - always
     - ignore
@@ -80,6 +83,7 @@ options:
     - Use I(certificate_key) if the certificate specified does not contain the
       key.
     - Use I(certificate_password) if the key is encrypted with a password.
+    - This option can be set using a Jinja2 template value.
     type: str
     env:
     - name: MICROSOFT_AD_LDAP_CERTIFICATE
@@ -89,6 +93,7 @@ options:
     - The value can either be a path to a file containing the key in the PEM or
       DER encoded form, or it can be the string of a PEM encoded key.
     - Use I(certificate_password) if the key is encrypted with a password.
+    - This option can be set using a Jinja2 template value.
     type: str
     env:
     - name: MICROSOFT_AD_LDAP_CERTIFICATE_KEY
@@ -96,6 +101,7 @@ options:
     description:
     - The password used to decrypt the certificate key specified by
       I(certificate) or I(certificate_key).
+    - This option can be set using a Jinja2 template value.
     type: str
     env:
     - name: MICROSOFT_AD_LDAP_CERTIFICATE_PASSWORD
@@ -103,6 +109,7 @@ options:
     description:
     - The timeout in seconds to wait until the connection is established before
       failing.
+    - This option can be set using a Jinja2 template value.
     default: 5
     type: int
     env:
@@ -117,6 +124,7 @@ options:
     - If using C(auth_protocol=simple) over LDAP without TLS then this must be
       set to C(False). As no encryption is used, all traffic will be in
       plaintext and should be avoided.
+    - This option can be set using a Jinja2 template value.
     default: true
     type: bool
     env:
@@ -129,6 +137,7 @@ options:
     - If I(auth_protocol) is C(negotiate), C(kerberos), or C(ntlm) and no
       password is specified, it will attempt to use the local cached credential
       specified by I(username) if available.
+    - This option can be set using a Jinja2 template value.
     type: str
     env:
     - name: MICROSOFT_AD_LDAP_PASSWORD
@@ -137,6 +146,7 @@ options:
     - The LDAP port to use for the connection.
     - Port 389 is used for LDAP and port 686 is used for LDAPS.
     - Defaults to port C(636) if C(tls_mode=ldaps) otherwise C(389).
+    - This option can be set using a Jinja2 template value.
     type: int
     env:
     - name: MICROSOFT_AD_LDAP_PORT
@@ -147,6 +157,7 @@ options:
       C(default_realm) setting and with an SRV DNS lookup.
     - See R(Server lookup,ansible_collections.microsoft.ad.docsite.guide_ldap_connection.server_lookup)
       for more information.
+    - This option can be set using a Jinja2 template value.
     type: str
     env:
     - name: MICROSOFT_AD_LDAP_SERVER
@@ -159,6 +170,7 @@ options:
       operation before the authentication bind.
     - It is recommended to use C(ldaps) over C(start_tls) if TLS is going to be
       used.
+    - This option can be set using a Jinja2 template value.
     choices:
     - ldaps
     - start_tls
@@ -173,6 +185,7 @@ options:
     - If I(auth_protocol) is C(negotiate), C(kerberos), or C(ntlm) and no
       username is specified, it will attempt to use the local cached credential
       if available, for example one retrieved by C(kinit).
+    - This option can be set using a Jinja2 template value.
     type: str
     env:
     - name: MICROSOFT_AD_LDAP_USERNAME

--- a/plugins/inventory/ldap.py
+++ b/plugins/inventory/ldap.py
@@ -312,7 +312,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 "inventory_hostname": inventory_hostname
             }
         connection_options = self.get_options()
-        template_fields = ['username', 'password', 'server', 'tls_mode', 'auth_protocol', 'ca_cert', 'cert_validation', 'certificate', 'certificate_key', 'certificate_key', 'encrypt']
+        template_fields = ['username', 'password', 'server', 'tls_mode', 'auth_protocol', 'ca_cert',
+                           'cert_validation', 'certificate', 'certificate_key', 'certificate_key', 'encrypt']
         for t in template_fields:
             if t in connection_options.keys():
                 if self.templar.is_template(connection_options[t]):

--- a/plugins/inventory/ldap.py
+++ b/plugins/inventory/ldap.py
@@ -311,8 +311,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             custom_attributes["inventory_hostname"] = {
                 "inventory_hostname": inventory_hostname
             }
-
         connection_options = self.get_options()
+        template_fields = ['username', 'password', 'server', 'tls_mode', 'auth_protocol', 'ca_cert', 'cert_validation', 'certificate', 'certificate_key', 'certificate_key', 'encrypt']
+        for t in template_fields:
+            if t in connection_options.keys():
+                if self.templar.is_template(connection_options[t]):
+                    self.display.vvv("detemplating option %s" % t)
+                    connection_options[t] = self.templar.template(variable=connection_options[t], disable_lookups=False)
+
         laps_decryptor = LAPSDecryptor(**connection_options)
         with create_ldap_connection(**connection_options) as client:
             schema = LDAPSchema.load_schema(client)

--- a/tests/integration/targets/inventory_ldap/roles/test/tasks/main.yml
+++ b/tests/integration/targets/inventory_ldap/roles/test/tasks/main.yml
@@ -95,6 +95,23 @@
 
 - import_tasks: invoke.yml
   vars:
+    scenario: LDAP through lookup templates
+    inventory:
+      plugin: microsoft.ad.ldap
+      server: !unsafe '{{ lookup("ansible.builtin.env", "LDAP_SERVER") }}'
+      username: !unsafe '{{ lookup("ansible.builtin.env", "LDAP_USERNAME") }}'
+      password: !unsafe '{{ lookup("ansible.builtin.env", "LDAP_PASSWORD") }}'
+  environment:
+    LDAP_SERVER: '{{ ldap_server }}'
+    LDAP_USERNAME: '{{ ldap_user }}'
+    LDAP_PASSWORD: '{{ ldap_pass }}'
+
+- name: assert LDAP through lookup templates
+  assert:
+    that: *default-assertion
+
+- import_tasks: invoke.yml
+  vars:
     scenario: LDAPS
     inventory:
       plugin: microsoft.ad.ldap


### PR DESCRIPTION
##### SUMMARY
Hello,
This PR contains some modifications in order to suppor Jinja2 templating in ldap inventory.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
##### ADDITIONAL INFORMATION
I have to to target an inventory directory to multiple Active Directory so I can't use environment variables.
```bash
$ tree inventory/
inventory/
├── 00_ad1.microsoft.ad.ldap.yml
├── 00_ad2.microsoft.ad.ldap.yml
├── 00_ad3.microsoft.ad.ldap.yml
└── 99_final.yml
```

I added a couple of lines in order to make connection options more dynamic and supporting Jinja2 templating as already implemented in other inventory plugins. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```YAML
plugin: microsoft.ad.ldap
server: mydomain.local.lcl
port: 389
username: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/my/secret:ad_credential_user') }}@{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/my/secret:ad_credential_realm') }}"
password: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/my/secret:ad_credential_password') }}"
```

Bye