### PR TITLE
microsoft.ad.user - Fix account_locked on creation

### DIFF
--- a/changelogs/fragments/user-account-locked.yml
+++ b/changelogs/fragments/user-account-locked.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    microsoft.ad.user - Fix issue when creating a new user account with ``account_locked: false`` -
+    https://github.com/ansible-collections/microsoft.ad/issues/108

--- a/plugins/modules/user.ps1
+++ b/plugins/modules/user.ps1
@@ -66,6 +66,9 @@ $setParams = @{
                 type = 'bool'
             }
             Attribute = 'LockedOut'
+            # We cannot lock a user and creating a user that is unlocked
+            # requires no action.
+            New = {}
             Set = {
                 param($Module, $ADParams, $SetParams, $ADObject)
 

--- a/tests/integration/targets/user/tasks/tests.yml
+++ b/tests/integration/targets/user/tasks/tests.yml
@@ -510,6 +510,7 @@
   user:
     name: MyUser
     state: present
+    account_locked: False
     city: Brisbane
     company: Red Hat
     country: au
@@ -563,6 +564,7 @@
   user:
     name: MyUser
     state: present
+    account_locked: False
     city: Brisbane
     company: Red Hat
     country: au
@@ -685,6 +687,7 @@
   user:
     name: MyUser
     state: present
+    account_locked: False
     city: Brisbane
     company: Red Hat
     country: au


### PR DESCRIPTION
##### SUMMARY
Ensure that creating a new user with an explicit account_locked value does not fail.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/108

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
microsoft.ad.user