### PR TITLE
microsoft.ad.user - Add group lookup DN logic

### DIFF
--- a/changelogs/fragments/user-groups.yml
+++ b/changelogs/fragments/user-groups.yml
@@ -1,0 +1,9 @@
+minor_changes:
+  - >-
+    microsoft.ad.user - Support group member lookup on alternative server using the DN lookup syntax.
+    This syntax uses a dictionary where ``name`` defined the group to lookup and ``server`` defines the
+    server to lookup the group on.
+  - >-
+    microsoft.ad.user - Rename the option ``groups.missing_action`` to ``groups.lookup_failure_action``
+    to make the option more consistent with other modules. The ``missing_action`` option is still
+    supported as an alias.

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -116,10 +116,20 @@ options:
     - To clear all group memberships, use I(set) with an empty list.
     - Note that users cannot be removed from their principal group (for
       example, "Domain Users"). Attempting to do so will display a warning.
+    - Adding and removing a user from a group is done on the group AD object.
+      If the group is an object in a different domain, then it may require
+      explicit I(server) and I(domain_credentials) for it to work.
     - Each subkey is set to a list of groups objects to add, remove or
       set as the membership of this AD user respectively. A group can be in
       the form of a C(distinguishedName), C(objectGUID), C(objectSid), or
       C(sAMAccountName).
+    - Each subkey value is a list of group objects in the form of a
+      C(distinguishedName), C(objectGUID), C(objectSid), C(sAMAccountName),
+      or C(userPrincipalName) string or a dictionary with the I(name) and
+      optional I(server) key.
+    - See
+      R(DN Lookup Attributes,ansible_collections.microsoft.ad.docsite.guide_attributes.dn_lookup_attributes)
+      for more information on how DN lookups work.
     - See R(Setting list option values,ansible_collections.microsoft.ad.docsite.guide_list_values)
       for more information on how to add/remove/set list options.
     type: dict
@@ -128,20 +138,20 @@ options:
         description:
         - The groups to add the user to.
         type: list
-        elements: str
+        elements: raw
       remove:
         description:
         - The groups to remove the user from.
         type: list
-        elements: str
+        elements: raw
       set:
         description:
         - The only groups the user is a member of.
         - This will clear out any existing groups if not in the specified list.
         - Set to an empty list to clear all group membership of the user.
         type: list
-        elements: str
-      missing_behaviour:
+        elements: raw
+      lookup_failure_action:
         description:
         - Controls what happens when a group specified by C(groups) is an
           invalid group name.
@@ -150,6 +160,8 @@ options:
         - C(ignore) will ignore any groups that does not exist.
         - C(warn) will display a warning for any groups that do not exist but
           will continue without failing.
+        aliases:
+        - missing_behaviour
         choices:
         - fail
         - ignore

--- a/tests/integration/targets/domain_child/tasks/cross_domain.yml
+++ b/tests/integration/targets/domain_child/tasks/cross_domain.yml
@@ -380,3 +380,217 @@
   assert:
     that:
     - not lookup_with_creds_again is changed
+
+- name: create user group with DN lookup and creds - check mode
+  microsoft.ad.user:
+    name: ChildUser1
+    path: '{{ child_ou }}'
+    state: present
+    password: '{{ domain_password }}'
+    update_password: when_changed
+    domain_credentials:
+    - name: '{{ domain_realm }}'
+      username: '{{ domain_user_upn }}'
+      password: '{{ domain_password }}'
+    groups:
+      add:
+      - Group-CHILD
+      - name: Group-PARENT
+        server: '{{ domain_realm }}'
+  register: new_user_with_group_check
+  delegate_to: CHILD
+  check_mode: true
+
+- name: get result of create user group with DN lookup and creds - check mode
+  microsoft.ad.object_info:
+    identity: '{{ new_user_with_group_check.distinguished_name }}'
+    properties:
+    - memberOf
+  register: new_user_with_group_check_actual
+  delegate_to: CHILD
+
+- name: assert set value with DN lookup and creds
+  assert:
+    that:
+    - new_user_with_group_check is changed
+    - new_user_with_group_check.distinguished_name == "CN=ChildUser1," ~ child_ou
+    - new_user_with_group_check_actual.objects == []
+
+- name: create user group with DN lookup and creds
+  microsoft.ad.user:
+    name: ChildUser1
+    path: '{{ child_ou }}'
+    state: present
+    password: '{{ domain_password }}'
+    update_password: when_changed
+    domain_credentials:
+    - name: '{{ domain_realm }}'
+      username: '{{ domain_user_upn }}'
+      password: '{{ domain_password }}'
+    groups:
+      add:
+      - Group-CHILD
+      - name: Group-PARENT
+        server: '{{ domain_realm }}'
+  register: new_user_with_group
+  delegate_to: CHILD
+
+- name: replicate group membership of parent group to child domain after adding group
+  ansible.windows.win_command: >-
+    repadmin.exe
+    /replsingleobj
+    {{ hostvars["CHILD"]["new_hostname"] }}.{{ hostvars["CHILD"]["child_domain_name"] }}
+    parent.{{ domain_realm }}
+    {{ parent_group }}
+  delegate_to: CHILD
+
+- name: get result of create user group with DN lookup and creds
+  microsoft.ad.object_info:
+    identity: '{{ new_user_with_group.distinguished_name }}'
+    properties:
+    - memberOf
+  register: new_user_with_group_actual
+  delegate_to: CHILD
+
+- name: assert create user group with DN lookup and creds
+  assert:
+    that:
+    - new_user_with_group is changed
+    - new_user_with_group.distinguished_name == "CN=ChildUser1," ~ child_ou
+    - new_user_with_group_actual.objects | count == 1
+    - new_user_with_group_actual.objects[0].DistinguishedName == new_user_with_group.distinguished_name
+    - >-
+      "CN=Group-CHILD," ~ child_ou in new_user_with_group_actual.objects[0].memberOf
+    - >-
+      "CN=Group-PARENT," ~ parent_ou in new_user_with_group_actual.objects[0].memberOf
+
+- name: create user group with DN lookup and creds - idempotent
+  microsoft.ad.user:
+    name: ChildUser1
+    path: '{{ child_ou }}'
+    state: present
+    password: '{{ domain_password }}'
+    update_password: when_changed
+    domain_credentials:
+    - name: '{{ domain_realm }}'
+      username: '{{ domain_user_upn }}'
+      password: '{{ domain_password }}'
+    groups:
+      add:
+      - Group-CHILD
+      - name: Group-PARENT
+        server: '{{ domain_realm }}'
+  register: new_user_with_group_again
+  delegate_to: CHILD
+
+- name: assert create user group with DN lookup and creds - idempotent
+  assert:
+    that:
+    - not new_user_with_group_again is changed
+
+- name: remove user group with DN lookup and creds - check mode
+  microsoft.ad.user:
+    name: ChildUser1
+    path: '{{ child_ou }}'
+    state: present
+    password: '{{ domain_password }}'
+    update_password: when_changed
+    domain_credentials:
+    - name: '{{ domain_realm }}'
+      username: '{{ domain_user_upn }}'
+      password: '{{ domain_password }}'
+    groups:
+      remove:
+      - Group-CHILD
+      - name: Group-PARENT
+        server: '{{ domain_realm }}'
+  register: remove_user_with_group_check
+  delegate_to: CHILD
+  check_mode: true
+
+- name: get result of remove user group with DN lookup and creds - check mode
+  microsoft.ad.object_info:
+    identity: '{{ remove_user_with_group_check.distinguished_name }}'
+    properties:
+    - memberOf
+  register: remove_user_with_group_check_actual
+  delegate_to: CHILD
+
+- name: assert remove user group with DN lookup and creds - check mode
+  assert:
+    that:
+    - remove_user_with_group_check is changed
+    - remove_user_with_group_check.distinguished_name == "CN=ChildUser1," ~ child_ou
+    - >-
+      "CN=Group-CHILD," ~ child_ou in remove_user_with_group_check_actual.objects[0].memberOf
+    - >-
+      "CN=Group-PARENT," ~ parent_ou in remove_user_with_group_check_actual.objects[0].memberOf
+
+- name: remove user group with DN lookup and creds
+  microsoft.ad.user:
+    name: ChildUser1
+    path: '{{ child_ou }}'
+    state: present
+    password: '{{ domain_password }}'
+    update_password: when_changed
+    domain_credentials:
+    - name: '{{ domain_realm }}'
+      username: '{{ domain_user_upn }}'
+      password: '{{ domain_password }}'
+    groups:
+      remove:
+      - Group-CHILD
+      - name: Group-PARENT
+        server: '{{ domain_realm }}'
+  register: remove_user_with_group
+  delegate_to: CHILD
+
+- name: replicate group membership of parent group to child domain after removing group
+  ansible.windows.win_command: >-
+    repadmin.exe
+    /replsingleobj
+    {{ hostvars["CHILD"]["new_hostname"] }}.{{ hostvars["CHILD"]["child_domain_name"] }}
+    parent.{{ domain_realm }}
+    {{ parent_group }}
+  delegate_to: CHILD
+
+- name: get result of remove user group with DN lookup and creds
+  microsoft.ad.object_info:
+    identity: '{{ remove_user_with_group.distinguished_name }}'
+    properties:
+    - memberOf
+  register: remove_user_with_group_actual
+  delegate_to: CHILD
+
+- name: assert remove user group with DN lookup and creds
+  assert:
+    that:
+    - remove_user_with_group is changed
+    - remove_user_with_group.distinguished_name == "CN=ChildUser1," ~ child_ou
+    - remove_user_with_group_actual.objects | count == 1
+    - remove_user_with_group_actual.objects[0].DistinguishedName == new_user_with_group.distinguished_name
+    - remove_user_with_group_actual.objects[0].memberOf == None
+
+- name: remove user group with DN lookup and creds - idempotent
+  microsoft.ad.user:
+    name: ChildUser1
+    path: '{{ child_ou }}'
+    state: present
+    password: '{{ domain_password }}'
+    update_password: when_changed
+    domain_credentials:
+    - name: '{{ domain_realm }}'
+      username: '{{ domain_user_upn }}'
+      password: '{{ domain_password }}'
+    groups:
+      remove:
+      - Group-CHILD
+      - name: Group-PARENT
+        server: '{{ domain_realm }}'
+  register: remove_user_with_group_again
+  delegate_to: CHILD
+
+- name: assert remove user group with DN lookup and creds - idempotent
+  assert:
+    that:
+    - not remove_user_with_group_again is changed

--- a/tests/integration/targets/user/tasks/tests.yml
+++ b/tests/integration/targets/user/tasks/tests.yml
@@ -1098,7 +1098,8 @@
       - Invalid
   register: fail_missing_group
   failed_when:
-  - '"Failed to locate group Invalid: Cannot find an object with identity" not in fail_missing_group.msg'
+  - >-
+    "Failed to find the AD object DNs for groups.add. Invalid identities: 'Invalid'" not in fail_missing_group.msg
 
 - name: warn on group that is missing
   user:
@@ -1107,7 +1108,7 @@
     groups:
       add:
       - Invalid
-      missing_behaviour: warn
+      lookup_failure_action: warn
   register: warn_missing_group
 
 - name: assert warn on group that is missing
@@ -1115,7 +1116,8 @@
     that:
     - not warn_missing_group is changed
     - warn_missing_group.warnings | length == 1
-    - '"Failed to locate group Invalid but continuing on" in warn_missing_group.warnings[0]'
+    - >-
+      "Failed to find the AD object DNs for groups.add. Ignoring invalid identities: 'Invalid'" in warn_missing_group.warnings[0]
 
 - name: ignore on group that is missing
   user:
@@ -1123,7 +1125,7 @@
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
       add:
-      - Invalid
+      - name: Invalid
       missing_behaviour: ignore
   register: ignore_missing_group
 
@@ -1139,7 +1141,7 @@
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
     groups:
       remove:
-      - domain admins
+      - name: domain admins
       - Enterprise Admins
   register: groups_remove
 


### PR DESCRIPTION
##### SUMMARY
Adds the same DN lookup logic to the microsoft.ad.user groups option. This allows the caller to add/remove/set the user's group membership to groups that are in a different domain. This change also aligns renames the missing_behaviour option to lookup_failure_action to be consistent with the other lookup DN options. THe missing_behaviour option is still present as an alias for backwards compatibility.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad.user