### PR TITLE
Raise minimum supported Ansible version to 2.15

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -120,20 +120,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-  - stage: Ansible_2_14
-    displayName: Ansible 2.14
-    dependsOn:
-      - Dependencies
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: "{0}"
-          testFormat: "2.14/{0}"
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
   - stage: Windows
     displayName: Windows
     dependsOn:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `microsoft.ad` collection includes the plugins supported by Ansible to help 
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.14**.
+This collection has been tested against following Ansible versions: **>=2.15**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/ansible-version.yml
+++ b/changelogs/fragments/ansible-version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Set minimum supported Ansible version to 2.15 to align with the versions still supported by Ansible.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: microsoft
 name: ad
-version: 1.6.0
+version: 1.7.0
 readme: README.md
 authors:
   - Jordan Borean @jborean93

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.14'
+requires_ansible: '>=2.15'
 action_groups:
   domain:
     - computer

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,0 @@
-plugins/action/domain_child.py action-plugin-docs # ansible-test is ignoring sidecar docs


### PR DESCRIPTION
##### SUMMARY
Ansible 2.14 is EOL so the new minimum is 2.15.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad