### PR TITLE
membership - Added domain_server option

### DIFF
--- a/changelogs/fragments/membership-server.yml
+++ b/changelogs/fragments/membership-server.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    microsoft.ad.membership - Added ``domain_server`` option to specify the DC to use for domain join operations -
+    https://github.com/ansible-collections/microsoft.ad/issues/131#issuecomment-2201151651

--- a/plugins/modules/membership.ps1
+++ b/plugins/modules/membership.ps1
@@ -20,6 +20,9 @@ $spec = @{
         domain_ou_path = @{
             type = 'str'
         }
+        domain_server = @{
+            type = 'str'
+        }
         hostname = @{
             type = 'str'
         }
@@ -69,6 +72,7 @@ $domainCredential = if ($module.Params.domain_admin_user) {
     )
 }
 $domainOUPath = $module.Params.domain_ou_path
+$domainServer = $module.Params.domain_server
 $hostname = $module.Params.hostname
 $state = $module.Params.state
 $workgroupName = $module.Params.workgroup_name
@@ -205,6 +209,9 @@ if ($state -eq 'domain') {
             }
             if ($domainOUPath) {
                 $joinParams.OUPath = $domainOUPath
+            }
+            if ($domainServer) {
+                $joinParams.Server = $domainServer
             }
 
             try {

--- a/plugins/modules/membership.py
+++ b/plugins/modules/membership.py
@@ -32,6 +32,11 @@ options:
     - This is only used when adding the target host to a domain, if it is already a member then it is ignored.
     - This cannot be set when I(offline_join_blob) is specified.
     type: str
+  domain_server:
+    description:
+    - Specifies the domain controller to use when joining the domain.
+    type: str
+    version_added: 1.7.0
   hostname:
     description:
     - The desired hostname for the Windows host.


### PR DESCRIPTION
##### SUMMARY
Added the option domain_server to the microsoft.ad.membership module. This option allows the caller to specify the domain controller to use for domain join operations rather than have Windows lookup the DC for the domain specified.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/131#issuecomment-2201151651

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad.membership