### PR TITLE
group - Fix setting members on builtin group

### DIFF
--- a/changelogs/fragments/130-group-member.yml
+++ b/changelogs/fragments/130-group-member.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    microsoft.ad.group - Fix setting group members of Builtin groups of a domain controller -
+    https://github.com/ansible-collections/microsoft.ad/issues/130

--- a/plugins/modules/group.ps1
+++ b/plugins/modules/group.ps1
@@ -34,6 +34,11 @@ $setParams = @{
             Attribute = 'member'
             DNLookup = $true
             IsRawAttribute = $true
+            # If the group is part of the CN=Builtin groups, it cannot
+            # use -Replace. This ensures it always uses -Add/-Remove when
+            # setting a changed value to handle this.
+            # https://github.com/ansible-collections/microsoft.ad/issues/130
+            SupportsReplace = $false
         }
         [PSCustomObject]@{
             Name = 'sam_account_name'

--- a/tests/integration/targets/group/tasks/tests.yml
+++ b/tests/integration/targets/group/tasks/tests.yml
@@ -67,6 +67,50 @@
     that:
     - not create_group_again is changed
 
+- name: add member to builtin group
+  group:
+    name: Administrators
+    path: CN=Builtin,{{ setup_domain_info.output[0].defaultNamingContext }}
+    members:
+      add:
+      - '{{ create_group.distinguished_name }}'
+  register: add_member_to_builtin
+
+- name: get result of add member to builtin group
+  object_info:
+    identity: '{{ add_member_to_builtin.object_guid }}'
+    properties:
+    - member
+  register: add_member_to_builtin_actual
+
+- name: assert add member to builtin group
+  assert:
+    that:
+    - add_member_to_builtin is changed
+    - create_group.distinguished_name in add_member_to_builtin_actual.objects[0].member
+
+- name: remove member on builtin group
+  group:
+    name: Administrators
+    path: CN=Builtin,{{ setup_domain_info.output[0].defaultNamingContext }}
+    members:
+      remove:
+      - '{{ create_group.distinguished_name }}'
+  register: remove_member_from_builtin
+
+- name: get result of add member to builtin group
+  object_info:
+    identity: '{{ add_member_to_builtin.object_guid }}'
+    properties:
+    - member
+  register: remove_member_from_builtin_actual
+
+- name: assert remove member to builtin group
+  assert:
+    that:
+    - remove_member_from_builtin is changed
+    - create_group.distinguished_name not in remove_member_from_builtin_actual.objects[0].member
+
 - name: create ou to store group members
   ou:
     name: MyOU


### PR DESCRIPTION
##### SUMMARY
Implement fix for when trying to set group members on a group that is Builtin to the domain controller. This reverts the logic back to how it was before v1.6.0 so that setting these members continues to work.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/130

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
microsoft.ad.group