### PR TITLE
Added microsoft.ad.service account module

### DIFF
--- a/plugins/module_utils/_ADObject.psm1
+++ b/plugins/module_utils/_ADObject.psm1
@@ -758,7 +758,11 @@ Function Get-AnsibleADObject {
     # typically ends with $ we want to try again with the $ append to the
     # filter.
     # https://github.com/ansible-collections/microsoft.ad/issues/124
-    if (-not $obj -and $tryDollarFallback -and $GetCommand.Name -in @('Get-ADComputer')) {
+    $dollarCommands = @(
+        'Get-ADComputer'
+        'Get-ADServiceAccount'
+    )
+    if (-not $obj -and $tryDollarFallback -and $GetCommand.Name -in $dollarCommands) {
         $getParams.LDAPFilter = $getParams.LDAPFilter.Substring(0, $getParams.LDAPFilter.Length - 1) + '$)'
         $obj = & $GetCommand @getParams | Select-Object -First 1
     }
@@ -986,6 +990,9 @@ Function Invoke-AnsibleADObject {
                 $option = @{
                     type = 'dict'
                     options = @{}
+                }
+                if ($optionElement.ContainsKey('no_log')) {
+                    $option.no_log = $optionElement.no_log
                 }
 
                 if ($propInfo.DNLookup) {

--- a/plugins/modules/service_account.ps1
+++ b/plugins/modules/service_account.ps1
@@ -1,0 +1,234 @@
+#!powershell
+
+# Copyright: (c) 2024, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ..module_utils._ADObject
+
+$setParams = @{
+    PropertyInfo = @(
+        [PSCustomObject]@{
+            Name = 'allowed_to_retrieve_password'
+            Option = @{
+                # The values aren't password, will satisfy sanity tests
+                no_log = $false
+                type = 'add_remove_set'
+            }
+            Attribute = 'PrincipalsAllowedToRetrieveManagedPassword'
+            DNLookup = $true
+        }
+        [PSCustomObject]@{
+            Name = 'delegates'
+            Option = @{
+                aliases = 'principals_allowed_to_delegate'
+                type = 'add_remove_set'
+            }
+            Attribute = 'PrincipalsAllowedToDelegateToAccount'
+            DNLookup = $true
+        }
+        [PSCustomObject]@{
+            Name = 'dns_hostname'
+            Option = @{ type = 'str' }
+            Attribute = 'DNSHostName'
+        }
+        [PSCustomObject]@{
+            Name = 'do_not_append_dollar_to_sam'
+            Option = @{
+                default = $false
+                type = 'bool'
+            }
+        }
+        [PSCustomObject]@{
+            Name = 'enabled'
+            Option = @{ type = 'bool' }
+            Attribute = 'Enabled'
+        }
+        [PSCustomObject]@{
+            Name = 'kerberos_encryption_types'
+            Option = @{
+                type = 'add_remove_set'
+                choices = 'aes128', 'aes256', 'des', 'rc4'
+            }
+            Attribute = 'KerberosEncryptionType'
+            CaseInsensitive = $true
+
+            New = {
+                param($Module, $ADParams, $NewParams)
+
+                $encTypes = @(
+                    $Module.Params.kerberos_encryption_types.add
+                    $Module.Params.kerberos_encryption_types.set
+                ) | Select-Object -Unique
+
+                $NewParams.KerberosEncryptionType = $encTypes
+                $Module.Diff.after.kerberos_encryption_types = $MencTypes
+            }
+            Set = {
+                param($Module, $ADParams, $SetParams, $ADObject)
+
+                # This is an enum value and needs custom handling for things like
+                # unsetting the values with none.
+                $rawValue = $ADObject.KerberosEncryptionType.Value
+
+                $existing = foreach ($v in [System.Enum]::GetValues($rawValue.GetType())) {
+                    if ($rawValue -band $v) { $v.ToString() }
+                }
+                if ($existing -eq 'None') {
+                    $existing = @()
+                }
+                $module.Diff.before.kerberos_encryption_types = $existing
+
+                $desired = $Module.Params.kerberos_encryption_types
+                $compareParams = @{
+                    Existing = $existing
+                    CaseInsensitive = $true
+                }
+                $res = Compare-AnsibleADIdempotentList @compareParams @desired
+                if ($res.Changed) {
+                    if ($res.Value) {
+                        $SetParams.KerberosEncryptionType = $res.Value -join ', '
+                    }
+                    else {
+                        $SetParams.KerberosEncryptionType = 'None'
+                    }
+                }
+                $module.Diff.after.kerberos_encryption_types = $res.Value
+            }
+        }
+        [PSCustomObject]@{
+            Name = 'outbound_auth_only'
+            Option = @{
+                default = $false
+                type = 'bool'
+            }
+        }
+        [PSCustomObject]@{
+            Name = 'sam_account_name'
+            Option = @{ type = 'str' }
+            Attribute = 'sAMAccountName'
+            # New handling is done in PostAction as New-ADServiceAccount cannot
+            # set a SAM without the $ suffix.
+            Set = {
+                param($Module, $ADParams, $SetParams, $ADObject)
+
+                # Using the -SAMAccountName parameter will automatically append
+                # '$' to the value. We want to set the provided user value
+                # which may not have the suffix so we use the raw attribute
+                # replacement method.
+                $sam = $Module.Params.sam_account_name
+                if ($sam -ne $ADObject.SAMAccountName) {
+                    if (-not $SetParams.ContainsKey('Replace')) {
+                        $SetParams['Replace'] = @{}
+                    }
+                    $SetParams.Replace['sAMAccountName'] = $sam
+                }
+
+                $module.Diff.after.sam_account_name = $sam
+            }
+        }
+        [PSCustomObject]@{
+            Name = 'spn'
+            Option = @{
+                aliases = 'spns'
+                type = 'add_remove_set'
+            }
+            Attribute = 'servicePrincipalName'
+            CaseInsensitive = $true
+            IsRawAttribute = $true
+        }
+        [PSCustomObject]@{
+            Name = 'trusted_for_delegation'
+            Option = @{ type = 'bool' }
+            Attribute = 'TrustedForDelegation'
+        }
+        [PSCustomObject]@{
+            Name = 'upn'
+            Option = @{ type = 'str' }
+            Attribute = 'userPrincipalName'
+            IsRawAttribute = $true
+        }
+    )
+    ModuleNoun = 'ADServiceAccount'
+    DefaultPath = {
+        param($Module, $ADParams)
+
+        $GUID_MANAGED_SERVICE_ACCOUNTS_CONTAINER_W = '1EB93889E40C45DF9F0C64D23BBB6237'
+        $defaultNamingContext = (Get-ADRootDSE @ADParams -Properties defaultNamingContext).defaultNamingContext
+
+        Get-ADObject @ADParams -Identity $defaultNamingContext -Properties otherWellKnownObjects |
+            Select-Object -ExpandProperty otherWellKnownObjects |
+            Where-Object { $_.StartsWith("B:32:$($GUID_MANAGED_SERVICE_ACCOUNTS_CONTAINER_W):") } |
+            ForEach-Object Substring 38
+    }
+    PreAction = {
+        param ($Module, $ADParams, $ADObject)
+
+        if ($Module.Params.outbound_auth_only) {
+            if ($Module.Params.dns_hostname) {
+                $Module.FailJson("dns_hostname can not be set when outbound_auth_only=true.")
+            }
+            elseif (-not $ADObject) {
+                # -RestrictToOutboundAuthenticationOnly is used in a parameter
+                # set where we cannot set
+                # PrincipalsAllowedToRetrieveManagedPassword. If
+                # outbound_auth_only is set, we use a temp value and unset it
+                # in the post action to simplify our code.
+                $Module.Params.dns_hostname = [Guid]::NewGuid().ToString()
+            }
+        }
+        elseif (
+            $module.Params.state -eq 'present' -and
+            -not $ADObject -and
+            -not $Module.Params.dns_hostname
+        ) {
+            $Module.FailJson('dns_hostname is required when creating a new service account.')
+        }
+
+        if (
+            $Module.Params.sam_account_name -and
+            -not $Module.Params.sam_account_name.EndsWith('$') -and
+            -not $Module.Params.do_not_append_dollar_to_sam
+        ) {
+            $Module.Params.sam_account_name = "$($Module.Params.sam_account_name)$"
+        }
+    }
+    PostAction = {
+        param($Module, $ADParams, $ADObject)
+
+        if ($ADObject) {
+            $Module.Result.sid = $ADObject.SID.Value
+
+            $setParams = @{}
+            # This should only happen when the service account was created.
+            # The code will set sam_account_name to the desired value without
+            # the '$' suffix.
+            if (
+                $Module.Params.state -eq 'present' -and
+                $Module.Params.sam_account_name -and
+                $Module.Params.do_not_append_dollar_to_sam -and
+                $Module.Params.sam_account_name -ne $ADObject.SAMAccountName
+            ) {
+                $setParams['Replace'] = @{
+                    sAMAccountName = $module.Params.sam_account_name
+                }
+            }
+            if (
+                $Module.Params.state -eq 'present' -and
+                $Module.Params.outbound_auth_only
+            ) {
+                $Module.Diff.after.Remove('dns_hostname')
+                $setParams['Clear'] = 'dnsHostName'
+            }
+
+            if ($setParams.Count) {
+                $ADObject | Set-ADServiceAccount -WhatIf:$Module.CheckMode @ADParams @setParams
+            }
+        }
+        elseif ($Module.Params.state -eq 'present') {
+            # Use dummy value for check mode when creating a new user
+            $Module.Result.sid = 'S-1-5-0000'
+        }
+    }
+}
+Invoke-AnsibleADObject @setParams

--- a/plugins/modules/service_account.yml
+++ b/plugins/modules/service_account.yml
@@ -1,0 +1,401 @@
+# Copyright: (c) 2024, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: service_account
+  short_description: Manage Active Directory service account objects
+  description:
+    - Manages Active Directory service account objects and their attributes.
+    - Currently this module only supports group managed service accounts
+      (gMSA).
+    - Before creating a gMSA, the AD environment must have created a KDS root
+      key. See
+      L(KDS Key,https://learn.microsoft.com/en-us/windows-server/security/group-managed-service-accounts/create-the-key-distribution-services-kds-root-key)
+      for more details. For the key to be effective immediately, set the
+      effective time for 10 hours ago and do not use the
+      C(-EffectiveImmediately) parameter. See the examples for more details.
+  version_added: 1.7.0
+  options:
+    allowed_to_retrieve_password:
+      description:
+        - The principals that are allowed to retrieve the password for the
+          service account to either add, remove, or set.
+        - Each subkey value is a list of values in the form of a
+          C(distinguishedName), C(objectGUID), C(objectSid), c(sAMAccountName),
+          or C(userPrincipalName) string or a dictionary with the I(name) and
+          optional I(server) key.
+        - This value is built into a security descriptor by the ActiveDirectory
+          cmdlet and set on the C(msDS-GroupMSAMembership) LDAP attribute.
+        - This corresponds to the C(-PrincipalsAllowedToRetrieveManagedPassword)
+          parameter on the AD cmdlets.
+        - To clear all principals, use I(set) with an empty list.
+        - See
+          R(DN Lookup Attributes,ansible_collections.microsoft.ad.docsite.guide_attributes.dn_lookup_attributes)
+          for more information on how DN lookups work.
+        - See
+          R(Setting list option values,ansible_collections.microsoft.ad.docsite.guide_list_values)
+          for more information on how to add/remove/set list options.
+      type: dict
+      suboptions:
+        add:
+          description:
+            - Adds the principals specified as principals allowed to retrieve
+              the service account password.
+            - Any existing principals not specified by I(add) will be untouched
+              unless specified by I(remove) or not in I(set).
+          type: list
+          elements: raw
+        lookup_failure_action:
+          description:
+            - Control the action to take when the lookup fails to find the DN.
+            - C(fail) will cause the task to fail.
+            - C(ignore) will ignore the value and continue.
+            - C(warn) will ignore the value and display a warning.
+          choices:
+            - fail
+            - ignore
+            - warn
+          default: fail
+          type: str
+        remove:
+          description:
+            - Removes the principals specified as principals allowed to
+              retrieve the service account password.
+            - Any existing pricipals not specified by I(remove) will be
+              untouched unless I(set) is defined.
+          type: list
+          elements: raw
+        set:
+          description:
+            - Sets the principals specified as principals allowed to retrieve
+              the service account password.
+            - This will remove any existing principals if not specified in this
+              list.
+            - Specify an empty list to remove all principals allowed to
+              delegate.
+          type: list
+          elements: raw
+    delegates:
+      description:
+        - The principal objects that the current AD object can trust for
+          delegation to either add, remove or set.
+        - This is also known as resource-based constrained delegation.
+        - Each subkey value is a list of values in the form of a
+          C(distinguishedName), C(objectGUID), C(objectSid), C(sAMAccountName),
+          or C(userPrincipalName) string or a dictionary with the I(name) and
+          optional I(server) key.
+        - This is the value set on the
+          C(msDS-AllowedToActOnBehalfOfOtherIdentity) LDAP attribute.
+        - This is a highly sensitive attribute as it allows the principals
+          specified to impersonate any account when authenticating with a
+          service running as this managed account.
+        - To clear all principals, use I(set) with an empty list.
+        - See
+          R(DN Lookup Attributes,ansible_collections.microsoft.ad.docsite.guide_attributes.dn_lookup_attributes)
+          for more information on how DN lookups work.
+        - See
+          R(Setting list option values,ansible_collections.microsoft.ad.docsite.guide_list_values)
+          for more information on how to add/remove/set list options.
+      aliases:
+        - principals_allowed_to_delegate
+      type: dict
+      suboptions:
+        add:
+          description:
+            - Adds the principals specified as principals allowed to delegate
+              to.
+            - Any existing principals not specified by I(add) will be untouched
+              unless specified by I(remove) or not in I(set).
+          type: list
+          elements: raw
+        lookup_failure_action:
+          description:
+            - Control the action to take when the lookup fails to find the DN.
+            - C(fail) will cause the task to fail.
+            - C(ignore) will ignore the value and continue.
+            - C(warn) will ignore the value and display a warning.
+          choices:
+            - fail
+            - ignore
+            - warn
+          default: fail
+          type: str
+        remove:
+          description:
+            - Removes the principals specified as principals allowed to
+              delegate to.
+            - Any existing pricipals not specified by I(remove) will be
+              untouched unless I(set) is defined.
+          type: list
+          elements: raw
+        set:
+          description:
+            - Sets the principals specified as principals allowed to delegate
+              to.
+            - This will remove any existing principals if not specified in this
+              list.
+            - Specify an empty list to remove all principals allowed to
+              delegate.
+          type: list
+          elements: raw
+    dns_hostname:
+      description:
+        - Specifies the DNS name of the service account.
+        - This is the value set on the C(dNSHostName) LDAP attribute.
+        - This cannot be set when C(outbound_auth_only=True), otherwise it
+          must be defined.
+      type: str
+    do_not_append_dollar_to_sam:
+      description:
+        - Do not automatically append C($) to the I(sam_account_name) value.
+        - This only applies when I(sam_account_name) is explicitly set and can
+          be used to create a service account without the C($) suffix.
+      default: false
+      type: bool
+    enabled:
+      description:
+        - C(yes) will enable the service account.
+        - C(no) will disable the service account.
+      type: bool
+    kerberos_encryption_types:
+      description:
+        - Specifies the Kerberos encryption types supported the AD service
+          account.
+        - This is the value set on the C(msDS-SupportedEncryptionTypes) LDAP
+          attribute.
+        - Avoid using C(rc4) or C(des) as they are older an insecure encryption
+          protocols.
+        - To clear all encryption types, use I(set) with an empty list.
+        - See R(Setting list option values,ansible_collections.microsoft.ad.docsite.guide_list_values)
+          for more information on how to add/remove/set list options.
+      type: dict
+      suboptions:
+        add:
+          description:
+            - The encryption types to add to the existing set.
+            - Any existing encryption types not specified by I(add) will be
+              untouched unless specified by I(remove) or not in I(set).
+          choices:
+            - aes128
+            - aes256
+            - des
+            - rc4
+          type: list
+          elements: str
+        remove:
+          description:
+            - The encryption types to remove from the existing set.
+            - Any existing encryption types not specified by I(remove) will be
+              untouched unless I(set) is defined.
+          choices:
+            - aes128
+            - aes256
+            - des
+            - rc4
+          type: list
+          elements: str
+        set:
+          description:
+            - The encryption types to set as the only encryption types allowed
+              by the AD service account.
+            - This will remove any existing encryption types if not specified
+              in this list.
+            - Specify an empty list to remove all encryption types.
+          choices:
+            - aes128
+            - aes256
+            - des
+            - rc4
+          type: list
+          elements: str
+    outbound_auth_only:
+      description:
+        - Marks the service account for use with client outbound authentication
+          only.
+        - When set the service account can only be used for client roles only.
+          For example it can only be used for outbound authentication attempts
+          and cannot be used as a target authentication service principal.
+        - If set then I(dns_hostname) cannot be set.
+      default: false
+      type: bool
+    sam_account_name:
+      description:
+        - The C(sAMAccountName) value to set for the service account.
+        - It has a maximum of 256 characters, 15 is advised for older operating
+          systems compatibility.
+        - If ommitted the value is the same as C(name$) when the service
+          account is created.
+        - Note that service account C(sAMAccountName) values typically end with
+          a C($).
+        - By default if the C($) suffix is omitted, it will be added to the
+          end. If I(do_not_append_dollar_to_sam=True) then the provided value
+          will be used as is without adding C($) to the end.
+      type: str
+    spn:
+      description:
+        - Specifies the service principal name(s) for the account to add,
+          remove or set.
+        - This is the value set on the C(servicePrincipalName) LDAP attribute.
+        - To clear all service principal names, use I(set) with an empty list.
+        - See
+          R(Setting list option values,ansible_collections.microsoft.ad.docsite.guide_list_values)
+          for more information on how to add/remove/set list options.
+      aliases:
+        - spns
+      type: dict
+      suboptions:
+        add:
+          description:
+            - The SPNs to add to C(servicePrincipalName).
+          type: list
+          elements: str
+        remove:
+          description:
+            - The SPNs to remove from C(servicePrincipalName).
+          type: list
+          elements: str
+        set:
+          description:
+            - The SPNs to set as the only values in C(servicePrincipalName).
+            - This will clear out any existing SPNs if not in the specified
+              list.
+            - Set to an empty list to clear all SPNs on the AD object.
+          type: list
+          elements: str
+    trusted_for_delegation:
+      description:
+        - Specifies whether an account is trusted for Kerberos delegation.
+        - This is also known as unconstrained Kerberos delegation.
+        - This sets the C(ADS_UF_TRUSTED_FOR_DELEGATION) flag in the
+          C(userAccountControl) LDAP attribute.
+      type: bool
+    upn:
+      description:
+        - Configures the User Principal Name (UPN) for the account.
+        - The format is C(<username>@<domain>).
+        - This is the value set on the C(userPrincipalName) LDAP attribute.
+      type: str
+  notes:
+    - This module must be run on a Windows target host with the
+      C(ActiveDirectory) module installed.
+    - When matching by I(identity) with a C(sAMAccountName) value, the value
+      should endd with C($). If the provided value does not end with C($) the
+      module will still attempt to find the service account with the provided
+      value before attempting a fallback lookup with C($) appended to the end.
+  extends_documentation_fragment:
+    - microsoft.ad.ad_object
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms:
+        - windows
+  seealso:
+    - module: microsoft.ad.object_info
+    - module: microsoft.ad.object
+  author:
+    - Jordan Borean (@jborean93)
+
+EXAMPLES: |
+  # A gMSA requires a KDS root key to be created. This key must be valid for
+  # 10 hours before it can be used. This example creates the key and sets the
+  # time for 10 hours ago to let it be used immediately. If your environment
+  # uses multiple DCs you will still need to wait 10 hours for replication to
+  # occur or target the DC you created the key on. Required Domain Admin or
+  # Enterprise Admin privileges.
+  - name: Create KDS root key if not present
+    ansible.windows.win_powershell:
+      error_action: stop
+      script: |
+        $Ansible.Changed = $false
+        if (-not (Get-KdsRootKey)) {
+            Add-KdsRootKey -EffectiveTime ((Get-Date).AddHours(-10))
+            $Ansible.Changed = $true
+        }
+
+  - name: Create gMSA that allows Domain Admins to use
+    microsoft.ad.service_account:
+      identity: MyGMSA
+      dns_hostname: MyGMSA.my_org.local
+      description: GMSA for Domin Admins
+      state: present
+      allowed_to_retrieve_password:
+        set:
+          - Domain Admins
+
+  - name: create gMSA that allows the ITFarmHosts computer account to retrieve the pass
+    microsoft.ad.service_account:
+      identity: ITFarm1
+      dns_hostname: ITFarm1.contoso.com
+      allowed_to_retrieve_password:
+        set:
+          - ITFarmHosts$
+      kerberos_encryption_types:
+        set:
+          - aes128
+          - aes256
+      spn:
+        add:
+          - http/ITFarm1.contoso.com/contoso.com
+          - http/ITFarm1.contoso.com/contoso
+          - http/ITFarm1.contoso.com
+          - http/ITFarm1.contoso
+
+  - name: Remove gMSA by identity
+    microsoft.ad.service_account:
+      identity: ITFarm1$
+      state: absent
+
+  - name: Add SPNs to service account
+    microsoft.ad.service_account:
+      identity: MySA$
+      spn:
+        add:
+          - HOST/MySA
+          - HOST/MySA.domain.test
+          - HOST/MySA.domain.test:1234
+
+  - name: Remove SPNs on the service account
+    microsoft.ad.service_account:
+      identity: MySA$
+      spn:
+        remove:
+          - HOST/MySA
+          - HOST/MySA.domain.test
+          - HOST/MySA.domain.test:1234
+
+  - name: Add gMSA with sAMAccountName without $ suffix
+    microsoft.ad.service_account:
+      identity: MySA
+      dns_hostname: MySA.contoso.com
+      sam_account_name: MySA
+      do_not_append_dollar_to_sam: true
+
+RETURNS:
+  object_guid:
+    description:
+      - The C(objectGUID) of the AD object that was created, removed, or
+        edited.
+      - If a new object was created in check mode, a GUID of 0s will be
+        returned.
+    returned: always
+    type: str
+    sample: d84a141f-2b99-4f08-9da0-ed2d26864ba1
+  distinguished_name:
+    description:
+      - The C(distinguishedName) of the AD object that was created, removed,
+        or edited.
+    returned: always
+    type: str
+    sample: CN=act,CN=Managed Service Accounts,DC=domain,DC=test
+  sid:
+    description:
+      - The Security Identifier (SID) of the account managed.
+      - If a new serivce account was created in check mode, the SID will be
+        C(S-1-5-0000).
+    returned: always
+    type: str
+    sample: S-1-5-21-4151808797-3430561092-2843464588-1104

--- a/tests/integration/targets/service_account/aliases
+++ b/tests/integration/targets/service_account/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/service_account/meta/main.yml
+++ b/tests/integration/targets/service_account/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_domain

--- a/tests/integration/targets/service_account/tasks/main.yml
+++ b/tests/integration/targets/service_account/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: remove temp service account
+  service_account:
+    name: MySA
+    state: absent
+
+- name: create KDS root key if not present
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $Ansible.Changed = $false
+      if (-not (Get-KdsRootKey)) {
+          Add-KdsRootKey -EffectiveTime ((Get-Date).AddHours(-10))
+          $Ansible.Changed = $true
+      }
+  become: true
+  become_method: runas
+  become_user: SYSTEM
+
+- block:
+  - import_tasks: tests.yml
+
+  always:
+  - name: remove temp service account
+    service_account:
+      name: MySA
+      identity: '{{ object_identity | default(omit) }}'
+      state: absent

--- a/tests/integration/targets/service_account/tasks/tests.yml
+++ b/tests/integration/targets/service_account/tasks/tests.yml
@@ -1,0 +1,752 @@
+- name: expect failure if dns_hostname is not set for state=present
+  service_account:
+    name: MySA
+    state: present
+  register: fail_no_dns
+  failed_when: >-
+    fail_no_dns.msg != 'dns_hostname is required when creating a new service account.'
+
+- name: expect failure if dns_hostname and outbound_auth_only is set
+  service_account:
+    name: MySA
+    dns_hostname: DNSName
+    outbound_auth_only: true
+  register: fail_dns_outbound
+  failed_when: >-
+    fail_dns_outbound.msg != 'dns_hostname can not be set when outbound_auth_only=true.'
+
+- name: create sa - check
+  service_account:
+    name: MySA
+    dns_hostname: DNSName
+    state: present
+  register: create_sa_check
+  check_mode: true
+
+- name: get result of create sa - check
+  object_info:
+    identity: '{{ create_sa_check.distinguished_name }}'
+  register: create_sa_check_actual
+
+- name: assert create sa - check
+  assert:
+    that:
+    - create_sa_check is changed
+    - create_sa_check.distinguished_name == 'CN=MySA,CN=Managed Service Accounts,' ~ setup_domain_info.output[0].defaultNamingContext
+    - create_sa_check.object_guid == '00000000-0000-0000-0000-000000000000'
+    - create_sa_check.sid == 'S-1-5-0000'
+    - create_sa_check_actual.objects == []
+
+- name: create sa
+  service_account:
+    name: MySA
+    dns_hostname: DNSName
+    state: present
+  register: create_sa
+
+- set_fact:
+    object_identity: '{{ create_sa.object_guid }}'
+
+- name: get result of create sa
+  object_info:
+    identity: '{{ object_identity }}'
+    properties:
+    - dnsHostName
+    - objectSid
+    - sAMAccountName
+    - userAccountControl
+  register: create_sa_actual
+
+- name: assert create sa
+  assert:
+    that:
+    - create_sa is changed
+    - create_sa_actual.objects | length == 1
+    - create_sa.distinguished_name == 'CN=MySA,CN=Managed Service Accounts,' ~ setup_domain_info.output[0].defaultNamingContext
+    - create_sa.object_guid == create_sa_actual.objects[0].ObjectGUID
+    - create_sa.sid == create_sa_actual.objects[0].objectSid.Sid
+    - create_sa_actual.objects[0].DistinguishedName == create_sa.distinguished_name
+    - create_sa_actual.objects[0].Name == 'MySA'
+    - create_sa_actual.objects[0].dnsHostName == 'DNSName'
+    - create_sa_actual.objects[0].sAMAccountName == 'MySA$'
+    - create_sa_actual.objects[0].ObjectClass == 'msDS-GroupManagedServiceAccount'
+    - '"ADS_UF_ACCOUNTDISABLE" not in create_sa_actual.objects[0].userAccountControl_AnsibleFlags'
+
+- name: create sa - idempotent
+  service_account:
+    name: MySA
+    dns_hostname: DNSName
+    state: present
+  register: create_sa_again
+
+- name: assert create sa - idempotent
+  assert:
+    that:
+    - not create_sa_again is changed
+
+- name: remove sa - check
+  service_account:
+    identity: MySA
+    state: absent
+  register: remove_sa_check
+  check_mode: true
+
+- name: get result of remove sa - check
+  object_info:
+    identity: '{{ object_identity }}'
+  register: remove_sa_check_actual
+
+- name: assert remove sa - check
+  assert:
+    that:
+    - remove_sa_check is changed
+    - remove_sa_check.distinguished_name == create_sa.distinguished_name
+    - remove_sa_check.object_guid == create_sa.object_guid
+    - remove_sa_check.sid == create_sa.sid
+    - remove_sa_check_actual.objects | length == 1
+
+- name: remove sa
+  service_account:
+    identity: MySA
+    state: absent
+  register: remove_sa
+
+- name: get result of remove sa
+  object_info:
+    identity: '{{ object_identity }}'
+  register: remove_sa_actual
+
+- name: assert remove sa - check
+  assert:
+    that:
+    - remove_sa is changed
+    - remove_sa.distinguished_name == create_sa.distinguished_name
+    - remove_sa.object_guid == create_sa.object_guid
+    - remove_sa.sid == create_sa.sid
+    - remove_sa_actual.objects == []
+
+- name: remove sa - idempotent
+  service_account:
+    identity: MySA
+    state: absent
+  register: remove_sa_again
+
+- name: assert remove sa - idempotent
+  assert:
+    that:
+    - not remove_sa_again is changed
+
+- name: create test OU container
+  ou:
+    name: TestOU
+    state: present
+  register: test_ou
+
+- block:
+  - name: create sa with outbound auth only - check
+    service_account:
+      identity: MySA
+      path: '{{ test_ou.distinguished_name }}'
+      sam_account_name: OtherSA
+      allowed_to_retrieve_password:
+        set:
+        - Domain Admins
+      outbound_auth_only: true
+    register: create_sa_outbound_check
+    check_mode: true
+
+  - name: get result of create sa with outbound auth only - check
+    object_info:
+      identity: '{{ create_sa_outbound_check.distinguished_name }}'
+    register: create_sa_outbound_actual_check
+
+  - name: assert create sa with outbound auth only - check
+    assert:
+      that:
+      - create_sa_outbound_check is changed
+      - create_sa_outbound_check.distinguished_name == 'CN=MySA,' ~ test_ou.distinguished_name
+      - create_sa_outbound_actual_check.objects == []
+
+  - name: create sa with outbound auth only
+    service_account:
+      name: MySA
+      path: '{{ test_ou.distinguished_name }}'
+      sam_account_name: OtherSA
+      allowed_to_retrieve_password:
+        set:
+        - Domain Admins
+      outbound_auth_only: true
+    register: create_sa_outbound
+
+  - set_fact:
+      object_identity: '{{ create_sa_outbound.object_guid }}'
+
+  - name: get result of create sa with outbound auth only
+    ansible.windows.win_powershell:
+      parameters:
+        Identity: '{{ object_identity }}'
+        Properties:
+        - DistinguishedName
+        - Name
+        - ObjectGUID
+        - SID
+        - SamAccountName
+        - PrincipalsAllowedToRetrieveManagedPassword
+      script: |
+        param ($Identity, $Properties)
+
+        Get-ADServiceAccount -Identity $Identity -Properties $Properties |
+          Select-Object -Property $Properties
+    register: create_sa_outbound_actual
+
+  - name: assert create sa with outbound auth only
+    assert:
+      that:
+      - create_sa_outbound is changed
+      - create_sa_outbound.distinguished_name == 'CN=MySA,' ~ test_ou.distinguished_name
+      - create_sa_outbound_actual.output | length == 1
+      - create_sa_outbound_actual.output[0].DistinguishedName == create_sa_outbound.distinguished_name
+      - create_sa_outbound_actual.output[0].Name == 'MySA'
+      - create_sa_outbound_actual.output[0].ObjectGUID == create_sa_outbound.object_guid
+      - create_sa_outbound_actual.output[0].PrincipalsAllowedToRetrieveManagedPassword == ['CN=Domain Admins,CN=Users,' ~ setup_domain_info.output[0].defaultNamingContext]
+      - create_sa_outbound_actual.output[0].SID.Value == create_sa_outbound.sid
+      - create_sa_outbound_actual.output[0].SamAccountName == 'OtherSA$'
+
+  - name: create sa with outbound auth only - idempotent
+    service_account:
+      identity: OtherSA
+      path: '{{ test_ou.distinguished_name }}'
+      sam_account_name: OtherSA
+      allowed_to_retrieve_password:
+        set:
+        - name: Domain Admins
+      outbound_auth_only: true
+    register: create_sa_outbound_again
+
+  - name: assert create sa with outbound auth only - idempotent
+    assert:
+      that:
+      - not create_sa_outbound_again is changed
+
+  - name: remove sa with outbound auth only
+    service_account:
+      identity: OtherSA$
+      state: absent
+    register: remove_sa_outbound
+
+  - name: get result of remove sa with outbound auth only
+    object_info:
+      identity: '{{ object_identity }}'
+    register: remove_sa_outbound_actual
+
+  - name: assert remove sa with outbound auth only
+    assert:
+      that:
+      - remove_sa_outbound is changed
+      - remove_sa_outbound.distinguished_name == create_sa_outbound.distinguished_name
+      - remove_sa_outbound.object_guid == create_sa_outbound.object_guid
+      - remove_sa_outbound.sid == create_sa_outbound.sid
+      - remove_sa_outbound_actual.objects == []
+
+  always:
+  - name: remove test OU container
+    ou:
+      identity: '{{ test_ou.object_guid }}'
+      state: absent
+
+- name: create sa with no $ suffix - check
+  service_account:
+    name: MySA
+    dns_hostname: DNSName
+    state: present
+    sam_account_name: SATest
+    do_not_append_dollar_to_sam: true
+    kerberos_encryption_types:
+      add:
+      - aes128
+      - aes256
+  register: create_sa_no_dollar_check
+  check_mode: true
+
+- name: get result of create sa with no $ suffix - check
+  object_info:
+    identity: '{{ create_sa_no_dollar_check.distinguished_name }}'
+  register: create_sa_no_dollar_check_actual
+
+- name: create sa with no $ suffix - check
+  assert:
+    that:
+    - create_sa_no_dollar_check is changed
+    - create_sa_no_dollar_check_actual.objects == []
+
+- name: create sa with no $ suffix
+  service_account:
+    name: MySA
+    dns_hostname: DNSName
+    state: present
+    sam_account_name: SATest
+    do_not_append_dollar_to_sam: true
+    kerberos_encryption_types:
+      add:
+      - aes128
+      - aes256
+  register: create_sa_no_dollar
+
+- set_fact:
+    object_identity: '{{ create_sa_no_dollar.object_guid }}'
+
+- name: get result of create sa with no $ suffix
+  object_info:
+    identity: '{{ create_sa_no_dollar_check.distinguished_name }}'
+    properties:
+    - msDS-SupportedEncryptionTypes
+    - sAMAccountName
+  register: create_sa_no_dollar_actual
+
+- name: create sa with no $ suffix
+  assert:
+    that:
+    - create_sa_no_dollar is changed
+    - create_sa_no_dollar_actual.objects | length == 1
+    - create_sa_no_dollar_actual.objects[0].DistinguishedName == create_sa_no_dollar.distinguished_name
+    - create_sa_no_dollar_actual.objects[0]['msDS-SupportedEncryptionTypes'] == 24
+    - create_sa_no_dollar_actual.objects[0].Name == 'MySA'
+    - create_sa_no_dollar_actual.objects[0].ObjectGUID == create_sa_no_dollar.object_guid
+    - create_sa_no_dollar_actual.objects[0].sAMAccountName == 'SATest'
+
+- name: create sa with no $ suffix - idempotent
+  service_account:
+    name: MySA
+    dns_hostname: DNSName
+    state: present
+    sam_account_name: SATest
+    do_not_append_dollar_to_sam: true
+    kerberos_encryption_types:
+      add:
+      - aes128
+      - aes256
+  register: create_sa_no_dollar_again
+
+- name: assert create sa with no $ suffix - idempotent
+  assert:
+    that:
+    - not create_sa_no_dollar_again is changed
+
+- name: convert sa to outbound auth and change sAMAccountName - check
+  service_account:
+    name: MySA
+    state: present
+    kerberos_encryption_types:
+      remove:
+      - aes128
+      - des
+    sam_account_name: NewSATest
+    outbound_auth_only: true
+  register: convert_sa_outbound_check
+  check_mode: true
+
+- name: get result of convert sa to outbound auth and change sAMAccountName - check
+  object_info:
+    identity: '{{ create_sa_no_dollar_check.distinguished_name }}'
+    properties:
+    - dnsHostName
+    - msDS-SupportedEncryptionTypes
+    - sAMAccountName
+  register: convert_sa_outbound_check_actual
+
+- name: assert get result of convert sa to outbound auth and change sAMAccountName - check
+  assert:
+    that:
+    - convert_sa_outbound_check is changed
+    - convert_sa_outbound_check_actual.objects | length == 1
+    - convert_sa_outbound_check_actual.objects[0].DistinguishedName == create_sa_no_dollar.distinguished_name
+    - convert_sa_outbound_check_actual.objects[0].dnsHostName == 'DNSName'
+    - convert_sa_outbound_check_actual.objects[0]['msDS-SupportedEncryptionTypes'] == 24
+    - convert_sa_outbound_check_actual.objects[0].Name == 'MySA'
+    - convert_sa_outbound_check_actual.objects[0].ObjectGUID == create_sa_no_dollar.object_guid
+    - convert_sa_outbound_check_actual.objects[0].sAMAccountName == 'SATest'
+
+- name: convert sa to outbound auth and change sAMAccountName
+  service_account:
+    name: MySA
+    state: present
+    kerberos_encryption_types:
+      remove:
+      - aes128
+      - des
+    sam_account_name: NewSATest
+    outbound_auth_only: true
+  register: convert_sa_outbound
+
+- name: get result of convert sa to outbound auth and change sAMAccountName
+  object_info:
+    identity: '{{ create_sa_no_dollar_check.distinguished_name }}'
+    properties:
+    - dnsHostName
+    - msDS-SupportedEncryptionTypes
+    - sAMAccountName
+  register: convert_sa_outbound_actual
+
+- name: assert get result of convert sa to outbound auth and change sAMAccountName
+  assert:
+    that:
+    - convert_sa_outbound is changed
+    - convert_sa_outbound_actual.objects | length == 1
+    - convert_sa_outbound_actual.objects[0].DistinguishedName == create_sa_no_dollar.distinguished_name
+    - convert_sa_outbound_actual.objects[0].dnsHostName == None
+    - convert_sa_outbound_actual.objects[0]['msDS-SupportedEncryptionTypes'] == 16
+    - convert_sa_outbound_actual.objects[0].Name == 'MySA'
+    - convert_sa_outbound_actual.objects[0].ObjectGUID == create_sa_no_dollar.object_guid
+    - convert_sa_outbound_actual.objects[0].sAMAccountName == 'NewSATest$'
+
+- name: convert sa to outbound auth and change sAMAccountName - idempotent
+  service_account:
+    name: MySA
+    state: present
+    kerberos_encryption_types:
+      remove:
+      - aes128
+      - des
+    sam_account_name: NewSATest
+    outbound_auth_only: true
+  register: convert_sa_outbound_again
+
+- name: assert convert sa to outbound auth and change sAMAccountName - idempotent
+  assert:
+    that:
+    - not convert_sa_outbound_again is changed
+
+- name: change sa details - check
+  service_account:
+    identity: NewSATest$
+    state: present
+    allowed_to_retrieve_password:
+      add:
+      - Domain Users
+      remove:
+      - name: Domain Admins
+      - Administrators
+    enabled: false
+    kerberos_encryption_types:
+      set: []
+    spn:
+      set:
+      - HTTP/SPN
+      - HTTP/SPN2
+    trusted_for_delegation: true
+    upn: saUPN@{{ setup_domain_info.output[0].dnsHostName }}
+  register: change_sa_check
+  check_mode: true
+
+- name: get result of change sa details - check
+  ansible.windows.win_powershell:
+    parameters:
+      Identity: '{{ object_identity }}'
+      Properties:
+      - DistinguishedName
+      - DNSHostName
+      - Enabled
+      - KerberosEncryptionType
+      - Name
+      - ObjectGUID
+      - PrincipalsAllowedToRetrieveManagedPassword
+      - ServicePrincipalName
+      - SID
+      - SamAccountName
+      - TrustedForDelegation
+      - UserPrincipalName
+    script: |
+      param ($Identity, $Properties)
+
+      Get-ADServiceAccount -Identity $Identity -Properties $Properties |
+        Select-Object -Property $Properties
+  register: change_sa_check_actual
+
+- name: assert change sa details - check
+  assert:
+    that:
+    - change_sa_check is changed
+    - change_sa_check_actual.output[0].DNSHostName == None
+    - change_sa_check_actual.output[0].DistinguishedName == change_sa_check.distinguished_name
+    - change_sa_check_actual.output[0].Enabled == true
+    - change_sa_check_actual.output[0].KerberosEncryptionType == [16]
+    - change_sa_check_actual.output[0].Name == "MySA"
+    - change_sa_check_actual.output[0].ObjectGUID == object_identity
+    - change_sa_check_actual.output[0].PrincipalsAllowedToRetrieveManagedPassword == []
+    - change_sa_check_actual.output[0].SID.Value == change_sa_check.sid
+    - change_sa_check_actual.output[0].SamAccountName == "NewSATest$"
+    - change_sa_check_actual.output[0].ServicePrincipalName == []
+    - change_sa_check_actual.output[0].TrustedForDelegation == false
+    - change_sa_check_actual.output[0].UserPrincipalName == None
+
+- name: change sa details
+  service_account:
+    identity: NewSATest$
+    state: present
+    allowed_to_retrieve_password:
+      add:
+      - Domain Users
+      remove:
+      - name: Domain Admins
+      - Administrators
+    enabled: false
+    kerberos_encryption_types:
+      set: []
+    spn:
+      set:
+      - HTTP/SPN
+      - HTTP/SPN2
+    trusted_for_delegation: true
+    upn: saUPN@{{ setup_domain_info.output[0].dnsHostName }}
+  register: change_sa
+
+- name: get result of change sa details
+  ansible.windows.win_powershell:
+    parameters:
+      Identity: '{{ object_identity }}'
+      Properties:
+      - DistinguishedName
+      - DNSHostName
+      - Enabled
+      - KerberosEncryptionType
+      - Name
+      - ObjectGUID
+      - PrincipalsAllowedToRetrieveManagedPassword
+      - ServicePrincipalName
+      - SID
+      - SamAccountName
+      - TrustedForDelegation
+      - UserPrincipalName
+    script: |
+      param ($Identity, $Properties)
+
+      Get-ADServiceAccount -Identity $Identity -Properties $Properties |
+        Select-Object -Property $Properties
+  register: change_sa_actual
+
+- name: assert change sa details
+  assert:
+    that:
+    - change_sa is changed
+    - change_sa_actual.output[0].DNSHostName == None
+    - change_sa_actual.output[0].DistinguishedName == change_sa.distinguished_name
+    - change_sa_actual.output[0].Enabled == false
+    - change_sa_actual.output[0].KerberosEncryptionType == [0]
+    - change_sa_actual.output[0].Name == "MySA"
+    - change_sa_actual.output[0].ObjectGUID == object_identity
+    - change_sa_actual.output[0].PrincipalsAllowedToRetrieveManagedPassword == ["CN=Domain Users,CN=Users," ~ setup_domain_info.output[0].defaultNamingContext]
+    - change_sa_actual.output[0].SID.Value == change_sa.sid
+    - change_sa_actual.output[0].SamAccountName == "NewSATest$"
+    - change_sa_actual.output[0].ServicePrincipalName | length == 2
+    - '"HTTP/SPN" in change_sa_actual.output[0].ServicePrincipalName'
+    - '"HTTP/SPN2" in change_sa_actual.output[0].ServicePrincipalName'
+    - change_sa_actual.output[0].TrustedForDelegation == true
+    - change_sa_actual.output[0].UserPrincipalName == "saUPN@" ~ setup_domain_info.output[0].dnsHostName
+
+- name: change sa details - idempotent
+  service_account:
+    identity: NewSATest$
+    state: present
+    allowed_to_retrieve_password:
+      add:
+      - Domain Users
+      remove:
+      - name: Domain Admins
+      - Administrators
+    enabled: false
+    kerberos_encryption_types:
+      set: []
+    spn:
+      set:
+      - HTTP/SPN
+      - HTTP/SPN2
+    trusted_for_delegation: true
+    upn: saUPN@{{ setup_domain_info.output[0].dnsHostName }}
+  register: change_sa_again
+
+- name: assert change sa details - idempotent
+  assert:
+    that:
+    - not change_sa_again is changed
+
+- name: convert sa to service auth and no $ suffix - check
+  service_account:
+    name: MySA
+    state: present
+    dns_hostname: MyHostName
+    sam_account_name: MySA
+    do_not_append_dollar_to_sam: true
+    allowed_to_retrieve_password:
+      add:
+      - Domain Admins
+      remove:
+      - name: Domain Users
+      - Administrators
+    enabled: true
+    kerberos_encryption_types:
+      add:
+      - aes128
+      remove:
+      - aes256
+    spn:
+      add:
+      - HTTP/SPN
+      - HTTP/spn3
+      remove:
+      - HTTP/SPN1
+      - HTTP/SPN2
+    trusted_for_delegation: false
+    upn: otherUPN@{{ setup_domain_info.output[0].dnsHostName }}
+  register: change_sa_check
+  check_mode: true
+
+- name: get result of convert sa to service auth and no $ suffix - check
+  ansible.windows.win_powershell:
+    parameters:
+      Identity: '{{ object_identity }}'
+      Properties:
+      - DistinguishedName
+      - DNSHostName
+      - Enabled
+      - KerberosEncryptionType
+      - Name
+      - ObjectGUID
+      - PrincipalsAllowedToRetrieveManagedPassword
+      - ServicePrincipalName
+      - SID
+      - SamAccountName
+      - TrustedForDelegation
+      - UserPrincipalName
+    script: |
+      param ($Identity, $Properties)
+
+      Get-ADServiceAccount -Identity $Identity -Properties $Properties |
+        Select-Object -Property $Properties
+  register: change_sa_check_actual
+
+- name: assert convert sa to service auth and no $ suffix - check
+  assert:
+    that:
+    - change_sa_check is changed
+    - change_sa_check_actual.output[0].DNSHostName == None
+    - change_sa_check_actual.output[0].DistinguishedName == change_sa.distinguished_name
+    - change_sa_check_actual.output[0].Enabled == false
+    - change_sa_check_actual.output[0].KerberosEncryptionType == [0]
+    - change_sa_check_actual.output[0].Name == "MySA"
+    - change_sa_check_actual.output[0].ObjectGUID == object_identity
+    - change_sa_check_actual.output[0].PrincipalsAllowedToRetrieveManagedPassword == ["CN=Domain Users,CN=Users," ~ setup_domain_info.output[0].defaultNamingContext]
+    - change_sa_check_actual.output[0].SID.Value == change_sa.sid
+    - change_sa_check_actual.output[0].SamAccountName == "NewSATest$"
+    - change_sa_check_actual.output[0].ServicePrincipalName | length == 2
+    - '"HTTP/SPN" in change_sa_check_actual.output[0].ServicePrincipalName'
+    - '"HTTP/SPN2" in change_sa_check_actual.output[0].ServicePrincipalName'
+    - change_sa_check_actual.output[0].TrustedForDelegation == true
+    - change_sa_check_actual.output[0].UserPrincipalName == "saUPN@" ~ setup_domain_info.output[0].dnsHostName
+
+- name: convert sa to service auth and no $ suffix
+  service_account:
+    name: MySA
+    state: present
+    dns_hostname: MyHostName
+    sam_account_name: MySA
+    do_not_append_dollar_to_sam: true
+    allowed_to_retrieve_password:
+      add:
+      - Domain Admins
+      remove:
+      - name: Domain Users
+      - Administrators
+    enabled: true
+    kerberos_encryption_types:
+      add:
+      - aes128
+      remove:
+      - aes256
+    spn:
+      add:
+      - HTTP/SPN
+      - HTTP/spn3
+      remove:
+      - HTTP/SPN1
+      - HTTP/SPN2
+    trusted_for_delegation: false
+    upn: otherUPN@{{ setup_domain_info.output[0].dnsHostName }}
+  register: change_sa
+
+- name: get result of convert sa to service auth and no $ suffix
+  ansible.windows.win_powershell:
+    parameters:
+      Identity: '{{ object_identity }}'
+      Properties:
+      - DistinguishedName
+      - DNSHostName
+      - Enabled
+      - KerberosEncryptionType
+      - Name
+      - ObjectGUID
+      - PrincipalsAllowedToRetrieveManagedPassword
+      - ServicePrincipalName
+      - SID
+      - SamAccountName
+      - TrustedForDelegation
+      - UserPrincipalName
+    script: |
+      param ($Identity, $Properties)
+
+      Get-ADServiceAccount -Identity $Identity -Properties $Properties |
+        Select-Object -Property $Properties
+  register: change_sa_actual
+
+- name: assert convert sa to service auth and no $ suffix
+  assert:
+    that:
+    - change_sa is changed
+    - change_sa_actual.output[0].DNSHostName == 'MyHostName'
+    - change_sa_actual.output[0].DistinguishedName == change_sa.distinguished_name
+    - change_sa_actual.output[0].Enabled == true
+    - change_sa_actual.output[0].KerberosEncryptionType == [8]
+    - change_sa_actual.output[0].Name == "MySA"
+    - change_sa_actual.output[0].ObjectGUID == object_identity
+    - change_sa_actual.output[0].PrincipalsAllowedToRetrieveManagedPassword == ["CN=Domain Admins,CN=Users," ~ setup_domain_info.output[0].defaultNamingContext]
+    - change_sa_actual.output[0].SID.Value == change_sa.sid
+    - change_sa_actual.output[0].SamAccountName == "MySA"
+    - change_sa_actual.output[0].ServicePrincipalName | length == 2
+    - '"HTTP/SPN" in change_sa_actual.output[0].ServicePrincipalName'
+    - '"HTTP/spn3" in change_sa_actual.output[0].ServicePrincipalName'
+    - change_sa_actual.output[0].TrustedForDelegation == false
+    - change_sa_actual.output[0].UserPrincipalName == "otherUPN@" ~ setup_domain_info.output[0].dnsHostName
+
+- name: convert sa to service auth and no $ suffix - idempotent
+  service_account:
+    name: MySA
+    state: present
+    dns_hostname: MyHostName
+    sam_account_name: MySA
+    do_not_append_dollar_to_sam: true
+    allowed_to_retrieve_password:
+      add:
+      - Domain Admins
+      remove:
+      - name: Domain Users
+      - Administrators
+    enabled: true
+    kerberos_encryption_types:
+      add:
+      - aes128
+      remove:
+      - aes256
+    spn:
+      add:
+      - HTTP/SPN
+      - HTTP/spn3
+      remove:
+      - HTTP/SPN1
+      - HTTP/SPN2
+    trusted_for_delegation: false
+    upn: otherUPN@{{ setup_domain_info.output[0].dnsHostName }}
+  register: change_sa_again
+
+- name: assert convert sa to service auth and no $ suffix - idempotent
+  assert:
+    that:
+    - not change_sa_again is changed


### PR DESCRIPTION
##### SUMMARY
Adds the microsoft.ad.service_account module which can be used to manage service accounts like a group managed service account (gMSA). It is not possible to use the microsoft.ad.object module to achieve the same outcome as the attribute which stores what principals can retrieve the password is a SecurityDescriptor value which is not easy to craft in Ansible.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/123

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
microsoft.ad.service_account