### PR TITLE
Expand connection plugins used in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -130,9 +130,11 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}
           targets:
-            - test: 2016
-            - test: 2019
-            - test: 2022
+            - test: 2016/winrm/http
+            - test: 2019/winrm/https
+            - test: 2022/winrm/https
+            - test: 2022/psrp/https
+            - test: 2022/ssh/key
           groups:
             - 1
   - stage: Summary

--- a/tests/utils/shippable/windows.sh
+++ b/tests/utils/shippable/windows.sh
@@ -6,9 +6,11 @@ declare -a args
 IFS='/:' read -ra args <<< "$1"
 
 version="${args[1]}"
+connection="${args[2]}"
+connection_setting="${args[3]}"
 
-if [ "${#args[0]}" -gt 2 ]; then
-    target="shippable/windows/group${args[2]}/"
+if [ "${#args[0]}" -gt 4 ]; then
+    target="shippable/windows/group${args[4]}/"
 else
     target="shippable/windows/"
 fi
@@ -18,4 +20,6 @@ provider="${P:-default}"
 
 # shellcheck disable=SC2086
 ansible-test windows-integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --windows "${version}" --docker default --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"
+    --controller "docker:default" \
+    --target "remote:windows/${version},connection=${connection}+${connection_setting},provider=${provider}" \
+    --remote-terminate always --remote-stage "${stage}"


### PR DESCRIPTION
##### SUMMARY
Expands the testing matrix of the Windows connection plugins used in CI to cover all the supported connections of Windows.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
testing