### PR TITLE
Filter out MSA in the LDAP inventory plugin

### DIFF
--- a/changelogs/fragments/ldap-msa.yml
+++ b/changelogs/fragments/ldap-msa.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ldap - Filter out managed service accounts in the default LDAP filter used. The ``filter_without_computer`` can be
+    used to disable the default filter if needed.

--- a/plugins/inventory/ldap.py
+++ b/plugins/inventory/ldap.py
@@ -41,13 +41,13 @@ options:
     description:
     - The LDAP filter string used to query the computer objects.
     - By default, this will be combined with the filter
-      "(objectClass=computer)". Use I(filter_without_computer) to override
+      "(objectCategory=computer)". Use I(filter_without_computer) to override
       this behavior and have I(filter) be the only filter used.
     type: str
   filter_without_computer:
     description:
-    - Will not combine the I(filter) value with the filter
-      "(objectClass=computer)".
+    - Will not combine the I(filter) value with the default filter
+      "(objectCategory=computer)".
     - In most cases this should be C(false) but can be set to C(true) to have
       the I(filter) value specified be the only filter used.
     type: bool
@@ -293,7 +293,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "subtree": sansldap.SearchScope.SUBTREE,
         }[search_scope]
 
-        computer_filter = sansldap.FilterEquality("objectClass", b"computer")
+        computer_filter = sansldap.FilterEquality("objectCategory", b"computer")
         final_filter: sansldap.LDAPFilter
         if ldap_filter:
             ldap_filter_obj = sansldap.LDAPFilter.from_string(ldap_filter)
@@ -324,22 +324,24 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         # These options are in ../doc_fragments/ldap_connection.py
         template_fields = {
-            'auth_protocol',
-            'ca_cert',
-            'cert_validation',
-            'certificate',
-            'certificate_key',
-            'certificate_password',
-            'connection_timeout',
-            'encrypt',
-            'password',
-            'port',
-            'server',
-            'tls_mode',
-            'username',
+            "auth_protocol",
+            "ca_cert",
+            "cert_validation",
+            "certificate",
+            "certificate_key",
+            "certificate_password",
+            "connection_timeout",
+            "encrypt",
+            "password",
+            "port",
+            "server",
+            "tls_mode",
+            "username",
         }
         for option_name, option_value in connection_options.items():
-            if option_name in template_fields and self.templar.is_template(option_value):
+            if option_name in template_fields and self.templar.is_template(
+                option_value
+            ):
                 self.display.vvv(f"Templating option {option_name}")
                 connection_options[option_name] = self.templar.template(
                     variable=option_value,

--- a/tests/integration/targets/inventory_ldap/main.yml
+++ b/tests/integration/targets/inventory_ldap/main.yml
@@ -14,6 +14,19 @@
       dc_name: '{{ setup_domain_info.output[0].dnsHostName }}'
       cert_path: /tmp/microsoft.ad-{{ inventory_hostname }}
 
+  - name: create KDS root key if not present
+    ansible.windows.win_powershell:
+      error_action: stop
+      script: |
+        $Ansible.Changed = $false
+        if (-not (Get-KdsRootKey)) {
+            Add-KdsRootKey -EffectiveTime ((Get-Date).AddHours(-10))
+            $Ansible.Changed = $true
+        }
+    become: true
+    become_method: runas
+    become_user: SYSTEM
+
   - name: run tests
     import_role:
       name: test

--- a/tests/integration/targets/inventory_ldap/roles/test/tasks/main.yml
+++ b/tests/integration/targets/inventory_ldap/roles/test/tasks/main.yml
@@ -285,6 +285,9 @@
             'msDS-AllowedToDelegateTo' = 'dns 2'
         }
 
+        New-ADServiceAccount -Name MyGMSA -DNSHostName MyGMSA -Path $adParams.Path
+        New-ADServiceAccount -Name MySMSA -RestrictToSingleComputer -Path $adParams.Path
+
         Add-ADGroupMember -Identity $group1 -Members $comp1, $comp2
         Add-ADGroupMember -Identity $group2 -Members $comp1
 


### PR DESCRIPTION
##### SUMMARY
This change will filter out all managed service accounts in the default LDAP filter used with the `microsoft.ad.ldap` filter plugin. This ensures that the only objects returned as hosts are actual computer accounts and not object classes that descend from the `computer` class but are not actually computers.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
microsoft.ad.ldap