### PR TITLE
Fix debug_ldap_client doc

### DIFF
--- a/changelogs/fragments/debug-ldap-client-doc.yml
+++ b/changelogs/fragments/debug-ldap-client-doc.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    Fix ``microsoft.ad.debug_ldap_client`` documentation problem so it appears in the ``ansible-doc`` plugin list and
+    online documentation.

--- a/plugins/modules/debug_ldap_client.py
+++ b/plugins/modules/debug_ldap_client.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python
+# Copyright: (c) 2023, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# This is a stub to get the docs working, the implementation is an action plugin

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,4 +1,3 @@
-plugins/action/debug_ldap_client.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain_child.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain_controller.py action-plugin-docs # ansible-test is ignoring sidecar docs

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,3 @@
-plugins/action/debug_ldap_client.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain_child.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain_controller.py action-plugin-docs # ansible-test is ignoring sidecar docs

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,4 +1,3 @@
-plugins/action/debug_ldap_client.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain_child.py action-plugin-docs # ansible-test is ignoring sidecar docs
 plugins/action/domain_controller.py action-plugin-docs # ansible-test is ignoring sidecar docs


### PR DESCRIPTION
##### SUMMARY
Fixes `microsoft.ad.debug_ldap_client` documentation problem so that it
works with `ansible-doc` and the online plugin docs.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs