### PR TITLE
Update CI setup

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -78,6 +78,20 @@ stages:
               test: units
             - name: Lint
               test: lint
+  - stage: Ansible_2_18
+    displayName: Ansible 2.18
+    dependsOn:
+      - Dependencies
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: "{0}"
+          testFormat: "2.18/{0}"
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
   - stage: Ansible_2_17
     displayName: Ansible 2.17
     dependsOn:
@@ -146,6 +160,7 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_18
       - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15


### PR DESCRIPTION
##### SUMMARY
Updates CI to test out sanity on both 2.18 and 2.19 now that devel has been bumped to a new version. Include the new sanity ignore file for 2.19 and fix up the cert generation for the LDAPS CA certificate.

##### ISSUE TYPE
- Bugfix Pull Request