### PR TITLE
Added replication_source_dc options

### DIFF
--- a/changelogs/fragments/replication-dc.yml
+++ b/changelogs/fragments/replication-dc.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - >-
+    domain - Added ``replication_source_dc`` to specify the domain controller to use as the replication source for the
+    new domain - https://github.com/ansible-collections/microsoft.ad/issues/159
+  - >-
+    domain_controller - Added ``replication_source_dc`` to specify the domain controller to use as the replication
+    source for the new domain controller - https://github.com/ansible-collections/microsoft.ad/issues/159

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: microsoft
 name: ad
-version: 1.7.1
+version: 1.8.0
 readme: README.md
 authors:
   - Jordan Borean @jborean93

--- a/plugins/modules/domain_child.ps1
+++ b/plugins/modules/domain_child.ps1
@@ -50,6 +50,9 @@ $spec = @{
             default = 600
             type = 'int'
         }
+        replication_source_dc = @{
+            type = 'str'
+        }
         safe_mode_password = @{
             type = 'str'
             required = $true
@@ -83,6 +86,7 @@ $domainType = $module.Params.domain_type
 $installDns = $module.Params.install_dns
 $logPath = $module.Params.log_path
 $parentDomainName = $module.Params.parent_domain_name
+$replicationSourceDC = $module.Params.replication_source_dc
 $safeModePassword = $module.Params.safe_mode_password
 $siteName = $module.Params.site_name
 $sysvolPath = $module.Params.sysvol_path
@@ -168,6 +172,9 @@ if ($null -ne $installDns) {
 }
 if ($logPath) {
     $installParams.LogPath = $logPath
+}
+if ($replicationSourceDC) {
+    $installParams.ReplicationSourceDC = $replicationSourceDC
 }
 if ($siteName) {
     $installParams.SiteName = $siteName

--- a/plugins/modules/domain_child.yml
+++ b/plugins/modules/domain_child.yml
@@ -85,6 +85,12 @@ DOCUMENTATION:
           create a new domain tree in.
         - This can only be set when I(domain_type=tree).
       type: str
+    replication_source_dc:
+      description:
+        - Specifies the name of an existing domain controller in the forest that
+          will be used as the replication source for the new domain.
+      type: str
+      version_added: 1.8.0
     safe_mode_password:
       description:
         - Safe mode password for the domain controller.

--- a/plugins/modules/domain_controller.ps1
+++ b/plugins/modules/domain_controller.ps1
@@ -48,6 +48,9 @@ $spec = @{
             default = 600
             type = 'int'
         }
+        replication_source_dc = @{
+            type = 'str'
+        }
         safe_mode_password = @{
             no_log = $true
             type = 'str'
@@ -81,6 +84,7 @@ $installDns = $module.Params.install_dns
 $installMediaPath = $module.Params.install_media_path
 $logPath = $module.Params.domain_log_path
 $readOnly = $module.Params.read_only
+$replicationSourceDC = $module.Params.replication_source_dc
 $siteName = $module.Params.site_name
 $state = $module.Params.state
 $sysvolPath = $module.Params.sysvol_path
@@ -171,6 +175,9 @@ if ($state -eq 'domain_controller') {
             # while this is a switch value, if we set on $false site_name is required
             # https://github.com/ansible/ansible/issues/35858
             $installParams.ReadOnlyReplica = $true
+        }
+        if ($replicationSourceDC) {
+            $installParams.ReplicationSourceDC = $replicationSourceDC
         }
         if ($siteName) {
             $installParams.SiteName = $siteName

--- a/plugins/modules/domain_controller.yml
+++ b/plugins/modules/domain_controller.yml
@@ -66,6 +66,12 @@ DOCUMENTATION:
           existing domain.
       type: bool
       default: false
+    replication_source_dc:
+      description:
+        - Specifies the name of an existing domain controller in the forest that
+          will be used as the replication source for the new domain controller.
+      type: str
+      version_added: 1.8.0
     safe_mode_password:
       description:
         - Safe mode password for the domain controller (required when


### PR DESCRIPTION
##### SUMMARY
Adds the option `replication_source_dc` to the `microsoft.ad.domain` and `microsoft.ad.domain_controller` module that allows the caller to specify the DC used for replication when creating the domain controller.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/159

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
microsoft.ad.domain
microsoft.ad.domain_controller