### PR TITLE
[microsoft.ad.user] Add parameter to fail, ignore or warn if the account performing the action does not have the permissions required to modify the AD Group

### DIFF
--- a/changelogs/fragments/user-permissions-handling.yml
+++ b/changelogs/fragments/user-permissions-handling.yml
@@ -1,4 +1,4 @@
 minor_changes:
   - >-
     microsoft.ad.user - Added ``groups.permissions_failure_action`` to control the behaviour when failing to modify the user's groups -
-    https://github.com/ansible-collections/microsoft.ad/issues/140
+    (https://github.com/ansible-collections/microsoft.ad/issues/140).

--- a/changelogs/fragments/user-permissions-handling.yml
+++ b/changelogs/fragments/user-permissions-handling.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    microsoft.ad.user - Added ``groups.permissions_failure_action`` to control the behaviour when failing to modify the user's groups -
+    https://github.com/ansible-collections/microsoft.ad/issues/140

--- a/plugins/modules/user.ps1
+++ b/plugins/modules/user.ps1
@@ -402,7 +402,7 @@ $setParams = @{
         }
         $dnServerParams = @{}
         foreach ($actionKvp in $Module.Params.groups.GetEnumerator()) {
-            if ($null -eq $actionKvp.Value -or $actionKvp.Key -in @('lookup_failure_action', 'missing_behaviour', 'permission_failure_action')) {
+            if ($null -eq $actionKvp.Value -or $actionKvp.Key -in @('lookup_failure_action', 'missing_behaviour', 'permissions_failure_action')) {
                 continue
             }
 

--- a/plugins/modules/user.yml
+++ b/plugins/modules/user.yml
@@ -177,7 +177,7 @@ DOCUMENTATION:
             - Controls what happens when a group specified by C(groups) is not
               able to be modified by the user specified by C(domain_username)
             - C(fail) is the default and will return an error if any groups 
-            membership is not modifiable by the user.
+              membership is not modifiable by the user.
             - C(ignore) will ignore any groups that cannot be modified.
             - C(warn) will display a warning for any groups that cannot be
               modified but will continue without failing.

--- a/plugins/modules/user.yml
+++ b/plugins/modules/user.yml
@@ -159,13 +159,28 @@ DOCUMENTATION:
           description:
             - Controls what happens when a group specified by C(groups) is an
               invalid group name.
-            - C(fail) is the default and will return an error any groups do not
+            - C(fail) is the default and will return an error if any groups do not
               exist.
-            - C(ignore) will ignore any groups that does not exist.
+            - C(ignore) will ignore any groups that do not exist.
             - C(warn) will display a warning for any groups that do not exist
               but will continue without failing.
           aliases:
             - missing_behaviour
+          choices:
+            - fail
+            - ignore
+            - warn
+          default: fail
+          type: str
+        permissions_failure_action:
+          description:
+            - Controls what happens when a group specified by C(groups) is not
+              able to be modified by the user specified by C(domain_username)
+            - C(fail) is the default and will return an error if any groups 
+            membership is not modifiable by the user.
+            - C(ignore) will ignore any groups that cannot be modified.
+            - C(warn) will display a warning for any groups that cannot be
+              modified but will continue without failing.
           choices:
             - fail
             - ignore

--- a/plugins/modules/user.yml
+++ b/plugins/modules/user.yml
@@ -176,7 +176,7 @@ DOCUMENTATION:
           description:
             - Controls what happens when a group specified by C(groups) is not
               able to be modified by the user specified by C(domain_username)
-            - C(fail) is the default and will return an error if any groups 
+            - C(fail) is the default and will return an erro if any groups
               membership is not modifiable by the user.
             - C(ignore) will ignore any groups that cannot be modified.
             - C(warn) will display a warning for any groups that cannot be

--- a/plugins/modules/user.yml
+++ b/plugins/modules/user.yml
@@ -187,6 +187,7 @@ DOCUMENTATION:
             - warn
           default: fail
           type: str
+          version_added: 1.8.0
     password:
       description:
         - Optionally set the user's password to this (plain text) value.


### PR DESCRIPTION
##### SUMMARY
Fixes #140 

Adds sub-parameter to `groups`
`permissions_failure_action`

Options:
- fail
- ignore
- warn

Default: `fail`

This feature prevents microsoft.ad.user from failing when attempting to add or remove a user from a group that the `domain_username` user does not have permissions to modify if `ignore` or `warn` is specified.

Similar to the `lookup_failure_action` feature that prevents failures when attempting to add a group that does not exist, 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
groups:
  permissions_failure_action:

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
"exception": "Insufficient access rights to perform the operation\r\nAt line:458 char:25
+                         Set-ADObject -Identity $member -Add @{
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (CN=Restricted_Group...mydomain,DC=com:ADObject) [Set-ADObject], ADException

After:
  "warnings": [
    "Cannot add group 'CN=Restricted_Group,OU=Groups,DC=mydomain,DC=com'. You do not have the required permissions, skipping: Insufficient access rights to perform the operation"
  ],
```
