### PR TITLE
Increase minimum Ansible version to 2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -115,20 +115,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-  - stage: Ansible_2_15
-    displayName: Ansible 2.15
-    dependsOn:
-      - Dependencies
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: "{0}"
-          testFormat: "2.15/{0}"
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
   - stage: Windows
     displayName: Windows
     dependsOn:
@@ -162,7 +148,6 @@ stages:
       - Ansible_2_18
       - Ansible_2_17
       - Ansible_2_16
-      - Ansible_2_15
       - Windows
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15**.
+This collection has been tested against following Ansible versions: **>=2.16.0**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/ansible-version.yml
+++ b/changelogs/fragments/ansible-version.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - >-
+      Set minimum supported Ansible version to 2.16.0 to align with the versions still supported by Ansible.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.15'
+requires_ansible: '>=2.16.0'
 action_groups:
   domain:
     - computer

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,5 +1,0 @@
-plugins/action/domain.py action-plugin-docs # ansible-test is ignoring sidecar docs
-plugins/action/domain_child.py action-plugin-docs # ansible-test is ignoring sidecar docs
-plugins/action/domain_controller.py action-plugin-docs # ansible-test is ignoring sidecar docs
-plugins/action/membership.py action-plugin-docs # ansible-test is ignoring sidecar docs
-.azure-pipelines/scripts/publish-codecov.py replace-urlopen # fixed in newer Ansible versions


### PR DESCRIPTION
##### SUMMARY
Ansible 2.15 is EOL, this bumps the minimum versions to 2.16.

##### ISSUE TYPE
- Feature Pull Request