### PR TITLE
Fixed an issue where `microsoft.ad.domain` module did not error correctly

### DIFF
--- a/changelogs/fragments/domain-print-error-on-existing.yml
+++ b/changelogs/fragments/domain-print-error-on-existing.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    domain - Ensure that the `microsoft.ad.domain` module errors when a forest already exists.
+    This prevents the module from attempting to create a new forest if an existing forest is detected and prints an error message indicating that.

--- a/plugins/modules/domain.ps1
+++ b/plugins/modules/domain.ps1
@@ -114,7 +114,18 @@ catch [System.DirectoryServices.ActiveDirectory.ActiveDirectoryOperationExceptio
     $forest = $null
 }
 
-if (-not $forest) {
+try {
+    # ProductType 2 means the host is a domain controller, 1 means it's a workstation and 3 means it's a server that is a server
+    $host_is_dc = (Get-CimInstance -ClassName Win32_OperatingSystem -Property ProductType).ProductType -eq 2
+}
+catch {
+    $module.FailJson("Failed to determine if the host is already a domain controller: $($_.Exception.Message)", $_)
+}
+
+# Only installing the domain if the forest does not exist or the host is not a domain controller
+# This is to avoid an issue where the domain may already exist in another domain controller but the host itself is not a DC
+# By trying to run Install-ADDSForest in that scenario it will fail with the correct error message
+if (-not $forest -or -not $host_is_dc) {
     $installParams = @{
         DomainName = $dns_domain_name
         SafeModeAdministratorPassword = (ConvertTo-SecureString $safe_mode_password -AsPlainText -Force)


### PR DESCRIPTION
##### SUMMARY
This pull requests fixes an issue where the `microsoft.ad.domain` module leaves a host in a limbo state if it finds that the forest already exists but the host itself is not a domain controller. The issue can occur when more then 1 domain controller exists in a forest and a user tries the re-install one with the `microsoft.ad.domain` module. When trying to do it manually the domain controller will give an error that the forest or netbios name already exists. With this fix the `microsoft.ad.domain` module will give the same error.

Fixes https://github.com/ansible-collections/microsoft.ad/issues/177

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`microsoft.ad.domain` module

##### ADDITIONAL INFORMATION
More info is described in the issue - https://github.com/ansible-collections/microsoft.ad/issues/177