### PR TITLE
Fix up codecov ignore entry for Azure CI scripts

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,6 @@
 ---
 ignore:
-  - .azure-pipelines/*
-  - tests/unit/compat/*
-  - tests/unit/mock/*
+  - .azure-pipelines
   - tests/unit/**/conftest.py
   - tests/unit/conftest.py
 


### PR DESCRIPTION
##### SUMMARY
Fixes the ignore entry so it will not attempt to include the CI scripts in the coverage report.

##### ISSUE TYPE
- Bugfix Pull Request