### PR TITLE
Raise minimum ansible version to 2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -71,6 +71,20 @@ stages:
               test: sanity
             - name: Units
               test: units
+  - stage: Ansible_2_19
+    displayName: Ansible 2.19
+    dependsOn:
+      - Dependencies
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: "{0}"
+          testFormat: "2.19/{0}"
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
   - stage: Ansible_2_18
     displayName: Ansible 2.18
     dependsOn:
@@ -115,20 +129,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-  - stage: Ansible_2_15
-    displayName: Ansible 2.15
-    dependsOn:
-      - Dependencies
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: "{0}"
-          testFormat: "2.15/{0}"
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
   - stage: Windows
     displayName: Windows
     dependsOn:
@@ -159,10 +159,10 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_19
       - Ansible_2_18
       - Ansible_2_17
       - Ansible_2_16
-      - Ansible_2_15
       - Windows
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15**.
+This collection has been tested against following Ansible versions: **>=2.16**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
@@ -111,9 +111,9 @@ After the version is published, verify it exists on the [Active Directory Galaxy
 
 ## Support
 
-As a Red Hat Ansible [Certified Content](https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20Ansible%20Automation%20Platform), this collection is entitled to [support](https://access.redhat.com/support/) through [Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible) (AAP).
+As a Red Hat Ansible [Certified Content](https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20Ansible%20Automation%20Platform), this collection is entitled to [support](https://access.redhat.com/support/) through [Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible) (AAP) through the Red Hat Ansible team.
 
-If a support case cannot be opened with Red Hat and the collection has been obtained either from [Galaxy](https://galaxy.ansible.com/ui/) or [GitHub](https://github.com/ansible-collections/microsoft.ad), there is community support available at no charge.
+If a support case cannot be opened with Red Hat or the collection has been obtained either from [Galaxy](https://galaxy.ansible.com/ui/) or [GitHub](https://github.com/ansible-collections/microsoft.ad), you can open a GitHub issue on this repo but this has no guarantee of support or timeframes for a response.
 
 
 ## License

--- a/changelogs/fragments/ansible-ver.yml
+++ b/changelogs/fragments/ansible-ver.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Set minimum supported Ansible version to 2.16 to align with the versions still supported by Ansible.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: microsoft
 name: ad
-version: 1.8.1
+version: 1.9.0
 readme: README.md
 authors:
   - Jordan Borean @jborean93

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.15.0'
+requires_ansible: '>=2.16.0'
 action_groups:
   domain:
     - computer

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,5 +1,0 @@
-plugins/action/domain.py action-plugin-docs # ansible-test is ignoring sidecar docs
-plugins/action/domain_child.py action-plugin-docs # ansible-test is ignoring sidecar docs
-plugins/action/domain_controller.py action-plugin-docs # ansible-test is ignoring sidecar docs
-plugins/action/membership.py action-plugin-docs # ansible-test is ignoring sidecar docs
-.azure-pipelines/scripts/publish-codecov.py replace-urlopen # fixed in newer Ansible versions


### PR DESCRIPTION
##### SUMMARY
Raises the min Ansible version as 2.15 is no longer supported.

##### ISSUE TYPE
- Feature Pull Request