### PR TITLE
ldap - Ensure LDAP enc value is not templated

### DIFF
--- a/changelogs/fragments/laps-templating.yml
+++ b/changelogs/fragments/laps-templating.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    microsoft.ad.ldap - Ensure the encrypted LAPS value is marked as unsafe to stop unexpected templating of the raw
+    JSON result value - https://github.com/ansible-collections/microsoft.ad/issues/194

--- a/plugins/inventory/ldap.py
+++ b/plugins/inventory/ldap.py
@@ -391,7 +391,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     )
 
                     if name.lower() == "mslaps-encryptedpassword" and raw_values:
-                        host_vars["this"] = laps_decryptor.decrypt(raw_values[0])
+                        host_vars["this"] = wrap_var(laps_decryptor.decrypt(raw_values[0]))
                     else:
                         host_vars["this"] = wrap_var(values)
 


### PR DESCRIPTION
##### SUMMARY
Makes sure the LAPS encrypted value is marked as unsafe to avoid it from being templated as a string value. This means any password value that contains valid Jinja2 sequences like `{{`, `}}``, `{%`, etc will not be treated as a template.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/194

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`microsoft.ad.ldap`