### PR TITLE
Fix microsoft.ad.object_info returning multi valued attributes with only one entry as string instead of array (fixes #199)

### DIFF
--- a/plugins/modules/object_info.ps1
+++ b/plugins/modules/object_info.ps1
@@ -298,9 +298,11 @@ $module.Result.objects = @(foreach ($adId in $foundGuids) {
 
             $value = $adObject.$name
             if ($value -is [Microsoft.ActiveDirectory.Management.ADPropertyValueCollection]) {
-                $value = foreach ($v in $value) {
-                    ConvertTo-OutputValue -InputObject $v
+                $value_tmp = @()
+                foreach ($v in $value) {
+                    $value_tmp += ConvertTo-OutputValue -InputObject $v
                 }
+                $value = $value_tmp
             }
             else {
                 $value = ConvertTo-OutputValue -InputObject $value


### PR DESCRIPTION
##### SUMMARY
Fixes #199

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
microsoft.ad.object_info