### PR TITLE
add aap node event query file

### DIFF
--- a/changelogs/fragments/add-aap-query-file.yml
+++ b/changelogs/fragments/add-aap-query-file.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add AAP event query file for microsoft.ad.object_info module. This file is used by AAP to parse module output and extract node information.

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -1,0 +1,18 @@
+---
+microsoft.ad.object_info:
+  query: >-
+    .objects[] | select(.ObjectClass == "computer") | {
+      name: .dNSHostName,
+      canonical_facts: {
+        cn: .CN,
+        name: .Name,
+        object_guid: .ObjectGUID,
+        distinguished_name: .DistinguishedName,
+        dns_host_name: .dNSHostName,
+      },
+      facts: {
+        infra_type: "PrivateCloud",
+        device_type: "Computer",
+        device_category: "Compute"
+      }
+    }


### PR DESCRIPTION
##### SUMMARY
This change adds an event query file to the repo, with a query defined for the object_info module. This file is used by AAP instance only. There is no impact to the user experience or module execution. 
When a user runs the module in AAP (as part of playbook for example), AAP will execute a job in the background to parse any module output and extract information about nodes (computers, storage, networks, etc). AAP knows how/which modules to parse by reading the jq queries defined in the event query file.

##### ISSUE TYPE
- Feature Pull Request
