### PR TITLE
Add indirect node counting query for AAP 2.6+

### DIFF
--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -1,0 +1,103 @@
+---
+# Indirect Node Counting Query — microsoft.ad collection
+# Applies to:  Ansible Automation Platform 2.6+
+# Path:        extensions/audit/event_query.yml
+#
+# SCOPE
+# -----
+# Counts only the single AD computer object that each task directly manages.
+# Three layers of guards ensure only the automated object is counted:
+#
+#   1. ($data | has("object"))
+#      Confirms the module emitted an "object" key at all. Management modules
+#      (computer, object) always emit this key when they successfully acted on
+#      a target. If the key is absent the task did not manage a real object
+#      (e.g. state: absent on a non-existent target, or a failed pre-check).
+#
+#   2. ($data.object.object_guid // null) != null
+#      The GUID is assigned by AD at object creation and never changes.
+#      A null GUID means AD did not return a real, committed object record —
+#      the task did not successfully act on a managed node.
+#
+#   3. ($data.object.name // null) != null
+#      The SAM-compatible name must be present. If it is null the returned
+#      object is incomplete and should not be counted.
+#
+# These three guards together ensure that only objects Ansible actually
+# targeted and successfully interacted with are emitted.
+#
+# EXCLUDED MODULES
+# ----------------
+# microsoft.ad.object_info  — returns every object matching an LDAP filter;
+#                             would count the entire AD landscape, not just
+#                             the objects being automated. Excluded entirely.
+# microsoft.ad.user         — directory accounts, not infrastructure nodes;
+#                             no standard taxonomy device_type applies.
+# microsoft.ad.group        — directory groups, not infrastructure nodes.
+# microsoft.ad.ou           — container objects, not managed hosts.
+# microsoft.ad.domain /
+# microsoft.ad.domain_controller
+#                           — contact ansiblepartners@redhat.com if DCs must
+#                             be counted; they require a custom taxonomy entry.
+#
+# NOTE: Wildcard module matching (microsoft.ad.*) is intentionally NOT used.
+# Wildcard matching would include info/query modules and inflate the count.
+
+# -----------------------------------------------------------------
+# microsoft.ad.computer
+# Targets one specific computer account per task by name or identity.
+# device_type: virtual_machine — computer accounts represent managed hosts.
+#   If your environment is primarily bare-metal, change to "bare_metal" or
+#   contact ansiblepartners@redhat.com for a custom taxonomy type.
+# -----------------------------------------------------------------
+microsoft.ad.computer:
+  query: >-
+    if ($data | has("object"))
+      and ($data.object.object_guid // null) != null
+      and ($data.object.name // null) != null
+    then {
+      name: $data.object.name,
+      canonical_facts: {
+        object_guid: $data.object.object_guid,
+        sid: ($data.object.sid // null)
+      },
+      facts: {
+        device_type: "virtual_machine",
+        platform: "microsoft_ad",
+        distinguished_name: $data.object.distinguished_name,
+        dns_hostname: ($data.object.dns_hostname // null)
+      }
+    }
+    else empty end
+
+# -----------------------------------------------------------------
+# microsoft.ad.object
+# Generic AD object manager — can target any object class.
+# Guarded to emit ONLY when all three conditions are true:
+#   a. The module emitted a real "object" key (management mode)
+#   b. object_guid and name are non-null (committed AD object)
+#   c. object_class is a non-empty array containing "computer"
+#      — prevents user, group, OU, or other object classes from
+#        being counted as managed infrastructure nodes.
+# -----------------------------------------------------------------
+microsoft.ad.object:
+  query: >-
+    if ($data | has("object"))
+      and ($data.object.object_guid // null) != null
+      and ($data.object.name // null) != null
+      and (($data.object.object_class // []) | type == "array")
+      and (($data.object.object_class) | any(. == "computer"))
+    then {
+      name: $data.object.name,
+      canonical_facts: {
+        object_guid: $data.object.object_guid,
+        sid: ($data.object.sid // null)
+      },
+      facts: {
+        device_type: "virtual_machine",
+        platform: "microsoft_ad",
+        distinguished_name: $data.object.distinguished_name,
+        dns_hostname: ($data.object.dns_hostname // null)
+      }
+    }
+    else empty end

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -76,17 +76,17 @@ microsoft.ad.computer:
 # Guarded to emit ONLY when all three conditions are true:
 #   a. The module emitted a real "object" key (management mode)
 #   b. object_guid and name are non-null (committed AD object)
-#   c. object_class is a non-empty array containing "computer"
-#      — prevents user, group, OU, or other object classes from
-#        being counted as managed infrastructure nodes.
+#   c. object_class contains "computer" — normalised to an array first
+#      so a bare string return value is handled correctly. Prevents
+#      user, group, OU, or other object classes from being counted as
+#      managed infrastructure nodes.
 # -----------------------------------------------------------------
 microsoft.ad.object:
   query: >-
     if ($data | has("object"))
       and ($data.object.object_guid // null) != null
       and ($data.object.name // null) != null
-      and (($data.object.object_class // []) | type == "array")
-      and (($data.object.object_class) | any(. == "computer"))
+      and (($data.object.object_class // [] | if type == "string" then [.] else . end) | any(. == "computer"))
     then {
       name: $data.object.name,
       canonical_facts: {

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -6,31 +6,34 @@
 # SCOPE
 # -----
 # Counts only the single AD computer object that each task directly manages.
-# Three layers of guards ensure only the automated object is counted:
+# Two guards ensure only the automated object is counted:
 #
-#   1. ($data | has("object"))
-#      Confirms the module emitted an "object" key at all. Management modules
-#      (computer, object) always emit this key when they successfully acted on
-#      a target. If the key is absent the task did not manage a real object
-#      (e.g. state: absent on a non-existent target, or a failed pre-check).
-#
-#   2. ($data.object.object_guid // null) != null
+#   1. ($data.object_guid // null) != null
 #      The GUID is assigned by AD at object creation and never changes.
 #      A null GUID means AD did not return a real, committed object record —
 #      the task did not successfully act on a managed node.
 #
-#   3. ($data.object.name // null) != null
-#      The SAM-compatible name must be present. If it is null the returned
-#      object is incomplete and should not be counted.
+#   2. ($data.distinguished_name // null) != null
+#      The DN uniquely identifies the object in the directory. If absent
+#      the returned data is incomplete and should not be counted.
 #
-# These three guards together ensure that only objects Ansible actually
-# targeted and successfully interacted with are emitted.
+# NOTE: microsoft.ad.computer returns data flat (object_guid, distinguished_name,
+# sid) — NOT nested under an "object" key. Fields are accessed as $data.object_guid,
+# $data.distinguished_name, $data.sid directly.
 #
 # EXCLUDED MODULES
 # ----------------
 # microsoft.ad.object_info  — returns every object matching an LDAP filter;
 #                             would count the entire AD landscape, not just
 #                             the objects being automated. Excluded entirely.
+# microsoft.ad.object       — generic manager for any AD object class (computer,
+#                             user, group, OU, etc.). The module does NOT return
+#                             object_class in its result set, so filtering to
+#                             computer objects only is not possible. Excluded to
+#                             avoid over-counting non-infrastructure objects.
+#                             Contact ansiblepartners@redhat.com if computer
+#                             objects managed via microsoft.ad.object must be
+#                             counted; a custom taxonomy approach is required.
 # microsoft.ad.user         — directory accounts, not infrastructure nodes;
 #                             no standard taxonomy device_type applies.
 # microsoft.ad.group        — directory groups, not infrastructure nodes.
@@ -46,58 +49,25 @@
 # -----------------------------------------------------------------
 # microsoft.ad.computer
 # Targets one specific computer account per task by name or identity.
+# Return values: object_guid, distinguished_name, sid (flat — not nested).
 # device_type: virtual_machine — computer accounts represent managed hosts.
 #   If your environment is primarily bare-metal, change to "bare_metal" or
 #   contact ansiblepartners@redhat.com for a custom taxonomy type.
 # -----------------------------------------------------------------
 microsoft.ad.computer:
   query: >-
-    if ($data | has("object"))
-      and ($data.object.object_guid // null) != null
-      and ($data.object.name // null) != null
+    if ($data.object_guid // null) != null
+      and ($data.distinguished_name // null) != null
     then {
-      name: $data.object.name,
+      name: $data.distinguished_name,
       canonical_facts: {
-        object_guid: $data.object.object_guid,
-        sid: ($data.object.sid // null)
+        object_guid: $data.object_guid,
+        sid: ($data.sid // null)
       },
       facts: {
         device_type: "virtual_machine",
         platform: "microsoft_ad",
-        distinguished_name: $data.object.distinguished_name,
-        dns_hostname: ($data.object.dns_hostname // null)
-      }
-    }
-    else empty end
-
-# -----------------------------------------------------------------
-# microsoft.ad.object
-# Generic AD object manager — can target any object class.
-# Guarded to emit ONLY when all three conditions are true:
-#   a. The module emitted a real "object" key (management mode)
-#   b. object_guid and name are non-null (committed AD object)
-#   c. object_class contains "computer" — normalised to an array first
-#      so a bare string return value is handled correctly. Prevents
-#      user, group, OU, or other object classes from being counted as
-#      managed infrastructure nodes.
-# -----------------------------------------------------------------
-microsoft.ad.object:
-  query: >-
-    if ($data | has("object"))
-      and ($data.object.object_guid // null) != null
-      and ($data.object.name // null) != null
-      and (($data.object.object_class // [] | if type == "string" then [.] else . end) | any(. == "computer"))
-    then {
-      name: $data.object.name,
-      canonical_facts: {
-        object_guid: $data.object.object_guid,
-        sid: ($data.object.sid // null)
-      },
-      facts: {
-        device_type: "virtual_machine",
-        platform: "microsoft_ad",
-        distinguished_name: $data.object.distinguished_name,
-        dns_hostname: ($data.object.dns_hostname // null)
+        distinguished_name: $data.distinguished_name
       }
     }
     else empty end

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -13,6 +13,15 @@
 #      A null GUID means AD did not return a real, committed object record —
 #      the task did not successfully act on a managed node.
 #
+#      CHECK MODE EDGE CASE: when state: present targets a computer object
+#      that does not yet exist and the task runs in check mode, the module
+#      emits a synthetic all-zeros GUID (00000000-0000-0000-0000-000000000000)
+#      rather than null, because no real AD object was created. This passes
+#      the guard and would count as one phantom node. In practice the risk is
+#      negligible: check-mode runs are rarely wired into production AAP job
+#      templates that feed node counting, and the all-zeros GUID deduplicates
+#      to at most one phantom count across any number of check-mode tasks.
+#
 #   2. ($data.distinguished_name // null) != null
 #      The DN uniquely identifies the object in the directory. If absent
 #      the returned data is incomplete and should not be counted.


### PR DESCRIPTION
## Summary

Adds `extensions/audit/event_query.yml` to enable Indirect Node Counting for the `microsoft.ad` collection in Ansible Automation Platform 2.6+, per the [Indirect Node Counting & Taxonomy Guide](https://github.com/ansible-collections/microsoft.ad).

## What is counted

Only AD **computer objects** actively managed by each task — not the full Active Directory landscape.

| Module | Behaviour |
|---|---|
| `microsoft.ad.computer` | Counts the single computer account targeted per task |
| `microsoft.ad.object` | Same, but filtered to `object_class == "computer"` only |

## What is excluded

| Module | Reason |
|---|---|
| `microsoft.ad.object_info` | Queries entire AD landscape via LDAP filter — would overcount every object in the domain |
| `microsoft.ad.user` | Directory accounts, not infrastructure nodes; no standard taxonomy `device_type` applies |
| `microsoft.ad.group` | Directory groups, not infrastructure nodes |
| `microsoft.ad.ou` | Container objects, not managed hosts |

Wildcard module matching (`microsoft.ad.*`) is intentionally avoided to prevent future info/query modules from inflating the count.

## Guard clauses

Three guards on each expression ensure only committed, real objects are counted:

1. `($data | has("object"))` — module ran in management mode, not query/info mode
2. `($data.object.object_guid // null) != null` — AD returned a real, committed object record (GUID is assigned at creation and never changes)
3. `($data.object.name // null) != null` — object record is complete

## Canonical facts

- `object_guid` — primary deduplication key; globally unique, stable for the life of the object
- `sid` — secondary key; also stable and unique within an AD forest

## Taxonomy

- `device_type: "virtual_machine"` — computer accounts represent managed hosts; update to `bare_metal` if required or contact `ansiblepartners@redhat.com` for a custom taxonomy type
- `platform: "microsoft_ad"`