### PR TITLE
feat: add gpo_link module for managing GPO links

### DIFF
--- a/plugins/modules/gpo_link.ps1
+++ b/plugins/modules/gpo_link.ps1
@@ -51,16 +51,15 @@ try {
 }
 
 # Resolve GPO identity — get both name and GUID for return values
-$gpoIdentity = if ($gpoGuid) { $gpoGuid } else { $gpoName }
-
 try {
-    $gpoObject = Get-GPO @gpParams -Name $gpoIdentity -ErrorAction Stop 2>$null
-} catch {
-    try {
-        $gpoObject = Get-GPO @gpParams -Guid $gpoIdentity -ErrorAction Stop 2>$null
-    } catch {
-        $module.FailJson("GPO '$gpoIdentity' not found: $_", $_)
+    if ($gpoGuid) {
+        $gpoObject = Get-GPO @gpParams -Guid $gpoGuid -ErrorAction Stop
+    } else {
+        $gpoObject = Get-GPO @gpParams -Name $gpoName -ErrorAction Stop
     }
+} catch {
+    $identifier = if ($gpoGuid) { $gpoGuid } else { $gpoName }
+    $module.FailJson("GPO '$identifier' not found: $_", $_)
 }
 
 $resolvedName = $gpoObject.DisplayName

--- a/plugins/modules/gpo_link.ps1
+++ b/plugins/modules/gpo_link.ps1
@@ -1,0 +1,234 @@
+#!powershell
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        gpo_name = @{ type = 'str' }
+        gpo_guid = @{ type = 'str' }
+        target = @{ type = 'str'; required = $true }
+        link_enabled = @{ type = 'bool' }
+        enforced = @{ type = 'bool' }
+        order = @{ type = 'int' }
+        state = @{ type = 'str'; choices = @('absent', 'present'); default = 'present' }
+        domain = @{ type = 'str' }
+        server = @{ type = 'str' }
+    }
+    mutually_exclusive = @(
+        , @('gpo_name', 'gpo_guid')
+    )
+    required_one_of = @(
+        , @('gpo_name', 'gpo_guid')
+    )
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$gpoName = $module.Params.gpo_name
+$gpoGuid = $module.Params.gpo_guid
+$target = $module.Params.target
+$linkEnabled = $module.Params.link_enabled
+$enforced = $module.Params.enforced
+$order = $module.Params.order
+$state = $module.Params.state
+$domain = $module.Params.domain
+$server = $module.Params.server
+
+# Build common parameters for GP cmdlets
+$gpParams = @{}
+if ($domain) { $gpParams.Domain = $domain }
+if ($server) { $gpParams.Server = $server }
+
+# Ensure the GroupPolicy module is available
+try {
+    Import-Module GroupPolicy -ErrorAction Stop
+} catch {
+    $module.FailJson("The GroupPolicy PowerShell module is not available. Install RSAT or the GroupPolicy feature.", $_)
+}
+
+# Resolve GPO identity — get both name and GUID for return values
+$gpoIdentity = if ($gpoGuid) { $gpoGuid } else { $gpoName }
+
+try {
+    $gpoObject = Get-GPO @gpParams -Name $gpoIdentity -ErrorAction Stop 2>$null
+} catch {
+    try {
+        $gpoObject = Get-GPO @gpParams -Guid $gpoIdentity -ErrorAction Stop 2>$null
+    } catch {
+        $module.FailJson("GPO '$gpoIdentity' not found: $_", $_)
+    }
+}
+
+$resolvedName = $gpoObject.DisplayName
+$resolvedGuid = $gpoObject.Id.ToString()
+
+# Set return values that are always present
+$module.Result.gpo_name = $resolvedName
+$module.Result.gpo_guid = $resolvedGuid
+$module.Result.target = $target
+
+# Find existing link
+$existingLink = $null
+try {
+    $inheritance = Get-GPInheritance @gpParams -Target $target -ErrorAction Stop
+    $existingLink = $inheritance.GpoLinks | Where-Object {
+        $_.GpoId.ToString() -eq $resolvedGuid
+    }
+} catch {
+    if ($state -eq 'present') {
+        # Target may not exist — let New-GPLink handle the error
+    }
+}
+
+# Build diff output
+$module.Diff.before = @{}
+$module.Diff.after = @{}
+
+if ($existingLink) {
+    $module.Diff.before = @{
+        gpo_name = $resolvedName
+        target = $target
+        link_enabled = ($existingLink.Enabled -eq 'Yes')
+        enforced = ($existingLink.Enforced -eq 'Yes')
+        order = $existingLink.Order
+    }
+}
+
+if ($state -eq 'absent') {
+    # Remove the GPO link
+    if ($existingLink) {
+        $module.Result.changed = $true
+        $module.Diff.after = @{}
+
+        if (-not $module.CheckMode) {
+            try {
+                Remove-GPLink @gpParams -Guid $resolvedGuid -Target $target -ErrorAction Stop
+            } catch {
+                $module.FailJson("Failed to remove GPO link: $_", $_)
+            }
+        }
+    }
+    # If no existing link, nothing to do — already absent
+} else {
+    # state=present — create or update the link
+    if (-not $existingLink) {
+        # Create new link
+        $module.Result.changed = $true
+
+        $newLinkParams = @{
+            Guid = $resolvedGuid
+            Target = $target
+            ErrorAction = 'Stop'
+        }
+
+        # Set link_enabled (New-GPLink uses -LinkEnabled)
+        if ($null -ne $linkEnabled) {
+            $newLinkParams.LinkEnabled = if ($linkEnabled) { 'Yes' } else { 'No' }
+        } else {
+            $newLinkParams.LinkEnabled = 'Yes'
+        }
+
+        # Set enforced
+        $newEnforced = $false
+        if ($null -ne $enforced) {
+            $newEnforced = $enforced
+        }
+
+        $module.Diff.after = @{
+            gpo_name = $resolvedName
+            target = $target
+            link_enabled = if ($null -ne $linkEnabled) { $linkEnabled } else { $true }
+            enforced = $newEnforced
+        }
+
+        if (-not $module.CheckMode) {
+            try {
+                $newLink = New-GPLink @gpParams @newLinkParams
+
+                # Set enforced separately — New-GPLink doesn't have -Enforced
+                if ($newEnforced) {
+                    Set-GPLink @gpParams -Guid $resolvedGuid -Target $target -Enforced 'Yes' -ErrorAction Stop | Out-Null
+                }
+
+                # Set order if specified
+                if ($null -ne $order) {
+                    Set-GPLink @gpParams -Guid $resolvedGuid -Target $target -Order $order -ErrorAction Stop | Out-Null
+                }
+
+                # Fetch final state for return values
+                $finalInheritance = Get-GPInheritance @gpParams -Target $target -ErrorAction Stop
+                $finalLink = $finalInheritance.GpoLinks | Where-Object {
+                    $_.GpoId.ToString() -eq $resolvedGuid
+                }
+                if ($finalLink) {
+                    $module.Diff.after.order = $finalLink.Order
+                    $module.Diff.after.enforced = ($finalLink.Enforced -eq 'Yes')
+                    $module.Diff.after.link_enabled = ($finalLink.Enabled -eq 'Yes')
+                }
+            } catch {
+                $module.FailJson("Failed to create GPO link: $_", $_)
+            }
+        }
+    } else {
+        # Update existing link
+        $needsUpdate = $false
+        $setParams = @{
+            Guid = $resolvedGuid
+            Target = $target
+            ErrorAction = 'Stop'
+        }
+
+        $afterState = @{
+            gpo_name = $resolvedName
+            target = $target
+            link_enabled = ($existingLink.Enabled -eq 'Yes')
+            enforced = ($existingLink.Enforced -eq 'Yes')
+            order = $existingLink.Order
+        }
+
+        if (($null -ne $linkEnabled) -and ($linkEnabled -ne ($existingLink.Enabled -eq 'Yes'))) {
+            $setParams.LinkEnabled = if ($linkEnabled) { 'Yes' } else { 'No' }
+            $afterState.link_enabled = $linkEnabled
+            $needsUpdate = $true
+        }
+
+        if (($null -ne $enforced) -and ($enforced -ne ($existingLink.Enforced -eq 'Yes'))) {
+            $setParams.Enforced = if ($enforced) { 'Yes' } else { 'No' }
+            $afterState.enforced = $enforced
+            $needsUpdate = $true
+        }
+
+        if (($null -ne $order) -and ($order -ne $existingLink.Order)) {
+            $setParams.Order = $order
+            $afterState.order = $order
+            $needsUpdate = $true
+        }
+
+        $module.Diff.after = $afterState
+
+        if ($needsUpdate) {
+            $module.Result.changed = $true
+
+            if (-not $module.CheckMode) {
+                try {
+                    Set-GPLink @gpParams @setParams | Out-Null
+                } catch {
+                    $module.FailJson("Failed to update GPO link: $_", $_)
+                }
+            }
+        }
+    }
+
+    # Populate return values for present state
+    $module.Result.link_enabled = $module.Diff.after.link_enabled
+    $module.Result.enforced = $module.Diff.after.enforced
+    if ($module.Diff.after.ContainsKey('order')) {
+        $module.Result.order = $module.Diff.after.order
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/gpo_link.yml
+++ b/plugins/modules/gpo_link.yml
@@ -1,0 +1,193 @@
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: gpo_link
+  short_description: Manage Active Directory Group Policy Object links
+  description:
+    - Links, unlinks, enables, disables, and enforces Group Policy Objects
+      (GPOs) on Active Directory targets such as sites, domains, and
+      organizational units.
+    - This module wraps the C(New-GPLink), C(Set-GPLink), and
+      C(Remove-GPLink) PowerShell cmdlets from the C(GroupPolicy) module.
+    - Replaces the need to use M(ansible.windows.win_powershell) with inline
+      C(Set-GPLink) scripts.
+  options:
+    gpo_name:
+      description:
+        - The display name of the GPO to link.
+        - Exactly one of I(gpo_name) or I(gpo_guid) must be specified.
+      type: str
+    gpo_guid:
+      description:
+        - The GUID of the GPO to link.
+        - Exactly one of I(gpo_name) or I(gpo_guid) must be specified.
+      type: str
+    target:
+      description:
+        - The LDAP distinguished name of the site, domain, or OU to which
+          the GPO is linked.
+        - 'For example: C(OU=Servers,DC=contoso,DC=com) or
+          C(DC=contoso,DC=com).'
+      type: str
+      required: true
+    link_enabled:
+      description:
+        - Whether the GPO link is enabled.
+        - A disabled link remains associated with the target but its
+          settings are not applied.
+        - Defaults to C(true) when creating a new link.
+      type: bool
+    enforced:
+      description:
+        - Whether the GPO link is enforced.
+        - An enforced link cannot be blocked by child containers.
+        - Defaults to C(false) when creating a new link.
+      type: bool
+    order:
+      description:
+        - The link order (processing priority) of the GPO on the target.
+        - Lower numbers indicate higher priority.
+        - Valid values start at C(1).
+      type: int
+    state:
+      description:
+        - C(present) ensures the GPO is linked to the target.
+        - C(absent) ensures the GPO link is removed from the target.
+      type: str
+      choices:
+        - absent
+        - present
+      default: present
+    domain:
+      description:
+        - The domain to target for the GPO operation.
+        - If not specified, the domain of the user running the module is
+          used.
+      type: str
+    server:
+      description:
+        - The domain controller to target for the GPO operation.
+        - If not specified, the module uses the default DC discovery.
+      type: str
+  notes:
+    - This module requires the C(GroupPolicy) PowerShell module to be
+      installed on the Windows target host. This module is available as
+      part of the Remote Server Administration Tools (RSAT) feature.
+    - Unlike modules that use the C(ActiveDirectory) PowerShell module,
+      this module uses the C(GroupPolicy) module and does not extend the
+      C(microsoft.ad.ad_object) documentation fragment.
+    - Multiple GPOs can be linked to the same target by calling this
+      module multiple times with different I(gpo_name) or I(gpo_guid)
+      values.
+  extends_documentation_fragment:
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms:
+        - windows
+  seealso:
+    - module: microsoft.ad.ou
+    - module: microsoft.ad.group
+    - module: microsoft.ad.object
+  author:
+    - Steve Fulmer (@stevefulmer)
+
+EXAMPLES: |
+  - name: Link a GPO to an OU
+    microsoft.ad.gpo_link:
+      gpo_name: Default Security Policy
+      target: "OU=Servers,DC=contoso,DC=com"
+      state: present
+
+  - name: Link a GPO by GUID
+    microsoft.ad.gpo_link:
+      gpo_guid: "12345678-1234-1234-1234-123456789012"
+      target: "OU=Workstations,DC=contoso,DC=com"
+      state: present
+      link_enabled: true
+
+  - name: Enforce a GPO link
+    microsoft.ad.gpo_link:
+      gpo_name: Compliance Baseline
+      target: "DC=contoso,DC=com"
+      enforced: true
+
+  - name: Disable a GPO link without removing it
+    microsoft.ad.gpo_link:
+      gpo_name: Test Policy
+      target: "OU=Lab,DC=contoso,DC=com"
+      link_enabled: false
+
+  - name: Set GPO link order
+    microsoft.ad.gpo_link:
+      gpo_name: High Priority Policy
+      target: "OU=Servers,DC=contoso,DC=com"
+      order: 1
+
+  - name: Remove a GPO link
+    microsoft.ad.gpo_link:
+      gpo_name: Deprecated Policy
+      target: "OU=Servers,DC=contoso,DC=com"
+      state: absent
+
+  - name: Link multiple GPOs to the same OU
+    microsoft.ad.gpo_link:
+      gpo_name: "{{ item }}"
+      target: "OU=Servers,DC=contoso,DC=com"
+      state: present
+      link_enabled: true
+    loop:
+      - Security Baseline
+      - Monitoring Policy
+      - Patch Management
+
+  - name: Manage GPO link on a specific domain controller
+    microsoft.ad.gpo_link:
+      gpo_name: Regional Policy
+      target: "OU=Branch,DC=contoso,DC=com"
+      server: dc01.contoso.com
+      state: present
+      enforced: true
+
+RETURN:
+  gpo_name:
+    description:
+      - The display name of the GPO.
+    returned: always
+    type: str
+    sample: Default Security Policy
+  gpo_guid:
+    description:
+      - The GUID of the GPO.
+    returned: when the link exists
+    type: str
+    sample: 12345678-1234-1234-1234-123456789012
+  target:
+    description:
+      - The distinguished name of the target container.
+    returned: always
+    type: str
+    sample: "OU=Servers,DC=contoso,DC=com"
+  link_enabled:
+    description:
+      - Whether the GPO link is enabled.
+    returned: when state=present
+    type: bool
+    sample: true
+  enforced:
+    description:
+      - Whether the GPO link is enforced.
+    returned: when state=present
+    type: bool
+    sample: false
+  order:
+    description:
+      - The link order of the GPO on the target.
+    returned: when state=present
+    type: int
+    sample: 1


### PR DESCRIPTION
## Summary

- Adds `microsoft.ad.gpo_link` module for declarative management of Group Policy Object links on AD sites, domains, and OUs
- Wraps `New-GPLink`, `Set-GPLink`, and `Remove-GPLink` PowerShell cmdlets from the GroupPolicy module
- Supports: link/unlink (state), enable/disable, enforce, link ordering, check mode, and diff mode
- Eliminates the need for `win_powershell` with inline `Set-GPLink` scripts

## Files

- `plugins/modules/gpo_link.yml` — Full DOCUMENTATION, EXAMPLES, and RETURN definitions
- `plugins/modules/gpo_link.ps1` — PowerShell implementation using `Ansible.Basic`

## Test plan

- [ ] `ansible-test sanity --docker` passes
- [ ] Verify module loads and argument validation works on a Windows target
- [ ] Test link creation (state=present) on an OU
- [ ] Test link removal (state=absent)
- [ ] Test idempotency (run twice, second run shows no change)
- [ ] Test check mode (--check shows changes without applying)
- [ ] Test diff mode (--diff shows before/after)
- [ ] Test link_enabled toggle (enable/disable without removing)
- [ ] Test enforced flag
- [ ] Test order parameter
- [ ] Test with gpo_name vs gpo_guid

Ref: AAP-44072

🤖 Generated with [Claude Code](https://claude.com/claude-code)