### PR TITLE
Fix empty attribute for object creation

### DIFF
--- a/changelogs/fragments/new-ad-object-empty-attribute.yml
+++ b/changelogs/fragments/new-ad-object-empty-attribute.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    Fix bug when creating a new AD object with an attribute set to an empty value. For example using
+    ``allowed_to_retrieve_password: {set: []}`` on ``microsoft.ad.service_account`` will be treated like the value was
+    not specified at all - https://github.com/ansible-collections/microsoft.ad/issues/229

--- a/plugins/module_utils/_ADObject.psm1
+++ b/plugins/module_utils/_ADObject.psm1
@@ -1255,17 +1255,19 @@ Function Invoke-AnsibleADObject {
 
                     # If the value is empty we don't want to explicitly set it
                     # as that will be the default and can fail if empty.
-                    if ($propInfo.IsRawAttribute -and @($propValue).Count) {
-                        if (-not $newParams.ContainsKey('OtherAttributes')) {
-                            $newParams.OtherAttributes = @{}
-                        }
+                    if (@($propValue).Count) {
+                        if ($propInfo.IsRawAttribute) {
+                            if (-not $newParams.ContainsKey('OtherAttributes')) {
+                                $newParams.OtherAttributes = @{}
+                            }
 
-                        # The AD cmdlets don't like explicitly casted arrays, use
-                        # ForEach-Object to get back a vanilla object[] to set.
-                        $newParams.OtherAttributes[$propInfo.Attribute] = $propValue | ForEach-Object { "$_" }
-                    }
-                    elseif (-not $propInfo.IsRawAttribute) {
-                        $newParams[$propInfo.Attribute] = $propValue
+                            # The AD cmdlets don't like explicitly casted arrays, use
+                            # ForEach-Object to get back a vanilla object[] to set.
+                            $newParams.OtherAttributes[$propInfo.Attribute] = $propValue | ForEach-Object { "$_" }
+                        }
+                        else {
+                            $newParams[$propInfo.Attribute] = $propValue
+                        }
                     }
 
                     if ($propInfo.Option.no_log) {

--- a/tests/integration/targets/service_account/tasks/tests.yml
+++ b/tests/integration/targets/service_account/tasks/tests.yml
@@ -265,6 +265,10 @@
       add:
       - aes128
       - aes256
+    # Tests that an explicit empty list still works
+    # https://github.com/ansible-collections/microsoft.ad/issues/229
+    allowed_to_retrieve_password:
+      set: []
   register: create_sa_no_dollar_check
   check_mode: true
 
@@ -290,6 +294,8 @@
       add:
       - aes128
       - aes256
+    allowed_to_retrieve_password:
+      set: []
   register: create_sa_no_dollar
 
 - set_fact:


### PR DESCRIPTION
##### SUMMARY
When creating an AD object with an attribute that results in an empty set of values we need to skip setting the parameter for that attribute on the `New-*` cmdlet.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/229

##### ISSUE TYPE
- Bugfix Pull Request