### PR TITLE
Added domain_realm option for LDAP inventory

### DIFF
--- a/docs/docsite/rst/guide_ldap_connection.rst
+++ b/docs/docsite/rst/guide_ldap_connection.rst
@@ -83,6 +83,8 @@ Connecting to a Microsoft Active Directory or LDAP server requires information l
 +===============+================================+=============================================+
 | server        | Server lookup through Kerberos | The LDAP server hostname                    |
 +---------------+--------------------------------+---------------------------------------------+
+| domain_realm  | Default realm from Kerberos    | The realm to use for server SRV lookup      |
++---------------+--------------------------------+---------------------------------------------+
 | port          | 389 or 686 if tls_mode=ldaps   | The LDAP port                               |
 +---------------+--------------------------------+---------------------------------------------+
 | tls_mode      | LDAPS if port=686 else None    | TLS details - LDAP, LDAP + StartTLS, LDAPS  |
@@ -105,13 +107,13 @@ Server lookup
 If no server option was explicitly set, the plugin will attempt to lookup the LDAP server based on the current environment configuration. This is only possible if:
 
 * The ``dnspython`` Python package is installed
-* The ``pyspnego[kerberos]`` Python package for Kerberos is installed
-* The underlying Kerberos library has a ``default_realm`` set in the `MIT krb5.conf <https://web.mit.edu/kerberos/krb5-latest/doc/admin/host_config.html#default-realm>`_
+* The ``domain_realm`` value is explicitly set or
+* The ``pyspnego[kerberos]`` Python package for Kerberos is installed and the Kerberos library has a ``default_realm`` set in the `MIT krb5.conf <https://web.mit.edu/kerberos/krb5-latest/doc/admin/host_config.html#default-realm>`_
 
 If none of the above are true, the connection will fail and an explicit server must be supplied. If all the requirements are satisfied this is the server lookup workflow:
 
-* The ``default_realm`` of the local Kerberos configuration is retrieved
-* A DNS SRV lookup is done for the record ``_ldap._tcp.dc._msdcs.{{ default_realm }}``
+* The ``domain_realm`` specified in the options is used as the ``{{ realm }}``, otherwise the ``default_realm`` of the local Kerberos configuration is retrieved
+* A DNS SRV lookup is done for the record ``_ldap._tcp.dc._msdcs.{{ realm }}``
 * The DNS records are sorted by priority and weight and the first is selected
 * The hostname and port on the selected SRV record are used for the lookup
 

--- a/plugins/doc_fragments/ldap_connection.py
+++ b/plugins/doc_fragments/ldap_connection.py
@@ -114,6 +114,16 @@ options:
     type: int
     env:
     - name: MICROSOFT_AD_LDAP_CONNECTION_TIMEOUT
+  domain_realm:
+    description:
+    - Sets the domain realm to use for the LDAP server lookup performed when
+      O(server) is not specified.
+    - If not specified, the default realm from the Kerberos configuration will
+      be used instead.
+    type: str
+    env:
+    - name: MICROSOFT_AD_LDAP_DOMAIN_REALM
+    version_added: '1.11.0'
   encrypt:
     description:
     - Whether encryption is required for the connection.
@@ -153,8 +163,9 @@ options:
   server:
     description:
     - The domain controller/server to connect to.
-    - If not specified the server will be derived from the current krb5.conf
-      C(default_realm) setting and with an SRV DNS lookup.
+    - If not specified the server will be found using an SRV DNS lookup for the
+      domain specified by O(domain_realm) or the Kerberos C(default_realm)
+      configuration setting.
     - See R(Server lookup,ansible_collections.microsoft.ad.docsite.guide_ldap_connection.server_lookup)
       for more information.
     - This option can be set using a Jinja2 template value.

--- a/plugins/inventory/ldap.py
+++ b/plugins/inventory/ldap.py
@@ -340,6 +340,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "certificate_key",
             "certificate_password",
             "connection_timeout",
+            "domain_realm",
             "encrypt",
             "password",
             "port",

--- a/plugins/plugin_utils/_ldap/__init__.py
+++ b/plugins/plugin_utils/_ldap/__init__.py
@@ -47,6 +47,7 @@ def create_ldap_connection(
     server: t.Optional[str] = None,
     tls_mode: t.Optional[str] = None,
     username: t.Optional[str] = None,
+    domain_realm: t.Optional[str] = None,
     **kwargs: t.Any,  # Catches any other module option not needed here
 ) -> SyncLDAPClient:
     """Creates the LDAP client.
@@ -75,7 +76,8 @@ def create_ldap_connection(
         server: The LDAP server to connect to.
         tls_mode: The TLS mode, can be ldaps or start_tls.
         username: The username to authenticate with.
-
+        domain_realm: The domain realm to use for LDAP server lookup. If not
+            specified, will use the default realm from the Kerberos config.
     Returns:
         LDAPClient: The LDAP client.
     """
@@ -83,7 +85,7 @@ def create_ldap_connection(
         raise ImportError(str(LDAP_IMP_ERR)) from LDAP_IMP_ERR
 
     if not server:
-        server, lookup_port = lookup_ldap_server()
+        server, lookup_port = lookup_ldap_server(default_realm=domain_realm)
         if not port:
             port = lookup_port
 

--- a/plugins/plugin_utils/_ldap/_lookup.py
+++ b/plugins/plugin_utils/_ldap/_lookup.py
@@ -67,12 +67,18 @@ class SrvRecord(t.NamedTuple):
         return sorted(answers, key=lambda a: (a.priority, -a.weight))
 
 
-def lookup_ldap_server() -> t.Tuple[str, int]:
+def lookup_ldap_server(
+    default_realm: t.Optional[str] = None,
+) -> t.Tuple[str, int]:
     """Attempts to lookup LDAP server.
 
     Attempts to lookup LDAP server based on the current Kerberos host
     configuration. Will them perform an SRV lookup for
     '_ldap._tcp.dc._msdcs.{realm}' to get the LDAP server hostname nad port.
+
+    Args:
+        default_realm: The default Kerberos realm to use, falls back to the
+            Kerberos config default_realm entry.
 
     Returns:
         Tuple[str, int]: The LDAP hostname and port.
@@ -82,12 +88,17 @@ def lookup_ldap_server() -> t.Tuple[str, int]:
         krb5.Krb5Error: Kerberos configuration problem
         dns.exception.DNSException: DNS lookup error.
     """
-    required_libs = [(HAS_KRB5, "krb5"), (HAS_DNSPYTHON, "dnspython")]
+    required_libs = [(HAS_DNSPYTHON, "dnspython")]
+    if not default_realm:
+        required_libs.append((HAS_KRB5, "krb5"))
+
     missing_libs = [lib for present, lib in required_libs if not present]
     if missing_libs:
         raise ImportError(f"Cannot lookup server without the python libraries {', '.join(missing_libs)}")
 
-    ctx = krb5.init_context()
-    default_realm = krb5.get_default_realm(ctx).decode("utf-8")
+    if not default_realm:
+        ctx = krb5.init_context()
+        default_realm = krb5.get_default_realm(ctx).decode("utf-8")
+
     answer = SrvRecord.lookup("ldap", "tcp", f"dc._msdcs.{default_realm}")[0]
     return answer.target, answer.port


### PR DESCRIPTION
##### SUMMARY
Adds the `domain_realm` option for the `microsoft.ad.ldap` inventory plugin that can be used to specify the realm to use for the LDAP server SRV lookup. If unset the existing Kerberos configuration lookup will be used.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/223

##### ISSUE TYPE
- Feature Pull Request