### PR TITLE
feat(cs_template): add module to manage AD CS certificate templates

### DIFF
--- a/changelogs/fragments/cs-template.yml
+++ b/changelogs/fragments/cs-template.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    cs_template - New module to create, modify, and remove AD Certificate
+    Services certificate templates and publish them to Certificate Authorities.

--- a/changelogs/fragments/cs-template.yml
+++ b/changelogs/fragments/cs-template.yml
@@ -1,4 +1,0 @@
-minor_changes:
-  - >-
-    cs_template - New module to create, modify, and remove AD Certificate
-    Services certificate templates and publish them to Certificate Authorities.

--- a/plugins/modules/cs_template.ps1
+++ b/plugins/modules/cs_template.ps1
@@ -5,6 +5,8 @@
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
 
+using namespace System.Management.Automation
+
 $spec = @{
     options = @{
         name = @{
@@ -40,14 +42,17 @@ $spec = @{
             type = 'int'
         }
         enrollment_flag = @{
-            type = 'int'
+            type = 'list'
+            elements = 'str'
         }
         private_key_flag = @{
-            type = 'int'
+            type = 'list'
+            elements = 'str'
             no_log = $false
         }
         certificate_name_flag = @{
-            type = 'int'
+            type = 'list'
+            elements = 'str'
         }
         schema_version = @{
             type = 'int'
@@ -69,15 +74,6 @@ $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 $module.Result.changed = $false
 $module.Result.distinguished_name = $null
 $module.Result.template_oid = $null
-$module.Result.display_name = $null
-$module.Result.key_size = $null
-$module.Result.schema_version = $null
-$module.Result.enrollment_flag = $null
-$module.Result.private_key_flag = $null
-$module.Result.certificate_name_flag = $null
-$module.Result.extended_key_usages = @()
-$module.Result.validity_period_days = $null
-$module.Result.renewal_period_days = $null
 
 $name = $module.Params.name
 $displayName = if ($module.Params.display_name) { $module.Params.display_name } else { $name }
@@ -89,7 +85,84 @@ if ($module.Params.domain_server) {
     $adParams.Server = $module.Params.domain_server
 }
 
-# Integer properties on the template that we clone and can override
+# Name-Value Maps
+
+$ekuMap = @{
+    'server_authentication'     = '1.3.6.1.5.5.7.3.1'
+    'client_authentication'     = '1.3.6.1.5.5.7.3.2'
+    'code_signing'              = '1.3.6.1.5.5.7.3.3'
+    'secure_email'              = '1.3.6.1.5.5.7.3.4'
+    'ip_security_end_system'    = '1.3.6.1.5.5.7.3.5'
+    'ip_security_tunnel'        = '1.3.6.1.5.5.7.3.6'
+    'ip_security_user'          = '1.3.6.1.5.5.7.3.7'
+    'time_stamping'             = '1.3.6.1.5.5.7.3.8'
+    'ocsp_signing'              = '1.3.6.1.5.5.7.3.9'
+    'smart_card_logon'          = '1.3.6.1.4.1.311.20.2.2'
+    'certificate_request_agent' = '1.3.6.1.4.1.311.20.2.1'
+    'encrypting_file_system'    = '1.3.6.1.4.1.311.10.3.4'
+    'file_recovery'             = '1.3.6.1.4.1.311.10.3.4.1'
+    'key_recovery'              = '1.3.6.1.4.1.311.10.3.11'
+    'key_recovery_agent'        = '1.3.6.1.4.1.311.21.6'
+    'document_signing'          = '1.3.6.1.4.1.311.10.3.12'
+    'remote_desktop'            = '1.3.6.1.4.1.311.54.1.2'
+    'kdc_authentication'        = '1.3.6.1.5.2.3.5'
+}
+
+$enrollmentFlagMap = @{
+    'include_symmetric_algorithms'            = 0x00000001
+    'pend_all_requests'                       = 0x00000002
+    'publish_to_kra_container'                = 0x00000004
+    'publish_to_ds'                           = 0x00000008
+    'auto_enrollment_check_user_ds_certificate' = 0x00000010
+    'auto_enrollment'                         = 0x00000020
+    'previous_approval_validate_reenrollment' = 0x00000040
+}
+
+$privateKeyFlagMap = @{
+    'require_private_key_archival'          = 0x00000001
+    'exportable_key'                        = 0x00000010
+    'strong_key_protection_required'        = 0x00000020
+    'require_alternate_signature_algorithm' = 0x00000040
+    'require_same_key_renewal'              = 0x00000080
+    'use_legacy_provider'                   = 0x00000100
+    'ek_trust_on_use'                       = 0x00000200
+    'ek_validate_cert'                      = 0x00000400
+    'ek_validate_key'                       = 0x00000800
+    'attest_preferred'                      = 0x00001000
+    'attest_required'                       = 0x00002000
+    'attestation_without_policy'            = 0x00004000
+    'hello_logon_key'                       = 0x00200000
+}
+
+$certNameFlagMap = @{
+    'enrollee_supplies_subject'          = 0x00000001
+    'enrollee_supplies_subject_alt_name' = 0x00010000
+    'subject_alt_require_domain_dns'     = 0x00400000
+    'subject_alt_require_spn'            = 0x00800000
+    'subject_alt_require_directory_guid' = 0x01000000
+    'subject_alt_require_upn'            = 0x02000000
+    'subject_alt_require_email'          = 0x04000000
+    'subject_alt_require_dns'            = 0x08000000
+    'subject_require_dns_as_cn'          = 0x10000000
+    'subject_require_email'              = 0x20000000
+    'subject_require_common_name'        = 0x40000000
+    'subject_require_directory_path'     = 0x80000000
+}
+
+# pKIKeyUsage is a byte array using ASN.1 BIT STRING encoding (bits reversed
+# within each byte). Byte 0 holds the first 8 usages, byte 1 holds decipher_only.
+$keyUsageMap = @{
+    'digital_signature' = @{ Byte = 0; Bit = 0x80 }
+    'non_repudiation'   = @{ Byte = 0; Bit = 0x40 }
+    'key_encipherment'  = @{ Byte = 0; Bit = 0x20 }
+    'data_encipherment' = @{ Byte = 0; Bit = 0x10 }
+    'key_agreement'     = @{ Byte = 0; Bit = 0x08 }
+    'key_cert_sign'     = @{ Byte = 0; Bit = 0x04 }
+    'crl_sign'          = @{ Byte = 0; Bit = 0x02 }
+    'encipher_only'     = @{ Byte = 0; Bit = 0x01 }
+    'decipher_only'     = @{ Byte = 1; Bit = 0x80 }
+}
+
 $intProperties = @(
     'flags'
     'revision'
@@ -124,36 +197,39 @@ $allTemplateProperties = $intProperties + $collectionProperties + $bytePropertie
 
 # Maps module params to LDAP attributes with type casting and comparison logic.
 # Used for both create (override cloned values) and update (idempotent set).
+# Flag params use Resolve-FlagList; EKU uses Resolve-EkuList; key_usage and
+# period bytes are handled separately in the code.
+
 $overrideMap = @(
     @{
         Param = 'key_size'
         Attr = 'msPKI-Minimal-Key-Size'
-        Cast = { param($v) [System.Int32]$v }
+        Cast = { param($v) [int]$v }
     }
     @{
         Param = 'schema_version'
         Attr = 'msPKI-Template-Schema-Version'
-        Cast = { param($v) [System.Int32]$v }
+        Cast = { param($v) [int]$v }
     }
     @{
         Param = 'enrollment_flag'
         Attr = 'msPKI-Enrollment-Flag'
-        Cast = { param($v) [System.Int32]$v }
+        Cast = { param($v) [int](Resolve-FlagList $v $enrollmentFlagMap 'enrollment_flag') }
     }
     @{
         Param = 'private_key_flag'
         Attr = 'msPKI-Private-Key-Flag'
-        Cast = { param($v) [System.Int32]$v }
+        Cast = { param($v) [int](Resolve-FlagList $v $privateKeyFlagMap 'private_key_flag') }
     }
     @{
         Param = 'certificate_name_flag'
         Attr = 'msPKI-Certificate-Name-Flag'
-        Cast = { param($v) [System.Int32]$v }
+        Cast = { param($v) [int](Resolve-FlagList $v $certNameFlagMap 'certificate_name_flag') }
     }
     @{
         Param = 'extended_key_usages'
         Attr = 'pKIExtendedKeyUsage'
-        Cast = { param($v) , [string[]]$v }
+        Cast = { param($v) , [string[]](Resolve-EkuList $v) }
     }
     @{
         Param = 'validity_period_days'
@@ -167,24 +243,65 @@ $overrideMap = @(
     }
 )
 
-Function Set-ResultFromTemplate {
-    param($Module, $ADObject)
-    $Module.Result.distinguished_name = $ADObject.DistinguishedName
-    $Module.Result.template_oid = $ADObject.'msPKI-Cert-Template-OID'
-    $Module.Result.display_name = $ADObject.DisplayName
-    $Module.Result.key_size = $ADObject.'msPKI-Minimal-Key-Size'
-    $Module.Result.schema_version = $ADObject.'msPKI-Template-Schema-Version'
-    $Module.Result.enrollment_flag = $ADObject.'msPKI-Enrollment-Flag'
-    $Module.Result.private_key_flag = $ADObject.'msPKI-Private-Key-Flag'
-    $Module.Result.certificate_name_flag = $ADObject.'msPKI-Certificate-Name-Flag'
-    $Module.Result.extended_key_usages = @($ADObject.pKIExtendedKeyUsage)
-    $Module.Result.validity_period_days = ConvertFrom-PeriodByte -Bytes $ADObject.pKIExpirationPeriod
-    $Module.Result.renewal_period_days = ConvertFrom-PeriodByte -Bytes $ADObject.pKIOverlapPeriod
+# Helper functions
+
+Function Resolve-FlagList {
+    param(
+        [object[]]$Values,
+        [hashtable]$FlagMap,
+        [string]$ParamName
+    )
+    $result = 0
+    foreach ($flag in $Values) {
+        $flagInt = 0
+        if ($FlagMap.ContainsKey([string]$flag)) {
+            $flagInt = $FlagMap[[string]$flag]
+        }
+        elseif ([LanguagePrimitives]::TryConvertTo($flag, [int], [ref]$flagInt)) {
+            # raw int or hex string parsed successfully
+        }
+        else {
+            $valid = ($FlagMap.Keys | Sort-Object) -join ", "
+            $module.FailJson("Invalid ${ParamName} value '${flag}'. Valid names: ${valid}, or an integer.")
+        }
+        $result = $result -bor $flagInt
+    }
+    $result
+}
+
+Function Resolve-EkuList {
+    param([object[]]$Values)
+    foreach ($v in $Values) {
+        $s = [string]$v
+        if ($ekuMap.ContainsKey($s)) { $ekuMap[$s] } else { $s }
+    }
+}
+
+Function Resolve-KeyUsageByte {
+    param([object[]]$Values)
+    $bytes = [byte[]]::new(2)
+    foreach ($v in $Values) {
+        $s = [string]$v
+        if (-not $keyUsageMap.ContainsKey($s)) {
+            $valid = ($keyUsageMap.Keys | Sort-Object) -join ", "
+            $module.FailJson("Invalid key_usage value '${s}'. Valid names: ${valid}.")
+        }
+        $entry = $keyUsageMap[$s]
+        $bytes[$entry.Byte] = $bytes[$entry.Byte] -bor $entry.Bit
+    }
+    , $bytes
+}
+
+Function Compare-KeyUsageByte {
+    param([byte[]]$Current, [byte[]]$Desired)
+    if ($null -eq $Current) { return $true }
+    $currentPadded = [byte[]]::new(2)
+    [Array]::Copy($Current, $currentPadded, [Math]::Min($Current.Length, 2))
+    ($currentPadded[0] -ne $Desired[0]) -or ($currentPadded[1] -ne $Desired[1])
 }
 
 # AD stores pKIExpirationPeriod / pKIOverlapPeriod as 8-byte little-endian
-# negative FILETIME intervals (100-nanosecond units). These helpers convert
-# between that encoding and a human-readable day count.
+# negative FILETIME intervals (100-nanosecond units).
 # 864000000000 = 1 day in 100ns units (24 * 60 * 60 * 10,000,000).
 Function ConvertTo-PeriodByte {
     <#
@@ -225,7 +342,9 @@ Function New-TemplateOID {
     do {
         $part1 = Get-Random -Minimum 10000000 -Maximum 99999999
         $part2 = Get-Random -Minimum 10000000 -Maximum 99999999
-        $hex = -join ((1..32) | ForEach-Object { '{0:X}' -f (Get-Random -Minimum 0 -Maximum 16) })
+        $hex = -join ((1..32) | ForEach-Object {
+            '{0:X}' -f (Get-Random -Minimum 0 -Maximum 16)
+        })
         $templateOID = "$forestOID.$part1.$part2"
         $oidCN = "$part2.$hex"
 
@@ -261,7 +380,7 @@ catch {
 
 if ($state -eq 'present') {
     if (-not $existingTemplate) {
-        # --- CREATE ---
+        # CREATE
         if (-not $sourceTemplate) {
             $module.FailJson("source_template is required when creating a new certificate template.")
         }
@@ -293,7 +412,7 @@ if ($state -eq 'present') {
             $oidPath = "CN=OID,CN=Public Key Services,CN=Services,$configNC"
             $oidAttrs = @{
                 'DisplayName' = $displayName
-                'flags' = [System.Int32]1
+                'flags' = [int]1
                 'msPKI-Cert-Template-OID' = $oid.TemplateOID
             }
             try {
@@ -304,9 +423,7 @@ if ($state -eq 'present') {
                 $module.FailJson("Failed to create OID object: $_", $_)
             }
 
-            # Clone source attributes into a clean hashtable.
-            # Get-ADObject wraps values in ADPropertyValueCollection; we must
-            # extract raw .NET types or New-ADObject rejects them.
+            # Clone source attributes, extracting raw .NET types from AD wrappers
             $templateAttrs = @{
                 'msPKI-Cert-Template-OID' = $oid.TemplateOID
             }
@@ -329,12 +446,17 @@ if ($state -eq 'present') {
                 }
             }
 
-            # Apply user overrides before creation
+            # Apply user overrides (flags, EKUs, periods, key_size, schema_version)
             foreach ($o in $overrideMap) {
                 $val = $module.Params[$o.Param]
                 if ($null -ne $val) {
                     $templateAttrs[$o.Attr] = & $o.Cast $val
                 }
+            }
+
+            # key_usage override (byte-level, outside overrideMap)
+            if ($null -ne $module.Params.key_usage) {
+                $templateAttrs['pKIKeyUsage'] = Resolve-KeyUsageByte $module.Params.key_usage
             }
 
             try {
@@ -350,37 +472,50 @@ if ($state -eq 'present') {
                 -LDAPFilter "(&(objectClass=pKICertificateTemplate)(cn=$name))" `
                 -Properties ($allTemplateProperties + @('displayName', 'msPKI-Cert-Template-OID'))
 
-            Set-ResultFromTemplate -Module $module -ADObject $existingTemplate
+            $module.Result.distinguished_name = $existingTemplate.DistinguishedName
+            $module.Result.template_oid = $oid.TemplateOID
         }
     }
     else {
-        # Update the template if the display name or any of the properties have changed
-        Set-ResultFromTemplate -Module $module -ADObject $existingTemplate
+        # UPDATE
+        $module.Result.distinguished_name = $existingTemplate.DistinguishedName
+        $module.Result.template_oid = $existingTemplate.'msPKI-Cert-Template-OID'
 
         $replaceAttrs = @{}
 
         if ($displayName -ne $existingTemplate.DisplayName -and $module.Params.display_name) {
             $replaceAttrs['displayName'] = $displayName
         }
+
         foreach ($o in $overrideMap) {
             $desired = $module.Params[$o.Param]
             if ($null -eq $desired) { continue }
 
             $current = $existingTemplate.($o.Attr)
+            $resolvedDesired = & $o.Cast $desired
             $needsUpdate = switch ($o.Param) {
                 'extended_key_usages' {
-                    [bool](Compare-Object -ReferenceObject @($current | Sort-Object) -DifferenceObject @($desired | Sort-Object))
+                    $resolvedOids = [string[]]$resolvedDesired
+                    [bool](Compare-Object -ReferenceObject @($current | Sort-Object) -DifferenceObject @($resolvedOids | Sort-Object))
                 }
                 { $_ -in 'validity_period_days', 'renewal_period_days' } {
                     $desired -ne (ConvertFrom-PeriodByte -Bytes $current)
                 }
                 default {
-                    $desired -ne $current
+                    $resolvedDesired -ne $current
                 }
             }
 
             if ($needsUpdate) {
-                $replaceAttrs[$o.Attr] = & $o.Cast $desired
+                $replaceAttrs[$o.Attr] = $resolvedDesired
+            }
+        }
+
+        # key_usage comparison (byte-level)
+        if ($null -ne $module.Params.key_usage) {
+            $desiredKU = Resolve-KeyUsageByte $module.Params.key_usage
+            if (Compare-KeyUsageByte -Current $existingTemplate.pKIKeyUsage -Desired $desiredKU) {
+                $replaceAttrs['pKIKeyUsage'] = $desiredKU
             }
         }
 
@@ -393,16 +528,8 @@ if ($state -eq 'present') {
                 catch {
                     $module.FailJson("Failed to update certificate template '$name': $_", $_)
                 }
-
-                $existingTemplate = Get-ADObject @adParams `
-                    -SearchBase $templatePath `
-                    -LDAPFilter "(&(objectClass=pKICertificateTemplate)(cn=$name))" `
-                    -Properties ($allTemplateProperties + @('displayName', 'msPKI-Cert-Template-OID'))
-
-                Set-ResultFromTemplate -Module $module -ADObject $existingTemplate
             }
         }
-
     }
 
     # Publish the template to the requested CAs
@@ -461,7 +588,8 @@ if ($state -eq 'present') {
 else {
     # Remove the template if it exists
     if ($existingTemplate) {
-        Set-ResultFromTemplate -Module $module -ADObject $existingTemplate
+        $module.Result.distinguished_name = $existingTemplate.DistinguishedName
+        $module.Result.template_oid = $existingTemplate.'msPKI-Cert-Template-OID'
         $module.Result.changed = $true
 
         if (-not $module.CheckMode) {

--- a/plugins/modules/cs_template.ps1
+++ b/plugins/modules/cs_template.ps1
@@ -88,79 +88,79 @@ if ($module.Params.domain_server) {
 # Name-Value Maps
 
 $ekuMap = @{
-    'server_authentication'     = '1.3.6.1.5.5.7.3.1'
-    'client_authentication'     = '1.3.6.1.5.5.7.3.2'
-    'code_signing'              = '1.3.6.1.5.5.7.3.3'
-    'secure_email'              = '1.3.6.1.5.5.7.3.4'
-    'ip_security_end_system'    = '1.3.6.1.5.5.7.3.5'
-    'ip_security_tunnel'        = '1.3.6.1.5.5.7.3.6'
-    'ip_security_user'          = '1.3.6.1.5.5.7.3.7'
-    'time_stamping'             = '1.3.6.1.5.5.7.3.8'
-    'ocsp_signing'              = '1.3.6.1.5.5.7.3.9'
-    'smart_card_logon'          = '1.3.6.1.4.1.311.20.2.2'
+    'server_authentication' = '1.3.6.1.5.5.7.3.1'
+    'client_authentication' = '1.3.6.1.5.5.7.3.2'
+    'code_signing' = '1.3.6.1.5.5.7.3.3'
+    'secure_email' = '1.3.6.1.5.5.7.3.4'
+    'ip_security_end_system' = '1.3.6.1.5.5.7.3.5'
+    'ip_security_tunnel' = '1.3.6.1.5.5.7.3.6'
+    'ip_security_user' = '1.3.6.1.5.5.7.3.7'
+    'time_stamping' = '1.3.6.1.5.5.7.3.8'
+    'ocsp_signing' = '1.3.6.1.5.5.7.3.9'
+    'smart_card_logon' = '1.3.6.1.4.1.311.20.2.2'
     'certificate_request_agent' = '1.3.6.1.4.1.311.20.2.1'
-    'encrypting_file_system'    = '1.3.6.1.4.1.311.10.3.4'
-    'file_recovery'             = '1.3.6.1.4.1.311.10.3.4.1'
-    'key_recovery'              = '1.3.6.1.4.1.311.10.3.11'
-    'key_recovery_agent'        = '1.3.6.1.4.1.311.21.6'
-    'document_signing'          = '1.3.6.1.4.1.311.10.3.12'
-    'remote_desktop'            = '1.3.6.1.4.1.311.54.1.2'
-    'kdc_authentication'        = '1.3.6.1.5.2.3.5'
+    'encrypting_file_system' = '1.3.6.1.4.1.311.10.3.4'
+    'file_recovery' = '1.3.6.1.4.1.311.10.3.4.1'
+    'key_recovery' = '1.3.6.1.4.1.311.10.3.11'
+    'key_recovery_agent' = '1.3.6.1.4.1.311.21.6'
+    'document_signing' = '1.3.6.1.4.1.311.10.3.12'
+    'remote_desktop' = '1.3.6.1.4.1.311.54.1.2'
+    'kdc_authentication' = '1.3.6.1.5.2.3.5'
 }
 
 $enrollmentFlagMap = @{
-    'include_symmetric_algorithms'            = 0x00000001
-    'pend_all_requests'                       = 0x00000002
-    'publish_to_kra_container'                = 0x00000004
-    'publish_to_ds'                           = 0x00000008
-    'auto_enrollment_check_user_ds_certificate' = 0x00000010
-    'auto_enrollment'                         = 0x00000020
-    'previous_approval_validate_reenrollment' = 0x00000040
+    'include_symmetric_algorithms' = 1
+    'pend_all_requests' = 2
+    'publish_to_kra_container' = 4
+    'publish_to_ds' = 8
+    'auto_enrollment_check_user_ds_certificate' = 16
+    'auto_enrollment' = 32
+    'previous_approval_validate_reenrollment' = 64
 }
 
 $privateKeyFlagMap = @{
-    'require_private_key_archival'          = 0x00000001
-    'exportable_key'                        = 0x00000010
-    'strong_key_protection_required'        = 0x00000020
-    'require_alternate_signature_algorithm' = 0x00000040
-    'require_same_key_renewal'              = 0x00000080
-    'use_legacy_provider'                   = 0x00000100
-    'ek_trust_on_use'                       = 0x00000200
-    'ek_validate_cert'                      = 0x00000400
-    'ek_validate_key'                       = 0x00000800
-    'attest_preferred'                      = 0x00001000
-    'attest_required'                       = 0x00002000
-    'attestation_without_policy'            = 0x00004000
-    'hello_logon_key'                       = 0x00200000
+    'require_private_key_archival' = 1
+    'exportable_key' = 16
+    'strong_key_protection_required' = 32
+    'require_alternate_signature_algorithm' = 64
+    'require_same_key_renewal' = 128
+    'use_legacy_provider' = 256
+    'ek_trust_on_use' = 512
+    'ek_validate_cert' = 1024
+    'ek_validate_key' = 2048
+    'attest_preferred' = 4096
+    'attest_required' = 8192
+    'attestation_without_policy' = 16384
+    'hello_logon_key' = 2097152
 }
 
 $certNameFlagMap = @{
-    'enrollee_supplies_subject'          = 0x00000001
-    'enrollee_supplies_subject_alt_name' = 0x00010000
-    'subject_alt_require_domain_dns'     = 0x00400000
-    'subject_alt_require_spn'            = 0x00800000
-    'subject_alt_require_directory_guid' = 0x01000000
-    'subject_alt_require_upn'            = 0x02000000
-    'subject_alt_require_email'          = 0x04000000
-    'subject_alt_require_dns'            = 0x08000000
-    'subject_require_dns_as_cn'          = 0x10000000
-    'subject_require_email'              = 0x20000000
-    'subject_require_common_name'        = 0x40000000
-    'subject_require_directory_path'     = 0x80000000
+    'enrollee_supplies_subject' = 1
+    'enrollee_supplies_subject_alt_name' = 65536
+    'subject_alt_require_domain_dns' = 4194304
+    'subject_alt_require_spn' = 8388608
+    'subject_alt_require_directory_guid' = 16777216
+    'subject_alt_require_upn' = 33554432
+    'subject_alt_require_email' = 67108864
+    'subject_alt_require_dns' = 134217728
+    'subject_require_dns_as_cn' = 268435456
+    'subject_require_email' = 536870912
+    'subject_require_common_name' = 1073741824
+    'subject_require_directory_path' = -2147483648
 }
 
 # pKIKeyUsage is a byte array using ASN.1 BIT STRING encoding (bits reversed
 # within each byte). Byte 0 holds the first 8 usages, byte 1 holds decipher_only.
 $keyUsageMap = @{
-    'digital_signature' = @{ Byte = 0; Bit = 0x80 }
-    'non_repudiation'   = @{ Byte = 0; Bit = 0x40 }
-    'key_encipherment'  = @{ Byte = 0; Bit = 0x20 }
-    'data_encipherment' = @{ Byte = 0; Bit = 0x10 }
-    'key_agreement'     = @{ Byte = 0; Bit = 0x08 }
-    'key_cert_sign'     = @{ Byte = 0; Bit = 0x04 }
-    'crl_sign'          = @{ Byte = 0; Bit = 0x02 }
-    'encipher_only'     = @{ Byte = 0; Bit = 0x01 }
-    'decipher_only'     = @{ Byte = 1; Bit = 0x80 }
+    'digital_signature' = @{ Byte = 0; Bit = 128 }
+    'non_repudiation' = @{ Byte = 0; Bit = 64 }
+    'key_encipherment' = @{ Byte = 0; Bit = 32 }
+    'data_encipherment' = @{ Byte = 0; Bit = 16 }
+    'key_agreement' = @{ Byte = 0; Bit = 8 }
+    'key_cert_sign' = @{ Byte = 0; Bit = 4 }
+    'crl_sign' = @{ Byte = 0; Bit = 2 }
+    'encipher_only' = @{ Byte = 0; Bit = 1 }
+    'decipher_only' = @{ Byte = 1; Bit = 128 }
 }
 
 $intProperties = @(
@@ -214,17 +214,17 @@ $overrideMap = @(
     @{
         Param = 'enrollment_flag'
         Attr = 'msPKI-Enrollment-Flag'
-        Cast = { param($v) [int](Resolve-FlagList $v $enrollmentFlagMap 'enrollment_flag') }
+        Cast = { param($v) [int](Resolve-FlagList -Values $v -FlagMap $enrollmentFlagMap -ParamName 'enrollment_flag') }
     }
     @{
         Param = 'private_key_flag'
         Attr = 'msPKI-Private-Key-Flag'
-        Cast = { param($v) [int](Resolve-FlagList $v $privateKeyFlagMap 'private_key_flag') }
+        Cast = { param($v) [int](Resolve-FlagList -Values $v -FlagMap $privateKeyFlagMap -ParamName 'private_key_flag') }
     }
     @{
         Param = 'certificate_name_flag'
         Attr = 'msPKI-Certificate-Name-Flag'
-        Cast = { param($v) [int](Resolve-FlagList $v $certNameFlagMap 'certificate_name_flag') }
+        Cast = { param($v) [int](Resolve-FlagList -Values $v -FlagMap $certNameFlagMap -ParamName 'certificate_name_flag') }
     }
     @{
         Param = 'extended_key_usages'
@@ -342,9 +342,7 @@ Function New-TemplateOID {
     do {
         $part1 = Get-Random -Minimum 10000000 -Maximum 99999999
         $part2 = Get-Random -Minimum 10000000 -Maximum 99999999
-        $hex = -join ((1..32) | ForEach-Object {
-            '{0:X}' -f (Get-Random -Minimum 0 -Maximum 16)
-        })
+        $hex = -join (1..32 | ForEach-Object { '{0:X}' -f (Get-Random -Minimum 0 -Maximum 16) })
         $templateOID = "$forestOID.$part1.$part2"
         $oidCN = "$part2.$hex"
 

--- a/plugins/modules/cs_template.ps1
+++ b/plugins/modules/cs_template.ps1
@@ -1,0 +1,517 @@
+#!powershell
+
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        name = @{
+            type = 'str'
+            required = $true
+        }
+        display_name = @{
+            type = 'str'
+        }
+        state = @{
+            type = 'str'
+            default = 'present'
+            choices = @('present', 'absent')
+        }
+        source_template = @{
+            type = 'str'
+        }
+        key_size = @{
+            type = 'int'
+        }
+        extended_key_usages = @{
+            type = 'list'
+            elements = 'str'
+        }
+        key_usage = @{
+            type = 'list'
+            elements = 'str'
+        }
+        validity_period_days = @{
+            type = 'int'
+        }
+        renewal_period_days = @{
+            type = 'int'
+        }
+        enrollment_flag = @{
+            type = 'int'
+        }
+        private_key_flag = @{
+            type = 'int'
+            no_log = $false
+        }
+        certificate_name_flag = @{
+            type = 'int'
+        }
+        schema_version = @{
+            type = 'int'
+            choices = @(2, 3, 4)
+        }
+        publish_to_ca = @{
+            type = 'list'
+            elements = 'str'
+        }
+        domain_server = @{
+            type = 'str'
+        }
+    }
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Result.changed = $false
+$module.Result.distinguished_name = $null
+$module.Result.template_oid = $null
+$module.Result.display_name = $null
+$module.Result.key_size = $null
+$module.Result.schema_version = $null
+$module.Result.enrollment_flag = $null
+$module.Result.private_key_flag = $null
+$module.Result.certificate_name_flag = $null
+$module.Result.extended_key_usages = @()
+$module.Result.validity_period_days = $null
+$module.Result.renewal_period_days = $null
+
+$name = $module.Params.name
+$displayName = if ($module.Params.display_name) { $module.Params.display_name } else { $name }
+$state = $module.Params.state
+$sourceTemplate = $module.Params.source_template
+
+$adParams = @{}
+if ($module.Params.domain_server) {
+    $adParams.Server = $module.Params.domain_server
+}
+
+# Integer properties on the template that we clone and can override
+$intProperties = @(
+    'flags'
+    'revision'
+    'pKIDefaultKeySpec'
+    'pKIMaxIssuingDepth'
+    'msPKI-RA-Signature'
+    'msPKI-Enrollment-Flag'
+    'msPKI-Private-Key-Flag'
+    'msPKI-Certificate-Name-Flag'
+    'msPKI-Minimal-Key-Size'
+    'msPKI-Template-Schema-Version'
+    'msPKI-Template-Minor-Revision'
+)
+
+# Collection (multi-valued string) properties
+$collectionProperties = @(
+    'pKIExtendedKeyUsage'
+    'pKICriticalExtensions'
+    'pKIDefaultCSPs'
+    'msPKI-Certificate-Application-Policy'
+    'msPKI-RA-Application-Policies'
+)
+
+# Byte-array properties
+$byteProperties = @(
+    'pKIExpirationPeriod'
+    'pKIOverlapPeriod'
+    'pKIKeyUsage'
+)
+
+$allTemplateProperties = $intProperties + $collectionProperties + $byteProperties
+
+# Maps module params to LDAP attributes with type casting and comparison logic.
+# Used for both create (override cloned values) and update (idempotent set).
+$overrideMap = @(
+    @{
+        Param = 'key_size'
+        Attr = 'msPKI-Minimal-Key-Size'
+        Cast = { param($v) [System.Int32]$v }
+    }
+    @{
+        Param = 'schema_version'
+        Attr = 'msPKI-Template-Schema-Version'
+        Cast = { param($v) [System.Int32]$v }
+    }
+    @{
+        Param = 'enrollment_flag'
+        Attr = 'msPKI-Enrollment-Flag'
+        Cast = { param($v) [System.Int32]$v }
+    }
+    @{
+        Param = 'private_key_flag'
+        Attr = 'msPKI-Private-Key-Flag'
+        Cast = { param($v) [System.Int32]$v }
+    }
+    @{
+        Param = 'certificate_name_flag'
+        Attr = 'msPKI-Certificate-Name-Flag'
+        Cast = { param($v) [System.Int32]$v }
+    }
+    @{
+        Param = 'extended_key_usages'
+        Attr = 'pKIExtendedKeyUsage'
+        Cast = { param($v) , [string[]]$v }
+    }
+    @{
+        Param = 'validity_period_days'
+        Attr = 'pKIExpirationPeriod'
+        Cast = { param($v) , [byte[]](ConvertTo-PeriodByte -Days $v) }
+    }
+    @{
+        Param = 'renewal_period_days'
+        Attr = 'pKIOverlapPeriod'
+        Cast = { param($v) , [byte[]](ConvertTo-PeriodByte -Days $v) }
+    }
+)
+
+Function Set-ResultFromTemplate {
+    param($Module, $ADObject)
+    $Module.Result.distinguished_name = $ADObject.DistinguishedName
+    $Module.Result.template_oid = $ADObject.'msPKI-Cert-Template-OID'
+    $Module.Result.display_name = $ADObject.DisplayName
+    $Module.Result.key_size = $ADObject.'msPKI-Minimal-Key-Size'
+    $Module.Result.schema_version = $ADObject.'msPKI-Template-Schema-Version'
+    $Module.Result.enrollment_flag = $ADObject.'msPKI-Enrollment-Flag'
+    $Module.Result.private_key_flag = $ADObject.'msPKI-Private-Key-Flag'
+    $Module.Result.certificate_name_flag = $ADObject.'msPKI-Certificate-Name-Flag'
+    $Module.Result.extended_key_usages = @($ADObject.pKIExtendedKeyUsage)
+    $Module.Result.validity_period_days = ConvertFrom-PeriodByte -Bytes $ADObject.pKIExpirationPeriod
+    $Module.Result.renewal_period_days = ConvertFrom-PeriodByte -Bytes $ADObject.pKIOverlapPeriod
+}
+
+# AD stores pKIExpirationPeriod / pKIOverlapPeriod as 8-byte little-endian
+# negative FILETIME intervals (100-nanosecond units). These helpers convert
+# between that encoding and a human-readable day count.
+# 864000000000 = 1 day in 100ns units (24 * 60 * 60 * 10,000,000).
+Function ConvertTo-PeriodByte {
+    <#
+    .SYNOPSIS
+    Converts days to the 8-byte negative FILETIME interval used by
+    pKIExpirationPeriod and pKIOverlapPeriod.
+    #>
+    param([int]$Days)
+    [System.BitConverter]::GetBytes([Int64](-$Days * 864000000000))
+}
+
+Function ConvertFrom-PeriodByte {
+    <#
+    .SYNOPSIS
+    Converts pKIExpirationPeriod / pKIOverlapPeriod bytes back to days.
+    #>
+    param([byte[]]$Bytes)
+    if ($null -eq $Bytes -or $Bytes.Length -ne 8) { return $null }
+    $ticks = [System.BitConverter]::ToInt64($Bytes, 0)
+    [Math]::Round(-$ticks / 864000000000)
+}
+
+Function New-TemplateOID {
+    <#
+    .SYNOPSIS
+    Generates a unique OID and CN for a new certificate template,
+    using the forest base OID from the OID container.
+    #>
+    param(
+        [hashtable]$ADParams,
+        [string]$ConfigNC
+    )
+
+    $oidPath = "CN=OID,CN=Public Key Services,CN=Services,$ConfigNC"
+    $forestOID = Get-ADObject @ADParams -Identity $oidPath -Properties 'msPKI-Cert-Template-OID' |
+        Select-Object -ExpandProperty 'msPKI-Cert-Template-OID'
+
+    do {
+        $part1 = Get-Random -Minimum 10000000 -Maximum 99999999
+        $part2 = Get-Random -Minimum 10000000 -Maximum 99999999
+        $hex = -join ((1..32) | ForEach-Object { '{0:X}' -f (Get-Random -Minimum 0 -Maximum 16) })
+        $templateOID = "$forestOID.$part1.$part2"
+        $oidCN = "$part2.$hex"
+
+        $existing = Get-ADObject @ADParams `
+            -SearchBase $oidPath `
+            -Filter { cn -eq $oidCN -and msPKI-Cert-Template-OID -eq $templateOID }
+    } until ($null -eq $existing)
+
+    @{
+        TemplateOID = $templateOID
+        OIDCN = $oidCN
+    }
+}
+
+try {
+    $configNC = (Get-ADRootDSE @adParams).configurationNamingContext
+}
+catch {
+    $module.FailJson("Failed to get AD configuration: $_", $_)
+}
+
+$templatePath = "CN=Certificate Templates,CN=Public Key Services,CN=Services,$configNC"
+
+try {
+    $existingTemplate = Get-ADObject @adParams `
+        -SearchBase $templatePath `
+        -LDAPFilter "(&(objectClass=pKICertificateTemplate)(cn=$name))" `
+        -Properties ($allTemplateProperties + @('displayName', 'msPKI-Cert-Template-OID'))
+}
+catch {
+    $module.FailJson("Failed to search for existing template '$name': $_", $_)
+}
+
+if ($state -eq 'present') {
+    if (-not $existingTemplate) {
+        # --- CREATE ---
+        if (-not $sourceTemplate) {
+            $module.FailJson("source_template is required when creating a new certificate template.")
+        }
+
+        try {
+            $source = Get-ADObject @adParams `
+                -SearchBase $templatePath `
+                -LDAPFilter "(&(objectClass=pKICertificateTemplate)(displayName=$sourceTemplate))" `
+                -Properties ($allTemplateProperties + @('displayName'))
+        }
+        catch {
+            $module.FailJson("Failed to find source template '$sourceTemplate': $_", $_)
+        }
+        if (-not $source) {
+            $module.FailJson("Source template '$sourceTemplate' not found in $templatePath.")
+        }
+
+        $module.Result.changed = $true
+
+        if (-not $module.CheckMode) {
+            try {
+                $oid = New-TemplateOID -ADParams $adParams -ConfigNC $configNC
+            }
+            catch {
+                $module.FailJson("Failed to generate template OID: $_", $_)
+            }
+
+            # Create the OID registration object
+            $oidPath = "CN=OID,CN=Public Key Services,CN=Services,$configNC"
+            $oidAttrs = @{
+                'DisplayName' = $displayName
+                'flags' = [System.Int32]1
+                'msPKI-Cert-Template-OID' = $oid.TemplateOID
+            }
+            try {
+                New-ADObject @adParams -Path $oidPath -OtherAttributes $oidAttrs `
+                    -Name $oid.OIDCN -Type 'msPKI-Enterprise-Oid'
+            }
+            catch {
+                $module.FailJson("Failed to create OID object: $_", $_)
+            }
+
+            # Clone source attributes into a clean hashtable.
+            # Get-ADObject wraps values in ADPropertyValueCollection; we must
+            # extract raw .NET types or New-ADObject rejects them.
+            $templateAttrs = @{
+                'msPKI-Cert-Template-OID' = $oid.TemplateOID
+            }
+            foreach ($prop in $intProperties) {
+                $raw = $source.$prop
+                if ($null -ne $raw) {
+                    $templateAttrs[$prop] = [int]$raw
+                }
+            }
+            foreach ($prop in $collectionProperties) {
+                $val = [string[]]@($source.$prop | Where-Object { $_ })
+                if ($val.Count -gt 0) {
+                    $templateAttrs[$prop] = $val
+                }
+            }
+            foreach ($prop in $byteProperties) {
+                $raw = $source.$prop
+                if ($null -ne $raw) {
+                    $templateAttrs[$prop] = [byte[]]$raw
+                }
+            }
+
+            # Apply user overrides before creation
+            foreach ($o in $overrideMap) {
+                $val = $module.Params[$o.Param]
+                if ($null -ne $val) {
+                    $templateAttrs[$o.Attr] = & $o.Cast $val
+                }
+            }
+
+            try {
+                New-ADObject @adParams -Path $templatePath -OtherAttributes $templateAttrs `
+                    -Name $name -DisplayName $displayName -Type 'pKICertificateTemplate'
+            }
+            catch {
+                $module.FailJson("Failed to create certificate template '$name': $_", $_)
+            }
+
+            $existingTemplate = Get-ADObject @adParams `
+                -SearchBase $templatePath `
+                -LDAPFilter "(&(objectClass=pKICertificateTemplate)(cn=$name))" `
+                -Properties ($allTemplateProperties + @('displayName', 'msPKI-Cert-Template-OID'))
+
+            Set-ResultFromTemplate -Module $module -ADObject $existingTemplate
+        }
+    }
+    else {
+        # Update the template if the display name or any of the properties have changed
+        Set-ResultFromTemplate -Module $module -ADObject $existingTemplate
+
+        $replaceAttrs = @{}
+
+        if ($displayName -ne $existingTemplate.DisplayName -and $module.Params.display_name) {
+            $replaceAttrs['displayName'] = $displayName
+        }
+        foreach ($o in $overrideMap) {
+            $desired = $module.Params[$o.Param]
+            if ($null -eq $desired) { continue }
+
+            $current = $existingTemplate.($o.Attr)
+            $needsUpdate = switch ($o.Param) {
+                'extended_key_usages' {
+                    [bool](Compare-Object -ReferenceObject @($current | Sort-Object) -DifferenceObject @($desired | Sort-Object))
+                }
+                { $_ -in 'validity_period_days', 'renewal_period_days' } {
+                    $desired -ne (ConvertFrom-PeriodByte -Bytes $current)
+                }
+                default {
+                    $desired -ne $current
+                }
+            }
+
+            if ($needsUpdate) {
+                $replaceAttrs[$o.Attr] = & $o.Cast $desired
+            }
+        }
+
+        if ($replaceAttrs.Count -gt 0) {
+            $module.Result.changed = $true
+            if (-not $module.CheckMode) {
+                try {
+                    Set-ADObject @adParams -Identity $existingTemplate.DistinguishedName -Replace $replaceAttrs
+                }
+                catch {
+                    $module.FailJson("Failed to update certificate template '$name': $_", $_)
+                }
+
+                $existingTemplate = Get-ADObject @adParams `
+                    -SearchBase $templatePath `
+                    -LDAPFilter "(&(objectClass=pKICertificateTemplate)(cn=$name))" `
+                    -Properties ($allTemplateProperties + @('displayName', 'msPKI-Cert-Template-OID'))
+
+                Set-ResultFromTemplate -Module $module -ADObject $existingTemplate
+            }
+        }
+
+    }
+
+    # Publish the template to the requested CAs
+    if ($null -ne $module.Params.publish_to_ca) {
+        $enrollmentPath = "CN=Enrollment Services,CN=Public Key Services,CN=Services,$configNC"
+        try {
+            $allCAs = @(Get-ADObject @adParams -SearchBase $enrollmentPath `
+                    -SearchScope OneLevel -Filter * -Properties certificateTemplates)
+        }
+        catch {
+            $module.FailJson("Failed to enumerate Certificate Authorities: $_", $_)
+        }
+
+        $desiredCANames = @($module.Params.publish_to_ca)
+
+        foreach ($ca in $allCAs) {
+            $currentTemplates = @($ca.certificateTemplates)
+            $isPublished = $currentTemplates -contains $name
+            $shouldBePublished = $desiredCANames -contains $ca.Name
+
+            if ($shouldBePublished -and -not $isPublished) {
+                $module.Result.changed = $true
+                if (-not $module.CheckMode) {
+                    try {
+                        Set-ADObject @adParams -Identity $ca.DistinguishedName `
+                            -Add @{ certificateTemplates = $name }
+                    }
+                    catch {
+                        $module.FailJson("Failed to publish template to CA '$($ca.Name)': $_", $_)
+                    }
+                }
+            }
+            elseif (-not $shouldBePublished -and $isPublished) {
+                $module.Result.changed = $true
+                if (-not $module.CheckMode) {
+                    try {
+                        Set-ADObject @adParams -Identity $ca.DistinguishedName `
+                            -Remove @{ certificateTemplates = $name }
+                    }
+                    catch {
+                        $module.FailJson("Failed to unpublish template from CA '$($ca.Name)': $_", $_)
+                    }
+                }
+            }
+        }
+
+        # Validate that all requested CAs exist
+        $knownCANames = @($allCAs | ForEach-Object { $_.Name })
+        foreach ($caName in $desiredCANames) {
+            if ($knownCANames -notcontains $caName) {
+                $module.Warn("Certificate Authority '$caName' was not found in Enrollment Services.")
+            }
+        }
+    }
+}
+else {
+    # Remove the template if it exists
+    if ($existingTemplate) {
+        Set-ResultFromTemplate -Module $module -ADObject $existingTemplate
+        $module.Result.changed = $true
+
+        if (-not $module.CheckMode) {
+            # Unpublish from all CAs
+            $enrollmentPath = "CN=Enrollment Services,CN=Public Key Services,CN=Services,$configNC"
+            try {
+                $allCAs = @(Get-ADObject @adParams -SearchBase $enrollmentPath `
+                        -SearchScope OneLevel -Filter * -Properties certificateTemplates)
+            }
+            catch {
+                $module.FailJson("Failed to enumerate CAs for unpublishing: $_", $_)
+            }
+
+            foreach ($ca in $allCAs) {
+                if (@($ca.certificateTemplates) -contains $name) {
+                    try {
+                        Set-ADObject @adParams -Identity $ca.DistinguishedName `
+                            -Remove @{ certificateTemplates = $name }
+                    }
+                    catch {
+                        $module.FailJson("Failed to unpublish template from CA '$($ca.Name)': $_", $_)
+                    }
+                }
+            }
+
+            # Remove the template object
+            try {
+                Remove-ADObject @adParams -Identity $existingTemplate.DistinguishedName -Confirm:$false
+            }
+            catch {
+                $module.FailJson("Failed to remove certificate template '$name': $_", $_)
+            }
+
+            # Remove the OID object
+            $templateOID = $existingTemplate.'msPKI-Cert-Template-OID'
+            if ($templateOID) {
+                $oidPath = "CN=OID,CN=Public Key Services,CN=Services,$configNC"
+                try {
+                    $oidObj = Get-ADObject @adParams -SearchBase $oidPath `
+                        -LDAPFilter "(msPKI-Cert-Template-OID=$templateOID)"
+                    if ($oidObj) {
+                        Remove-ADObject @adParams -Identity $oidObj.DistinguishedName -Confirm:$false
+                    }
+                }
+                catch {
+                    $module.Warn("Failed to remove OID object for template '$name': $_")
+                }
+            }
+        }
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/cs_template.yml
+++ b/plugins/modules/cs_template.yml
@@ -1,0 +1,248 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: cs_template
+  short_description: Manage AD Certificate Services certificate templates
+  version_added: 1.11.0
+  description:
+    - Create, modify, or remove Active Directory Certificate Services (AD CS)
+      certificate templates.
+    - New templates are created by cloning an existing source template and
+      overriding specific properties such as key size, extended key usages,
+      or validity period.
+    - Templates can optionally be published to (or unpublished from) one or
+      more Enterprise Certificate Authorities.
+  options:
+    name:
+      description:
+        - The CN (common name) of the certificate template.
+        - This is the unique short name used internally by AD CS (no spaces).
+      type: str
+      required: true
+    display_name:
+      description:
+        - The human-readable display name of the template.
+        - Defaults to the value of O(name) if not specified.
+      type: str
+    state:
+      description:
+        - Whether the template should be present or absent.
+        - When V(absent), the template is unpublished from all CAs, the
+          template AD object is removed.
+      type: str
+      default: present
+      choices: [present, absent]
+    source_template:
+      description:
+        - The display name of an existing template to clone when creating
+          a new template (e.g. V(WebServer), V(User), V(Computer)).
+        - Required when creating a template for the first time.
+        - Ignored when the template already exists (updates are applied
+          in-place).
+      type: str
+    key_size:
+      description:
+        - Minimum key size in bits for the certificate.
+        - Maps to the C(msPKI-Minimal-Key-Size) LDAP attribute.
+      type: int
+    extended_key_usages:
+      description:
+        - List of Extended Key Usage (EKU) OID strings.
+        - Maps to the C(pKIExtendedKeyUsage) LDAP attribute.
+      type: list
+      elements: str
+    key_usage:
+      description:
+        - List of key usage values.
+        - Maps to the C(pKIKeyUsage) LDAP attribute.
+      type: list
+      elements: str
+    validity_period_days:
+      description:
+        - Certificate validity period in days.
+        - Maps to the C(pKIExpirationPeriod) LDAP attribute.
+      type: int
+    renewal_period_days:
+      description:
+        - Certificate renewal overlap period in days.
+        - Maps to the C(pKIOverlapPeriod) LDAP attribute.
+      type: int
+    enrollment_flag:
+      description:
+        - Raw bitmask value for the C(msPKI-Enrollment-Flag) attribute.
+        - Controls enrollment behavior such as requiring CA manager
+          approval or including symmetric algorithms.
+      type: int
+    private_key_flag:
+      description:
+        - Raw bitmask value for the C(msPKI-Private-Key-Flag) attribute.
+        - Controls private key handling such as exportability and archival.
+      type: int
+    certificate_name_flag:
+      description:
+        - Raw bitmask value for the C(msPKI-Certificate-Name-Flag) attribute.
+        - Controls how the certificate subject name is constructed.
+      type: int
+    schema_version:
+      description:
+        - Certificate template schema version.
+        - V(2) requires Windows Server 2003+, V(3) requires 2008+,
+          V(4) requires 2012+.
+        - Maps to the C(msPKI-Template-Schema-Version) LDAP attribute.
+      type: int
+      choices: [2, 3, 4]
+    publish_to_ca:
+      description:
+        - List of Enterprise CA short names to which the template should
+          be published.
+        - When specified, the module ensures the template is published to
+          exactly the listed CAs and unpublished from any others.
+        - An empty list V([]) will unpublish the template from all CAs.
+        - When omitted, publishing state is not managed.
+      type: list
+      elements: str
+    domain_server:
+      description:
+        - The FQDN of the domain controller to target for all AD operations.
+        - When not specified, the module will use the default domain
+          controller discovery.
+      type: str
+
+  notes:
+    - This module must be run on a Windows target host with the
+      ActiveDirectory PowerShell module available.
+    - Enterprise Administrator permissions are required to create or
+      remove certificate templates in the Configuration partition.
+    - Certificate templates are stored in the AD Configuration partition.
+    - Publishing a template requires that at least one Enterprise CA
+      is installed in the forest, but the module does not need to run
+      on the CA server itself.
+  seealso:
+    - module: microsoft.ad.object_info
+  extends_documentation_fragment:
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: none
+    platform:
+      platforms:
+        - windows
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Create a certificate template cloned from WebServer with RSA 4096
+    microsoft.ad.cs_template:
+      name: Web4096Secure
+      display_name: Web Server (RSA 4096)
+      source_template: Web Server
+      key_size: 4096
+      validity_period_days: 365
+      renewal_period_days: 42
+      state: present
+
+  - name: Create a template with specific EKUs for server authentication
+    microsoft.ad.cs_template:
+      name: ServerAuth4096
+      display_name: Server Auth (4096-bit)
+      source_template: Web Server
+      key_size: 4096
+      extended_key_usages:
+        - "1.3.6.1.5.5.7.3.1"
+      state: present
+
+  - name: Update key size on an existing template
+    microsoft.ad.cs_template:
+      name: Web4096Secure
+      key_size: 8192
+      state: present
+
+  - name: Publish a template to a specific CA
+    microsoft.ad.cs_template:
+      name: Web4096Secure
+      publish_to_ca:
+        - contoso-DC01-CA
+      state: present
+
+  - name: Unpublish a template from all CAs
+    microsoft.ad.cs_template:
+      name: Web4096Secure
+      publish_to_ca: []
+      state: present
+
+  - name: Remove a certificate template
+    microsoft.ad.cs_template:
+      name: Web4096Secure
+      state: absent
+
+RETURN:
+  distinguished_name:
+    description:
+      - The distinguished name of the certificate template object.
+    returned: always
+    type: str
+    sample: "CN=Web4096Secure,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com"
+  template_oid:
+    description:
+      - The OID of the certificate template.
+    returned: always
+    type: str
+    sample: "1.3.6.1.4.1.311.21.8.11489019.14294623.5588661.594850.12204198.151.6616009.14891906"
+  display_name:
+    description:
+      - The display name of the certificate template.
+    returned: always
+    type: str
+    sample: "Web Server (RSA 4096)"
+  key_size:
+    description:
+      - The minimum key size in bits.
+    returned: always
+    type: int
+    sample: 4096
+  schema_version:
+    description:
+      - The template schema version.
+    returned: always
+    type: int
+    sample: 2
+  enrollment_flag:
+    description:
+      - The C(msPKI-Enrollment-Flag) bitmask value.
+    returned: always
+    type: int
+    sample: 0
+  private_key_flag:
+    description:
+      - The C(msPKI-Private-Key-Flag) bitmask value.
+    returned: always
+    type: int
+    sample: 16842752
+  certificate_name_flag:
+    description:
+      - The C(msPKI-Certificate-Name-Flag) bitmask value.
+    returned: always
+    type: int
+    sample: 134217728
+  extended_key_usages:
+    description:
+      - The list of Extended Key Usage OID strings.
+    returned: always
+    type: list
+    elements: str
+    sample: ["1.3.6.1.5.5.7.3.1"]
+  validity_period_days:
+    description:
+      - The certificate validity period in days.
+    returned: always
+    type: int
+    sample: 365
+  renewal_period_days:
+    description:
+      - The certificate renewal overlap period in days.
+    returned: always
+    type: int
+    sample: 42

--- a/plugins/modules/cs_template.yml
+++ b/plugins/modules/cs_template.yml
@@ -48,14 +48,26 @@ DOCUMENTATION:
       type: int
     extended_key_usages:
       description:
-        - List of Extended Key Usage (EKU) OID strings.
+        - List of Extended Key Usage (EKU) values.
+        - Each value can be a well-known name or a raw OID string.
         - Maps to the C(pKIExtendedKeyUsage) LDAP attribute.
+        - "Well-known names: V(server_authentication), V(client_authentication),
+          V(code_signing), V(secure_email), V(ip_security_end_system),
+          V(ip_security_tunnel), V(ip_security_user), V(time_stamping),
+          V(ocsp_signing), V(smart_card_logon), V(certificate_request_agent),
+          V(encrypting_file_system), V(file_recovery), V(key_recovery),
+          V(key_recovery_agent), V(document_signing), V(remote_desktop),
+          V(kdc_authentication)."
       type: list
       elements: str
     key_usage:
       description:
-        - List of key usage values.
+        - List of key usage flags to set on the template.
         - Maps to the C(pKIKeyUsage) LDAP attribute.
+        - "Valid values: V(digital_signature), V(non_repudiation),
+          V(key_encipherment), V(data_encipherment), V(key_agreement),
+          V(key_cert_sign), V(crl_sign), V(encipher_only),
+          V(decipher_only)."
       type: list
       elements: str
     validity_period_days:
@@ -70,20 +82,48 @@ DOCUMENTATION:
       type: int
     enrollment_flag:
       description:
-        - Raw bitmask value for the C(msPKI-Enrollment-Flag) attribute.
-        - Controls enrollment behavior such as requiring CA manager
-          approval or including symmetric algorithms.
-      type: int
+        - List of enrollment flag values to set on the template.
+        - Each value can be a well-known name or a raw integer (decimal or hex).
+        - Multiple values are combined with bitwise OR.
+        - Maps to the C(msPKI-Enrollment-Flag) LDAP attribute.
+        - "Well-known names: V(include_symmetric_algorithms),
+          V(pend_all_requests), V(publish_to_kra_container),
+          V(publish_to_ds), V(auto_enrollment_check_user_ds_certificate),
+          V(auto_enrollment),
+          V(previous_approval_validate_reenrollment)."
+      type: list
+      elements: str
     private_key_flag:
       description:
-        - Raw bitmask value for the C(msPKI-Private-Key-Flag) attribute.
-        - Controls private key handling such as exportability and archival.
-      type: int
+        - List of private key flag values to set on the template.
+        - Each value can be a well-known name or a raw integer (decimal or hex).
+        - Multiple values are combined with bitwise OR.
+        - Maps to the C(msPKI-Private-Key-Flag) LDAP attribute.
+        - "Well-known names: V(require_private_key_archival),
+          V(exportable_key), V(strong_key_protection_required),
+          V(require_alternate_signature_algorithm),
+          V(require_same_key_renewal), V(use_legacy_provider),
+          V(ek_trust_on_use), V(ek_validate_cert), V(ek_validate_key),
+          V(attest_preferred), V(attest_required),
+          V(attestation_without_policy), V(hello_logon_key)."
+      type: list
+      elements: str
     certificate_name_flag:
       description:
-        - Raw bitmask value for the C(msPKI-Certificate-Name-Flag) attribute.
-        - Controls how the certificate subject name is constructed.
-      type: int
+        - List of certificate name flag values to set on the template.
+        - Each value can be a well-known name or a raw integer (decimal or hex).
+        - Multiple values are combined with bitwise OR.
+        - Maps to the C(msPKI-Certificate-Name-Flag) LDAP attribute.
+        - "Well-known names: V(enrollee_supplies_subject),
+          V(enrollee_supplies_subject_alt_name),
+          V(subject_alt_require_domain_dns), V(subject_alt_require_spn),
+          V(subject_alt_require_directory_guid),
+          V(subject_alt_require_upn), V(subject_alt_require_email),
+          V(subject_alt_require_dns), V(subject_require_dns_as_cn),
+          V(subject_require_email), V(subject_require_common_name),
+          V(subject_require_directory_path)."
+      type: list
+      elements: str
     schema_version:
       description:
         - Certificate template schema version.
@@ -114,7 +154,8 @@ DOCUMENTATION:
       ActiveDirectory PowerShell module available.
     - Enterprise Administrator permissions are required to create or
       remove certificate templates in the Configuration partition.
-    - Certificate templates are stored in the AD Configuration partition.
+    - Certificate templates are stored in the AD Configuration partition
+      and replicated forest-wide.
     - Publishing a template requires that at least one Enterprise CA
       is installed in the forest, but the module does not need to run
       on the CA server itself.
@@ -140,18 +181,38 @@ EXAMPLES: |
       display_name: Web Server (RSA 4096)
       source_template: Web Server
       key_size: 4096
+      extended_key_usages:
+        - server_authentication
+      key_usage:
+        - digital_signature
+        - key_encipherment
+      private_key_flag:
+        - exportable_key
+      certificate_name_flag:
+        - enrollee_supplies_subject
       validity_period_days: 365
       renewal_period_days: 42
       state: present
 
   - name: Create a template with specific EKUs for server authentication
     microsoft.ad.cs_template:
-      name: ServerAuth4096
-      display_name: Server Auth (4096-bit)
+      name: CustomAuth
       source_template: Web Server
-      key_size: 4096
       extended_key_usages:
-        - "1.3.6.1.5.5.7.3.1"
+        - server_authentication
+        - "1.3.6.1.4.1.311.20.2.2"
+      state: present
+
+  - name: Use raw integer flags alongside named flags
+    microsoft.ad.cs_template:
+      name: MixedFlags
+      source_template: Web Server
+      enrollment_flag:
+        - auto_enrollment
+        - publish_to_ds
+      private_key_flag:
+        - exportable_key
+        - 0x00000100
       state: present
 
   - name: Update key size on an existing template
@@ -191,58 +252,3 @@ RETURN:
     returned: always
     type: str
     sample: "1.3.6.1.4.1.311.21.8.11489019.14294623.5588661.594850.12204198.151.6616009.14891906"
-  display_name:
-    description:
-      - The display name of the certificate template.
-    returned: always
-    type: str
-    sample: "Web Server (RSA 4096)"
-  key_size:
-    description:
-      - The minimum key size in bits.
-    returned: always
-    type: int
-    sample: 4096
-  schema_version:
-    description:
-      - The template schema version.
-    returned: always
-    type: int
-    sample: 2
-  enrollment_flag:
-    description:
-      - The C(msPKI-Enrollment-Flag) bitmask value.
-    returned: always
-    type: int
-    sample: 0
-  private_key_flag:
-    description:
-      - The C(msPKI-Private-Key-Flag) bitmask value.
-    returned: always
-    type: int
-    sample: 16842752
-  certificate_name_flag:
-    description:
-      - The C(msPKI-Certificate-Name-Flag) bitmask value.
-    returned: always
-    type: int
-    sample: 134217728
-  extended_key_usages:
-    description:
-      - The list of Extended Key Usage OID strings.
-    returned: always
-    type: list
-    elements: str
-    sample: ["1.3.6.1.5.5.7.3.1"]
-  validity_period_days:
-    description:
-      - The certificate validity period in days.
-    returned: always
-    type: int
-    sample: 365
-  renewal_period_days:
-    description:
-      - The certificate renewal overlap period in days.
-    returned: always
-    type: int
-    sample: 42

--- a/tests/integration/targets/cs_template/aliases
+++ b/tests/integration/targets/cs_template/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/cs_template/meta/main.yml
+++ b/tests/integration/targets/cs_template/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- name: setup_domain

--- a/tests/integration/targets/cs_template/meta/main.yml
+++ b/tests/integration/targets/cs_template/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
 - name: setup_domain
+- name: setup_adcs

--- a/tests/integration/targets/cs_template/tasks/main.yml
+++ b/tests/integration/targets/cs_template/tasks/main.yml
@@ -1,46 +1,6 @@
 ---
-# AD CS (AD-Certificate feature) must be installed and an Enterprise Root CA
-# configured before running these tests. This mirrors the setup in
-# tests/integration/targets/inventory_ldap/roles/setup_certificate/tasks/main.yml
 
-- name: Setup - ensure AD CS feature is installed
-  ansible.windows.win_feature:
-    name: AD-Certificate
-    state: present
-  register: _adcs_feature
-
-- name: Setup - reboot after AD CS install
-  ansible.windows.win_reboot:
-  when: _adcs_feature.reboot_required
-
-- name: Setup - configure Enterprise Root CA
-  ansible.windows.win_powershell:
-    script: |
-      $ErrorActionPreference = 'Stop'
-      $Ansible.Changed = $false
-
-      $caParams = @{
-          CAType             = 'EnterpriseRootCa'
-          CryptoProviderName = 'RSA#Microsoft Software Key Storage Provider'
-          KeyLength          = 2048
-          HashAlgorithmName  = 'SHA256'
-          Force              = $true
-      }
-      try {
-          Install-AdcsCertificationAuthority @caParams
-          $Ansible.Changed = $true
-      }
-      catch [Microsoft.CertificateServices.Deployment.Common.CertificateServicesBaseSetupException] {
-          if ($_.Exception.Message -like 'The Certification Authority is already installed.*') {
-              return
-          }
-          throw
-      }
-  become: true
-  become_method: ansible.builtin.runas
-  become_user: SYSTEM
-
-- name: Setup - get CA name for publish tests
+- name: Get CA name for publish tests
   ansible.windows.win_powershell:
     script: |
       $configNC = (Get-ADRootDSE).configurationNamingContext
@@ -49,7 +9,7 @@
       $Ansible.Result = $ca.Name
   register: _ca_info
 
-- name: Setup - set CA name fact
+- name: Set CA name fact
   ansible.builtin.set_fact:
     test_ca_name: "{{ _ca_info.result }}"
 
@@ -63,6 +23,9 @@
         key_size: 4096
         validity_period_days: 365
         renewal_period_days: 42
+        key_usage:
+          - digital_signature
+          - key_encipherment
         state: present
       register: _create_check
       check_mode: true
@@ -94,6 +57,9 @@
         key_size: 4096
         validity_period_days: 365
         renewal_period_days: 42
+        key_usage:
+          - digital_signature
+          - key_encipherment
         state: present
       register: _create
 
@@ -114,6 +80,9 @@
         key_size: 4096
         validity_period_days: 365
         renewal_period_days: 42
+        key_usage:
+          - digital_signature
+          - key_encipherment
         state: present
       register: _create_idem
 
@@ -146,28 +115,13 @@
         that:
           - _modify_idem is not changed
 
-    - name: Verify key size was actually updated
-      ansible.windows.win_powershell:
-        script: |
-          $configNC = (Get-ADRootDSE).configurationNamingContext
-          $path = "CN=Certificate Templates,CN=Public Key Services,CN=Services,$configNC"
-          $t = Get-ADObject -SearchBase $path `
-            -LDAPFilter '(&(objectClass=pKICertificateTemplate)(cn=AnsibleTestTemplate))' `
-            -Properties 'msPKI-Minimal-Key-Size'
-          $Ansible.Result = $t.'msPKI-Minimal-Key-Size'
-      register: _verify_key_size
-
-    - name: Assert key size is 8192
-      ansible.builtin.assert:
-        that:
-          - _verify_key_size.result == 8192
-
-    - name: Set extended key usages
+    # ---- MODIFY EKU with named values ----
+    - name: Set EKUs using human-readable names
       microsoft.ad.cs_template:
         name: AnsibleTestTemplate
         extended_key_usages:
-          - "1.3.6.1.5.5.7.3.1"
-          - "1.3.6.1.5.5.7.3.2"
+          - client_authentication
+          - server_authentication
         state: present
       register: _modify_eku
 
@@ -180,8 +134,8 @@
       microsoft.ad.cs_template:
         name: AnsibleTestTemplate
         extended_key_usages:
-          - "1.3.6.1.5.5.7.3.1"
-          - "1.3.6.1.5.5.7.3.2"
+          - server_authentication
+          - client_authentication
         state: present
       register: _modify_eku_idem
 
@@ -189,6 +143,48 @@
       ansible.builtin.assert:
         that:
           - _modify_eku_idem is not changed
+
+    # ---- MODIFY flags with named values ----
+    - name: Set enrollment_flag with named values
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        enrollment_flag:
+          - auto_enrollment
+          - publish_to_ds
+        state: present
+      register: _modify_enroll
+
+    - name: Assert enrollment_flag changed
+      ansible.builtin.assert:
+        that:
+          - _modify_enroll is changed
+
+    - name: Set same enrollment_flag again (idempotency)
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        enrollment_flag:
+          - auto_enrollment
+          - publish_to_ds
+        state: present
+      register: _modify_enroll_idem
+
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - _modify_enroll_idem is not changed
+
+    - name: Set private_key_flag with named value
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        private_key_flag:
+          - exportable_key
+        state: present
+      register: _modify_pk
+
+    - name: Assert private_key_flag changed
+      ansible.builtin.assert:
+        that:
+          - _modify_pk is changed
 
     - name: Publish template to CA
       microsoft.ad.cs_template:
@@ -251,20 +247,6 @@
       ansible.builtin.assert:
         that:
           - _remove_check is changed
-
-    - name: Verify template still exists after check mode remove
-      ansible.windows.win_powershell:
-        script: |
-          $configNC = (Get-ADRootDSE).configurationNamingContext
-          $path = "CN=Certificate Templates,CN=Public Key Services,CN=Services,$configNC"
-          $t = Get-ADObject -SearchBase $path -LDAPFilter '(&(objectClass=pKICertificateTemplate)(cn=AnsibleTestTemplate))'
-          $Ansible.Result = ($null -ne $t)
-      register: _remove_check_verify
-
-    - name: Assert template still exists after check mode
-      ansible.builtin.assert:
-        that:
-          - _remove_check_verify.result
 
     - name: Remove template
       microsoft.ad.cs_template:

--- a/tests/integration/targets/cs_template/tasks/main.yml
+++ b/tests/integration/targets/cs_template/tasks/main.yml
@@ -1,0 +1,296 @@
+---
+# AD CS (AD-Certificate feature) must be installed and an Enterprise Root CA
+# configured before running these tests. This mirrors the setup in
+# tests/integration/targets/inventory_ldap/roles/setup_certificate/tasks/main.yml
+
+- name: Setup - ensure AD CS feature is installed
+  ansible.windows.win_feature:
+    name: AD-Certificate
+    state: present
+  register: _adcs_feature
+
+- name: Setup - reboot after AD CS install
+  ansible.windows.win_reboot:
+  when: _adcs_feature.reboot_required
+
+- name: Setup - configure Enterprise Root CA
+  ansible.windows.win_powershell:
+    script: |
+      $ErrorActionPreference = 'Stop'
+      $Ansible.Changed = $false
+
+      $caParams = @{
+          CAType             = 'EnterpriseRootCa'
+          CryptoProviderName = 'RSA#Microsoft Software Key Storage Provider'
+          KeyLength          = 2048
+          HashAlgorithmName  = 'SHA256'
+          Force              = $true
+      }
+      try {
+          Install-AdcsCertificationAuthority @caParams
+          $Ansible.Changed = $true
+      }
+      catch [Microsoft.CertificateServices.Deployment.Common.CertificateServicesBaseSetupException] {
+          if ($_.Exception.Message -like 'The Certification Authority is already installed.*') {
+              return
+          }
+          throw
+      }
+  become: true
+  become_method: ansible.builtin.runas
+  become_user: SYSTEM
+
+- name: Setup - get CA name for publish tests
+  ansible.windows.win_powershell:
+    script: |
+      $configNC = (Get-ADRootDSE).configurationNamingContext
+      $enrollPath = "CN=Enrollment Services,CN=Public Key Services,CN=Services,$configNC"
+      $ca = Get-ADObject -SearchBase $enrollPath -SearchScope OneLevel -Filter * | Select-Object -First 1
+      $Ansible.Result = $ca.Name
+  register: _ca_info
+
+- name: Setup - set CA name fact
+  ansible.builtin.set_fact:
+    test_ca_name: "{{ _ca_info.result }}"
+
+- name: Test cs_template
+  block:
+    - name: Create template by cloning Web Server - check mode
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        display_name: Ansible Test Template
+        source_template: Web Server
+        key_size: 4096
+        validity_period_days: 365
+        renewal_period_days: 42
+        state: present
+      register: _create_check
+      check_mode: true
+
+    - name: Assert create check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _create_check is changed
+
+    - name: Verify template was not actually created in check mode
+      ansible.windows.win_powershell:
+        script: |
+          $configNC = (Get-ADRootDSE).configurationNamingContext
+          $path = "CN=Certificate Templates,CN=Public Key Services,CN=Services,$configNC"
+          $t = Get-ADObject -SearchBase $path -LDAPFilter '(&(objectClass=pKICertificateTemplate)(cn=AnsibleTestTemplate))'
+          $Ansible.Result = ($null -ne $t)
+      register: _check_mode_verify
+
+    - name: Assert template does not exist after check mode
+      ansible.builtin.assert:
+        that:
+          - not _check_mode_verify.result
+
+    - name: Create template by cloning Web Server
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        display_name: Ansible Test Template
+        source_template: Web Server
+        key_size: 4096
+        validity_period_days: 365
+        renewal_period_days: 42
+        state: present
+      register: _create
+
+    - name: Assert template was created
+      ansible.builtin.assert:
+        that:
+          - _create is changed
+          - _create.distinguished_name is defined
+          - _create.distinguished_name | length > 0
+          - _create.template_oid is defined
+          - _create.template_oid | length > 0
+
+    - name: Create same template again (idempotency)
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        display_name: Ansible Test Template
+        source_template: Web Server
+        key_size: 4096
+        validity_period_days: 365
+        renewal_period_days: 42
+        state: present
+      register: _create_idem
+
+    - name: Assert no change on idempotent run
+      ansible.builtin.assert:
+        that:
+          - _create_idem is not changed
+
+    - name: Update key size to 8192
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        key_size: 8192
+        state: present
+      register: _modify
+
+    - name: Assert modification reported changed
+      ansible.builtin.assert:
+        that:
+          - _modify is changed
+
+    - name: Update key size to 8192 again (idempotency)
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        key_size: 8192
+        state: present
+      register: _modify_idem
+
+    - name: Assert no change on idempotent modify
+      ansible.builtin.assert:
+        that:
+          - _modify_idem is not changed
+
+    - name: Verify key size was actually updated
+      ansible.windows.win_powershell:
+        script: |
+          $configNC = (Get-ADRootDSE).configurationNamingContext
+          $path = "CN=Certificate Templates,CN=Public Key Services,CN=Services,$configNC"
+          $t = Get-ADObject -SearchBase $path `
+            -LDAPFilter '(&(objectClass=pKICertificateTemplate)(cn=AnsibleTestTemplate))' `
+            -Properties 'msPKI-Minimal-Key-Size'
+          $Ansible.Result = $t.'msPKI-Minimal-Key-Size'
+      register: _verify_key_size
+
+    - name: Assert key size is 8192
+      ansible.builtin.assert:
+        that:
+          - _verify_key_size.result == 8192
+
+    - name: Set extended key usages
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        extended_key_usages:
+          - "1.3.6.1.5.5.7.3.1"
+          - "1.3.6.1.5.5.7.3.2"
+        state: present
+      register: _modify_eku
+
+    - name: Assert EKU change
+      ansible.builtin.assert:
+        that:
+          - _modify_eku is changed
+
+    - name: Set same EKUs again (idempotency)
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        extended_key_usages:
+          - "1.3.6.1.5.5.7.3.1"
+          - "1.3.6.1.5.5.7.3.2"
+        state: present
+      register: _modify_eku_idem
+
+    - name: Assert no change on idempotent EKU
+      ansible.builtin.assert:
+        that:
+          - _modify_eku_idem is not changed
+
+    - name: Publish template to CA
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        publish_to_ca:
+          - "{{ test_ca_name }}"
+        state: present
+      register: _publish
+
+    - name: Assert publish reported changed
+      ansible.builtin.assert:
+        that:
+          - _publish is changed
+
+    - name: Publish template to CA again (idempotency)
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        publish_to_ca:
+          - "{{ test_ca_name }}"
+        state: present
+      register: _publish_idem
+
+    - name: Assert no change on idempotent publish
+      ansible.builtin.assert:
+        that:
+          - _publish_idem is not changed
+
+    - name: Unpublish template from all CAs
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        publish_to_ca: []
+        state: present
+      register: _unpublish
+
+    - name: Assert unpublish reported changed
+      ansible.builtin.assert:
+        that:
+          - _unpublish is changed
+
+    - name: Unpublish again (idempotency)
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        publish_to_ca: []
+        state: present
+      register: _unpublish_idem
+
+    - name: Assert no change on idempotent unpublish
+      ansible.builtin.assert:
+        that:
+          - _unpublish_idem is not changed
+
+    - name: Remove template - check mode
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        state: absent
+      register: _remove_check
+      check_mode: true
+
+    - name: Assert remove check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _remove_check is changed
+
+    - name: Verify template still exists after check mode remove
+      ansible.windows.win_powershell:
+        script: |
+          $configNC = (Get-ADRootDSE).configurationNamingContext
+          $path = "CN=Certificate Templates,CN=Public Key Services,CN=Services,$configNC"
+          $t = Get-ADObject -SearchBase $path -LDAPFilter '(&(objectClass=pKICertificateTemplate)(cn=AnsibleTestTemplate))'
+          $Ansible.Result = ($null -ne $t)
+      register: _remove_check_verify
+
+    - name: Assert template still exists after check mode
+      ansible.builtin.assert:
+        that:
+          - _remove_check_verify.result
+
+    - name: Remove template
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        state: absent
+      register: _remove
+
+    - name: Assert remove reported changed
+      ansible.builtin.assert:
+        that:
+          - _remove is changed
+
+    - name: Remove template again (idempotency)
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        state: absent
+      register: _remove_idem
+
+    - name: Assert no change on idempotent remove
+      ansible.builtin.assert:
+        that:
+          - _remove_idem is not changed
+
+  always:
+    - name: Cleanup - remove test template if it exists
+      microsoft.ad.cs_template:
+        name: AnsibleTestTemplate
+        state: absent
+      failed_when: false

--- a/tests/integration/targets/setup_adcs/tasks/main.yml
+++ b/tests/integration/targets/setup_adcs/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Ensure AD CS feature is installed
+  ansible.windows.win_feature:
+    name: AD-Certificate
+    state: present
+  register: _adcs_feature
+
+- name: Reboot after AD CS install
+  ansible.windows.win_reboot:
+  when: _adcs_feature.reboot_required
+
+- name: Configure Enterprise Root CA
+  ansible.windows.win_powershell:
+    script: |
+      $ErrorActionPreference = 'Stop'
+      $Ansible.Changed = $false
+
+      $caParams = @{
+          CAType             = 'EnterpriseRootCa'
+          CryptoProviderName = 'RSA#Microsoft Software Key Storage Provider'
+          KeyLength          = 2048
+          HashAlgorithmName  = 'SHA256'
+          Force              = $true
+      }
+      try {
+          Install-AdcsCertificationAuthority @caParams
+          $Ansible.Changed = $true
+      }
+      catch [Microsoft.CertificateServices.Deployment.Common.CertificateServicesBaseSetupException] {
+          if ($_.Exception.Message -like 'The Certification Authority is already installed.*') {
+              return
+          }
+          throw
+      }
+  become: true
+  become_method: ansible.builtin.runas
+  become_user: SYSTEM
+  register: _adcs_ca_config
+
+- name: Reboot after CA configuration if connection was lost
+  ansible.windows.win_reboot:
+  when: _adcs_ca_config is changed


### PR DESCRIPTION
#### SUMMARY
- New `cs_template` module to create, modify, and remove Active Directory Certificate Services (AD CS) certificate templates
- Supports publishing/unpublishing templates to Enterprise Certificate Authorities via LDAP

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/cs_template.ps1
- plugins/modules/cs_template.yml
- tests/integration/targets/cs_template/
- changelogs/fragments/cs-template.yml

#### ADDITIONAL INFORMATION
- Integration tests cover create, idempotency, check mode, update (key_size, EKUs, validity, display_name, flags), publish/unpublish, and removal
