### PR TITLE
feat: add cs_authority module for CA CDP and AIA management

### DIFF
--- a/plugins/modules/cs_authority.ps1
+++ b/plugins/modules/cs_authority.ps1
@@ -1,0 +1,226 @@
+#!powershell
+
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$cdpSubspec = @{
+    options = @{
+        uri = @{ type = 'str'; required = $true }
+        publish_to_server = @{ type = 'bool'; default = $false }
+        publish_delta_to_server = @{ type = 'bool'; default = $false }
+        add_to_certificate_cdp = @{ type = 'bool'; default = $false }
+        add_to_freshest_crl = @{ type = 'bool'; default = $false }
+        add_to_crl_cdp = @{ type = 'bool'; default = $false }
+        add_to_crl_idp = @{ type = 'bool'; default = $false }
+    }
+}
+
+$aiaSubspec = @{
+    options = @{
+        uri = @{ type = 'str'; required = $true }
+        add_to_certificate_aia = @{ type = 'bool'; default = $false }
+        add_to_certificate_ocsp = @{ type = 'bool'; default = $false }
+    }
+}
+
+$spec = @{
+    options = @{
+        cdp = @{
+            type = 'list'
+            elements = 'dict'
+            options = $cdpSubspec.options
+        }
+        aia = @{
+            type = 'list'
+            elements = 'dict'
+            options = $aiaSubspec.options
+        }
+        restart_service = @{
+            type = 'bool'
+            default = $true
+        }
+    }
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$module.Result.changed = $false
+$module.Result.reboot_required = $false
+
+# Maps Ansible snake_case param names to cmdlet PascalCase switch names.
+# Used for key generation, splat building, and flag extraction.
+$cdpFlagMap = [ordered]@{
+    publish_to_server = 'PublishToServer'
+    publish_delta_to_server = 'PublishDeltaToServer'
+    add_to_certificate_cdp = 'AddToCertificateCdp'
+    add_to_freshest_crl = 'AddToFreshestCrl'
+    add_to_crl_cdp = 'AddToCrlCdp'
+    add_to_crl_idp = 'AddToCrlIdp'
+}
+
+$aiaFlagMap = [ordered]@{
+    add_to_certificate_aia = 'AddToCertificateAia'
+    add_to_certificate_ocsp = 'AddToCertificateOcsp'
+}
+
+Function Get-EntryKey {
+    <#
+    .SYNOPSIS
+    Builds a normalized string key from a cmdlet output object for set
+    comparison. Flag values are read using the PascalCase cmdlet property
+    names from the map.
+    #>
+    param($Entry, $FlagMap)
+    $parts = @($Entry.Uri)
+    foreach ($cmdletName in $FlagMap.Values) {
+        if ([bool]$Entry.$cmdletName) { $parts += '1' } else { $parts += '0' }
+    }
+    $parts -join '|'
+}
+
+Function Get-DesiredEntryKey {
+    <#
+    .SYNOPSIS
+    Builds a normalized string key from an Ansible param dict entry.
+    Flag values are read using the snake_case param names from the map.
+    #>
+    param([hashtable]$Entry, $FlagMap)
+    $parts = @($Entry.uri)
+    foreach ($paramName in $FlagMap.Keys) {
+        if ([bool]$Entry.$paramName) { $parts += '1' } else { $parts += '0' }
+    }
+    $parts -join '|'
+}
+
+Function ConvertTo-CmdletSplat {
+    <#
+    .SYNOPSIS
+    Builds a parameter splat for an Add/Remove cmdlet from an Ansible
+    param dict entry. Only includes flags that are true.
+    #>
+    param([hashtable]$Entry, $FlagMap)
+    $splat = @{ Uri = $Entry.uri }
+    foreach ($kvp in $FlagMap.GetEnumerator()) {
+        if ($Entry[$kvp.Key]) {
+            $splat[$kvp.Value] = $true
+        }
+    }
+    $splat
+}
+
+Function Sync-CAExtensionList {
+    <#
+    .SYNOPSIS
+    Compares current CA extension entries against a desired list and
+    applies additions/removals. Works for both CDP and AIA by accepting
+    the cmdlet names and flag map as parameters.
+    #>
+    param(
+        [string]$Label,
+        [hashtable[]]$DesiredEntries,
+        $FlagMap,
+        [string]$GetCmdlet,
+        [string]$AddCmdlet,
+        [string]$RemoveCmdlet
+    )
+
+    try {
+        $currentEntries = @(& $GetCmdlet)
+    }
+    catch {
+        $module.FailJson("Failed to get current $Label entries: $_", $_)
+    }
+
+    $currentKeys = @($currentEntries | ForEach-Object { Get-EntryKey $_ $FlagMap })
+    $desiredKeys = @($DesiredEntries | ForEach-Object { Get-DesiredEntryKey $_ $FlagMap })
+
+    $toRemove = @()
+    $toAdd = @()
+    if ($currentKeys.Count -eq 0 -and $desiredKeys.Count -eq 0) {
+        return
+    }
+    elseif ($currentKeys.Count -eq 0) {
+        $toAdd = $DesiredEntries
+    }
+    elseif ($desiredKeys.Count -eq 0) {
+        $toRemove = $currentEntries
+    }
+    else {
+        $diff = Compare-Object -ReferenceObject $currentKeys -DifferenceObject $desiredKeys
+        foreach ($d in $diff) {
+            if ($d.SideIndicator -eq '<=') {
+                $idx = [array]::IndexOf($currentKeys, $d.InputObject)
+                $toRemove += $currentEntries[$idx]
+            }
+            elseif ($d.SideIndicator -eq '=>') {
+                $idx = [array]::IndexOf($desiredKeys, $d.InputObject)
+                $toAdd += $DesiredEntries[$idx]
+            }
+        }
+    }
+
+    if ($toRemove.Count -eq 0 -and $toAdd.Count -eq 0) {
+        return
+    }
+
+    $module.Result.changed = $true
+
+    if (-not $module.CheckMode) {
+        foreach ($entry in $toRemove) {
+            try {
+                $null = & $RemoveCmdlet -Uri $entry.Uri -Force
+            }
+            catch {
+                $module.FailJson("Failed to remove $Label entry '$($entry.Uri)': $_", $_)
+            }
+        }
+        foreach ($entry in $toAdd) {
+            $splat = ConvertTo-CmdletSplat $entry $FlagMap
+            $splat.Force = $true
+            try {
+                $null = & $AddCmdlet @splat
+            }
+            catch {
+                $module.FailJson("Failed to add $Label entry '$($entry.uri)': $_", $_)
+            }
+        }
+    }
+}
+
+# Handle cdp
+if ($null -ne $module.Params.cdp) {
+    Sync-CAExtensionList `
+        -Label 'CDP' `
+        -DesiredEntries $module.Params.cdp `
+        -FlagMap $cdpFlagMap `
+        -GetCmdlet 'Get-CACrlDistributionPoint' `
+        -AddCmdlet 'Add-CACrlDistributionPoint' `
+        -RemoveCmdlet 'Remove-CACrlDistributionPoint'
+}
+
+# Handle aia
+if ($null -ne $module.Params.aia) {
+    Sync-CAExtensionList `
+        -Label 'AIA' `
+        -DesiredEntries $module.Params.aia `
+        -FlagMap $aiaFlagMap `
+        -GetCmdlet 'Get-CAAuthorityInformationAccess' `
+        -AddCmdlet 'Add-CAAuthorityInformationAccess' `
+        -RemoveCmdlet 'Remove-CAAuthorityInformationAccess'
+}
+
+# Restart CertSvc if changes were made and restart_service is requested
+if ($module.Result.changed -and $module.Params.restart_service) {
+    if (-not $module.CheckMode) {
+        try {
+            Restart-Service -Name CertSvc -Force
+        }
+        catch {
+            $module.FailJson("Failed to restart CertSvc service: $_", $_)
+        }
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/cs_authority.ps1
+++ b/plugins/modules/cs_authority.ps1
@@ -47,7 +47,6 @@ $spec = @{
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 $module.Result.changed = $false
-$module.Result.reboot_required = $false
 
 # Maps Ansible snake_case param names to cmdlet PascalCase switch names.
 # Used for key generation, splat building, and flag extraction.

--- a/plugins/modules/cs_authority.yml
+++ b/plugins/modules/cs_authority.yml
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: cs_authority
+  short_description: Manage CA CRL Distribution Points and Authority Information Access
+  version_added: 1.11.0
+  description:
+    - Manage CRL Distribution Point (CDP) and Authority Information Access
+      (AIA) extension entries on a Windows Certificate Authority.
+    - Uses the C(ADCSAdministration) PowerShell module cmdlets
+      C(Get-CACrlDistributionPoint), C(Add-CACrlDistributionPoint),
+      C(Remove-CACrlDistributionPoint), C(Get-CAAuthorityInformationAccess),
+      C(Add-CAAuthorityInformationAccess), and
+      C(Remove-CAAuthorityInformationAccess).
+    - When O(cdp) or O(aia) is specified, the module enforces the exact
+      desired list. Entries not in the desired list are removed, missing
+      entries are added, and entries with matching URI but different flags
+      are replaced.
+    - When O(cdp) or O(aia) is omitted, that extension type is not managed.
+    - The CertSvc service is restarted after changes when O(restart_service)
+      is V(true).
+  options:
+    cdp:
+      description:
+        - Desired list of CRL Distribution Point entries.
+        - Each entry specifies a URI and the boolean flags that control
+          how the CDP is used.
+        - When specified, the module enforces exactly this list of CDPs.
+          Existing entries not in the list are removed.
+        - An empty list V([]) removes all CDP entries.
+        - When omitted, CDP configuration is not managed.
+        - "URI strings may contain ADCS variable tokens in angle-bracket
+          format: C(<ServerDNSName>), C(<ServerShortName>),
+          C(<CAName>), C(<CertificateName>), C(<CATruncatedName>),
+          C(<CRLNameSuffix>), C(<DeltaCRLAllowed>),
+          C(<ConfigurationContainer>), C(<CDPObjectClass>),
+          C(<CAObjectClass>)."
+      type: list
+      elements: dict
+      suboptions:
+        uri:
+          description:
+            - The CDP URI.
+            - Supports HTTP, LDAP, UNC, and file path URIs.
+          type: str
+          required: true
+        publish_to_server:
+          description:
+            - Publish CRLs to this location.
+          type: bool
+          default: false
+        publish_delta_to_server:
+          description:
+            - Publish delta CRLs to this location.
+          type: bool
+          default: false
+        add_to_certificate_cdp:
+          description:
+            - Include this URI in the CDP extension of issued certificates.
+          type: bool
+          default: false
+        add_to_freshest_crl:
+          description:
+            - Include this URI in the freshest CRL extension for locating
+              delta CRLs.
+          type: bool
+          default: false
+        add_to_crl_cdp:
+          description:
+            - Include this URI in the CDP extension of issued CRLs.
+          type: bool
+          default: false
+        add_to_crl_idp:
+          description:
+            - Include this URI in the IDP (Issuing Distribution Point)
+              extension of issued CRLs.
+          type: bool
+          default: false
+    aia:
+      description:
+        - Desired list of Authority Information Access entries.
+        - Each entry specifies a URI and whether it is an AIA or OCSP
+          endpoint.
+        - When specified, the module enforces exactly this list of AIA
+          entries. Existing entries not in the list are removed.
+        - An empty list V([]) removes all AIA entries.
+        - When omitted, AIA configuration is not managed.
+      type: list
+      elements: dict
+      suboptions:
+        uri:
+          description:
+            - The AIA or OCSP URI.
+          type: str
+          required: true
+        add_to_certificate_aia:
+          description:
+            - Include this URI in the AIA extension of issued certificates.
+          type: bool
+          default: false
+        add_to_certificate_ocsp:
+          description:
+            - Include this URI in the OCSP extension of issued certificates.
+          type: bool
+          default: false
+    restart_service:
+      description:
+        - Whether to restart the CertSvc service after making changes.
+        - CDP and AIA changes typically require a service restart to take
+          effect on newly issued certificates.
+      type: bool
+      default: true
+
+  notes:
+    - This module must be run on the CA server itself.
+    - The C(ADCSAdministration) PowerShell module must be available on the
+      target host (installed with the AD CS role).
+    - Changes only affect newly issued certificates and CRLs. Previously
+      issued certificates retain their original CDP and AIA references.
+    - Administrator permissions on the CA are required.
+  seealso:
+    - module: microsoft.ad.cs_template
+  extends_documentation_fragment:
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: none
+    platform:
+      platforms:
+        - windows
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Configure CDP with HTTP and local file publishing
+    microsoft.ad.cs_authority:
+      cdp:
+        - uri: "C:\\Windows\\System32\\CertSrv\\CertEnroll\\<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          publish_to_server: true
+          publish_delta_to_server: true
+        - uri: "http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          add_to_certificate_cdp: true
+          add_to_freshest_crl: true
+
+  - name: Configure AIA with HTTP and OCSP
+    microsoft.ad.cs_authority:
+      aia:
+        - uri: "http://pki.corp.com/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+          add_to_certificate_aia: true
+        - uri: "http://ocsp.corp.com/ocsp"
+          add_to_certificate_ocsp: true
+
+  - name: Configure both CDP and AIA together
+    microsoft.ad.cs_authority:
+      cdp:
+        - uri: "C:\\Windows\\System32\\CertSrv\\CertEnroll\\<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          publish_to_server: true
+          publish_delta_to_server: true
+        - uri: "http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          add_to_certificate_cdp: true
+          add_to_freshest_crl: true
+      aia:
+        - uri: "http://pki.corp.com/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+          add_to_certificate_aia: true
+        - uri: "http://ocsp.corp.com/ocsp"
+          add_to_certificate_ocsp: true
+      restart_service: true
+
+  - name: Remove all CDP entries
+    microsoft.ad.cs_authority:
+      cdp: []
+
+  - name: Configure CDP without restarting the service
+    microsoft.ad.cs_authority:
+      cdp:
+        - uri: "http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          add_to_certificate_cdp: true
+      restart_service: false
+
+RETURN:
+  reboot_required:
+    description:
+      - Always V(false). CDP and AIA changes do not require a reboot,
+        only a CertSvc service restart.
+    returned: always
+    type: bool
+    sample: false

--- a/plugins/modules/cs_authority.yml
+++ b/plugins/modules/cs_authority.yml
@@ -138,34 +138,34 @@ EXAMPLES: |
   - name: Configure CDP with HTTP and local file publishing
     microsoft.ad.cs_authority:
       cdp:
-        - uri: "C:\\Windows\\System32\\CertSrv\\CertEnroll\\<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+        - uri: 'C:\Windows\System32\CertSrv\CertEnroll\<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
           publish_to_server: true
           publish_delta_to_server: true
-        - uri: "http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+        - uri: 'http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
           add_to_certificate_cdp: true
           add_to_freshest_crl: true
 
   - name: Configure AIA with HTTP and OCSP
     microsoft.ad.cs_authority:
       aia:
-        - uri: "http://pki.corp.com/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+        - uri: 'http://pki.corp.com/crl/<ServerDNSName>_<CAName><CertificateName>.crt'
           add_to_certificate_aia: true
-        - uri: "http://ocsp.corp.com/ocsp"
+        - uri: 'http://ocsp.corp.com/ocsp'
           add_to_certificate_ocsp: true
 
   - name: Configure both CDP and AIA together
     microsoft.ad.cs_authority:
       cdp:
-        - uri: "C:\\Windows\\System32\\CertSrv\\CertEnroll\\<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+        - uri: 'C:\Windows\System32\CertSrv\CertEnroll\<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
           publish_to_server: true
           publish_delta_to_server: true
-        - uri: "http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+        - uri: 'http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
           add_to_certificate_cdp: true
           add_to_freshest_crl: true
       aia:
-        - uri: "http://pki.corp.com/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+        - uri: 'http://pki.corp.com/crl/<ServerDNSName>_<CAName><CertificateName>.crt'
           add_to_certificate_aia: true
-        - uri: "http://ocsp.corp.com/ocsp"
+        - uri: 'http://ocsp.corp.com/ocsp'
           add_to_certificate_ocsp: true
       restart_service: true
 
@@ -176,15 +176,8 @@ EXAMPLES: |
   - name: Configure CDP without restarting the service
     microsoft.ad.cs_authority:
       cdp:
-        - uri: "http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+        - uri: 'http://pki.corp.com/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
           add_to_certificate_cdp: true
       restart_service: false
 
-RETURN:
-  reboot_required:
-    description:
-      - Always V(false). CDP and AIA changes do not require a reboot,
-        only a CertSvc service restart.
-    returned: always
-    type: bool
-    sample: false
+RETURN: {}

--- a/tests/integration/targets/cs_authority/aliases
+++ b/tests/integration/targets/cs_authority/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/cs_authority/meta/main.yml
+++ b/tests/integration/targets/cs_authority/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+- name: setup_domain
+- name: setup_adcs

--- a/tests/integration/targets/cs_authority/tasks/main.yml
+++ b/tests/integration/targets/cs_authority/tasks/main.yml
@@ -1,0 +1,309 @@
+---
+
+- name: Get current CDP and AIA baselines
+  ansible.windows.win_powershell:
+    script: |
+      $cdp = @(Get-CACrlDistributionPoint | ForEach-Object {
+          @{
+              Uri = $_.Uri
+              PublishToServer = [bool]$_.PublishToServer
+              PublishDeltaToServer = [bool]$_.PublishDeltaToServer
+              AddToCertificateCdp = [bool]$_.AddToCertificateCdp
+              AddToFreshestCrl = [bool]$_.AddToFreshestCrl
+              AddToCrlCdp = [bool]$_.AddToCrlCdp
+              AddToCrlIdp = [bool]$_.AddToCrlIdp
+          }
+      })
+      $aia = @(Get-CAAuthorityInformationAccess | ForEach-Object {
+          @{
+              Uri = $_.Uri
+              AddToCertificateAia = [bool]$_.AddToCertificateAia
+              AddToCertificateOcsp = [bool]$_.AddToCertificateOcsp
+          }
+      })
+      $Ansible.Result = @{ cdp = $cdp; aia = $aia }
+  register: _baseline
+
+- name: Save baseline facts
+  ansible.builtin.set_fact:
+    baseline_cdp: "{{ _baseline.result.cdp }}"
+    baseline_aia: "{{ _baseline.result.aia }}"
+
+- name: Test cs_authority
+  block:
+    - name: Set CDP entries - check mode
+      microsoft.ad.cs_authority:
+        cdp:
+          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+            add_to_certificate_cdp: true
+            add_to_freshest_crl: true
+        restart_service: false
+      register: _cdp_check
+      check_mode: true
+
+    - name: Assert CDP check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _cdp_check is changed
+
+    - name: Verify CDP was not actually modified in check mode
+      ansible.windows.win_powershell:
+        script: |
+          $current = @(Get-CACrlDistributionPoint)
+          $Ansible.Result = $current.Count
+      register: _cdp_check_verify
+
+    - name: Assert CDP count unchanged after check mode
+      ansible.builtin.assert:
+        that:
+          - _cdp_check_verify.result == (baseline_cdp | length)
+
+    # ---- CDP: set + idempotency ----
+    - name: Set CDP entries
+      microsoft.ad.cs_authority:
+        cdp:
+          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+            add_to_certificate_cdp: true
+            add_to_freshest_crl: true
+        restart_service: false
+      register: _cdp_set
+
+    - name: Assert CDP set reported changed
+      ansible.builtin.assert:
+        that:
+          - _cdp_set is changed
+
+    - name: Set same CDP entries again (idempotency)
+      microsoft.ad.cs_authority:
+        cdp:
+          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+            add_to_certificate_cdp: true
+            add_to_freshest_crl: true
+        restart_service: false
+      register: _cdp_set_idem
+
+    - name: Assert no change on idempotent CDP run
+      ansible.builtin.assert:
+        that:
+          - _cdp_set_idem is not changed
+
+    # ---- CDP: modify flags ----
+    - name: Modify CDP entry flags
+      microsoft.ad.cs_authority:
+        cdp:
+          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+            add_to_certificate_cdp: true
+            add_to_freshest_crl: false
+        restart_service: false
+      register: _cdp_modify
+
+    - name: Assert CDP modify reported changed
+      ansible.builtin.assert:
+        that:
+          - _cdp_modify is changed
+
+    - name: Modify CDP entry flags again (idempotency)
+      microsoft.ad.cs_authority:
+        cdp:
+          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+            add_to_certificate_cdp: true
+            add_to_freshest_crl: false
+        restart_service: false
+      register: _cdp_modify_idem
+
+    - name: Assert no change on idempotent CDP modify
+      ansible.builtin.assert:
+        that:
+          - _cdp_modify_idem is not changed
+
+    # ---- CDP: remove all ----
+    - name: Remove all CDP entries
+      microsoft.ad.cs_authority:
+        cdp: []
+        restart_service: false
+      register: _cdp_empty
+
+    - name: Assert CDP removal reported changed
+      ansible.builtin.assert:
+        that:
+          - _cdp_empty is changed
+
+    - name: Remove all CDP entries again (idempotency)
+      microsoft.ad.cs_authority:
+        cdp: []
+        restart_service: false
+      register: _cdp_empty_idem
+
+    - name: Assert no change on idempotent CDP removal
+      ansible.builtin.assert:
+        that:
+          - _cdp_empty_idem is not changed
+
+    # ---- AIA: check mode ----
+    - name: Set AIA entries - check mode
+      microsoft.ad.cs_authority:
+        aia:
+          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+            add_to_certificate_aia: true
+          - uri: "http://ocsp.test.local/ocsp"
+            add_to_certificate_ocsp: true
+        restart_service: false
+      register: _aia_check
+      check_mode: true
+
+    - name: Assert AIA check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _aia_check is changed
+
+    # ---- AIA: set + idempotency ----
+    - name: Set AIA entries
+      microsoft.ad.cs_authority:
+        aia:
+          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+            add_to_certificate_aia: true
+          - uri: "http://ocsp.test.local/ocsp"
+            add_to_certificate_ocsp: true
+        restart_service: false
+      register: _aia_set
+
+    - name: Assert AIA set reported changed
+      ansible.builtin.assert:
+        that:
+          - _aia_set is changed
+
+    - name: Set same AIA entries again (idempotency)
+      microsoft.ad.cs_authority:
+        aia:
+          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+            add_to_certificate_aia: true
+          - uri: "http://ocsp.test.local/ocsp"
+            add_to_certificate_ocsp: true
+        restart_service: false
+      register: _aia_set_idem
+
+    - name: Assert no change on idempotent AIA run
+      ansible.builtin.assert:
+        that:
+          - _aia_set_idem is not changed
+
+    # ---- AIA: modify ----
+    - name: Modify AIA to only have AIA entry (remove OCSP)
+      microsoft.ad.cs_authority:
+        aia:
+          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+            add_to_certificate_aia: true
+        restart_service: false
+      register: _aia_modify
+
+    - name: Assert AIA modify reported changed
+      ansible.builtin.assert:
+        that:
+          - _aia_modify is changed
+
+    # ---- Combined CDP + AIA ----
+    - name: Set both CDP and AIA together
+      microsoft.ad.cs_authority:
+        cdp:
+          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+            add_to_certificate_cdp: true
+        aia:
+          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+            add_to_certificate_aia: true
+        restart_service: false
+      register: _combined
+
+    - name: Assert combined set reported changed
+      ansible.builtin.assert:
+        that:
+          - _combined is changed
+
+    - name: Set both CDP and AIA again (idempotency)
+      microsoft.ad.cs_authority:
+        cdp:
+          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+            add_to_certificate_cdp: true
+        aia:
+          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+            add_to_certificate_aia: true
+        restart_service: false
+      register: _combined_idem
+
+    - name: Assert no change on idempotent combined run
+      ansible.builtin.assert:
+        that:
+          - _combined_idem is not changed
+
+    # ---- Isolation: CDP-only does not touch AIA ----
+    - name: Only manage CDP, leave AIA untouched
+      microsoft.ad.cs_authority:
+        cdp:
+          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+            add_to_certificate_cdp: true
+            add_to_freshest_crl: true
+        restart_service: false
+      register: _cdp_only
+
+    - name: Assert CDP-only run changed (flags differ)
+      ansible.builtin.assert:
+        that:
+          - _cdp_only is changed
+
+    - name: Verify AIA was not touched by CDP-only run
+      ansible.windows.win_powershell:
+        script: |
+          $aia = @(Get-CAAuthorityInformationAccess)
+          $Ansible.Result = $aia.Count
+      register: _aia_after_cdp_only
+
+    - name: Assert AIA count is still 1 (only the AIA entry from before)
+      ansible.builtin.assert:
+        that:
+          - _aia_after_cdp_only.result == 1
+
+  always:
+    - name: Restore baseline CDP entries
+      ansible.windows.win_powershell:
+        script: |
+          $ErrorActionPreference = 'Stop'
+          Get-CACrlDistributionPoint | ForEach-Object {
+              $null = Remove-CACrlDistributionPoint -Uri $_.Uri -Force
+          }
+
+          $json = '{{ baseline_cdp | to_json }}'
+          $baseline = @($json | ConvertFrom-Json)
+          foreach ($entry in $baseline) {
+              $params = @{ Uri = $entry.Uri; Force = $true }
+              if ($entry.PublishToServer) { $params.PublishToServer = $true }
+              if ($entry.PublishDeltaToServer) { $params.PublishDeltaToServer = $true }
+              if ($entry.AddToCertificateCdp) { $params.AddToCertificateCdp = $true }
+              if ($entry.AddToFreshestCrl) { $params.AddToFreshestCrl = $true }
+              if ($entry.AddToCrlCdp) { $params.AddToCrlCdp = $true }
+              if ($entry.AddToCrlIdp) { $params.AddToCrlIdp = $true }
+              $null = Add-CACrlDistributionPoint @params
+          }
+      failed_when: false
+
+    - name: Restore baseline AIA entries
+      ansible.windows.win_powershell:
+        script: |
+          $ErrorActionPreference = 'Stop'
+          Get-CAAuthorityInformationAccess | ForEach-Object {
+              $null = Remove-CAAuthorityInformationAccess -Uri $_.Uri -Force
+          }
+
+          $json = '{{ baseline_aia | to_json }}'
+          $baseline = @($json | ConvertFrom-Json)
+          foreach ($entry in $baseline) {
+              $params = @{ Uri = $entry.Uri; Force = $true }
+              if ($entry.AddToCertificateAia) { $params.AddToCertificateAia = $true }
+              if ($entry.AddToCertificateOcsp) { $params.AddToCertificateOcsp = $true }
+              $null = Add-CAAuthorityInformationAccess @params
+          }
+      failed_when: false
+
+    - name: Restart CertSvc after cleanup
+      ansible.windows.win_service:
+        name: CertSvc
+        state: restarted
+      failed_when: false

--- a/tests/integration/targets/cs_authority/tasks/main.yml
+++ b/tests/integration/targets/cs_authority/tasks/main.yml
@@ -34,7 +34,7 @@
     - name: Set CDP entries - check mode
       microsoft.ad.cs_authority:
         cdp:
-          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          - uri: 'http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
             add_to_certificate_cdp: true
             add_to_freshest_crl: true
         restart_service: false
@@ -62,7 +62,7 @@
     - name: Set CDP entries
       microsoft.ad.cs_authority:
         cdp:
-          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          - uri: 'http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
             add_to_certificate_cdp: true
             add_to_freshest_crl: true
         restart_service: false
@@ -76,7 +76,7 @@
     - name: Set same CDP entries again (idempotency)
       microsoft.ad.cs_authority:
         cdp:
-          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          - uri: 'http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
             add_to_certificate_cdp: true
             add_to_freshest_crl: true
         restart_service: false
@@ -91,7 +91,7 @@
     - name: Modify CDP entry flags
       microsoft.ad.cs_authority:
         cdp:
-          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          - uri: 'http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
             add_to_certificate_cdp: true
             add_to_freshest_crl: false
         restart_service: false
@@ -105,7 +105,7 @@
     - name: Modify CDP entry flags again (idempotency)
       microsoft.ad.cs_authority:
         cdp:
-          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          - uri: 'http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
             add_to_certificate_cdp: true
             add_to_freshest_crl: false
         restart_service: false
@@ -143,9 +143,9 @@
     - name: Set AIA entries - check mode
       microsoft.ad.cs_authority:
         aia:
-          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+          - uri: 'http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt'
             add_to_certificate_aia: true
-          - uri: "http://ocsp.test.local/ocsp"
+          - uri: 'http://ocsp.test.local/ocsp'
             add_to_certificate_ocsp: true
         restart_service: false
       register: _aia_check
@@ -160,9 +160,9 @@
     - name: Set AIA entries
       microsoft.ad.cs_authority:
         aia:
-          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+          - uri: 'http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt'
             add_to_certificate_aia: true
-          - uri: "http://ocsp.test.local/ocsp"
+          - uri: 'http://ocsp.test.local/ocsp'
             add_to_certificate_ocsp: true
         restart_service: false
       register: _aia_set
@@ -175,9 +175,9 @@
     - name: Set same AIA entries again (idempotency)
       microsoft.ad.cs_authority:
         aia:
-          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+          - uri: 'http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt'
             add_to_certificate_aia: true
-          - uri: "http://ocsp.test.local/ocsp"
+          - uri: 'http://ocsp.test.local/ocsp'
             add_to_certificate_ocsp: true
         restart_service: false
       register: _aia_set_idem
@@ -191,7 +191,7 @@
     - name: Modify AIA to only have AIA entry (remove OCSP)
       microsoft.ad.cs_authority:
         aia:
-          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+          - uri: 'http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt'
             add_to_certificate_aia: true
         restart_service: false
       register: _aia_modify
@@ -205,10 +205,10 @@
     - name: Set both CDP and AIA together
       microsoft.ad.cs_authority:
         cdp:
-          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          - uri: 'http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
             add_to_certificate_cdp: true
         aia:
-          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+          - uri: 'http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt'
             add_to_certificate_aia: true
         restart_service: false
       register: _combined
@@ -221,10 +221,10 @@
     - name: Set both CDP and AIA again (idempotency)
       microsoft.ad.cs_authority:
         cdp:
-          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          - uri: 'http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
             add_to_certificate_cdp: true
         aia:
-          - uri: "http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt"
+          - uri: 'http://pki.test.local/crl/<ServerDNSName>_<CAName><CertificateName>.crt'
             add_to_certificate_aia: true
         restart_service: false
       register: _combined_idem
@@ -238,7 +238,7 @@
     - name: Only manage CDP, leave AIA untouched
       microsoft.ad.cs_authority:
         cdp:
-          - uri: "http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl"
+          - uri: 'http://pki.test.local/crl/<CAName><CRLNameSuffix><DeltaCRLAllowed>.crl'
             add_to_certificate_cdp: true
             add_to_freshest_crl: true
         restart_service: false


### PR DESCRIPTION
#### SUMMARY
- New `microsoft.ad.cs_authority` module to declaratively manage CRL Distribution Point (CDP) and Authority Information Access (AIA) extensions on a Windows Certificate Authority
- Uses ADCSAdministration PowerShell cmdlets (Get/Add/Remove-CACrlDistributionPoint, Get/Add/Remove-CAAuthorityInformationAccess)
- Supports check mode, idempotency, and optional CertSvc service restart

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/cs_authority.ps1
- plugins/modules/cs_authority.yml
- tests/integration/targets/cs_authority/

#### ADDITIONAL INFORMATION
- URIs must use angle-bracket token format (e.g. `<CAName>`, `<ServerDNSName>`) matching what the ADCS cmdlets return