### PR TITLE
feat(fs_trust): add module to manage AD FS Relying Party Trusts

### DIFF
--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -167,9 +167,10 @@ if ($state -eq 'present') {
                         $Params['SamlEndpoint'] = @($eps)
                         Add-AdfsRelyingPartyTrust @Params
                     }
+                    [string[]]$samlUris = @($module.Params.saml_endpoint)
                     $winPS = New-PSSession -UseWindowsPowerShell
                     try {
-                        Invoke-Command -Session $winPS -ScriptBlock $addTrustWithEndpoints -ArgumentList $addParams, [string[]]$module.Params.saml_endpoint
+                        Invoke-Command -Session $winPS -ScriptBlock $addTrustWithEndpoints -ArgumentList $addParams, $samlUris
                     }
                     finally {
                         $winPS | Remove-PSSession

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -133,13 +133,6 @@ if ($state -eq 'present') {
         }
         else {
             $addParams.Identifier = $module.Params.identifier
-            if ($module.Params.saml_endpoint) {
-                $endpoints = @()
-                foreach ($ep in $module.Params.saml_endpoint) {
-                    $endpoints += New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $ep
-                }
-                $addParams.SamlEndpoint = $endpoints
-            }
             if ($module.Params.wsfed_endpoint) {
                 $addParams.WSFedEndpoint = [Uri]$module.Params.wsfed_endpoint
             }
@@ -161,7 +154,36 @@ if ($state -eq 'present') {
 
         if (-not $module.CheckMode) {
             try {
-                Add-AdfsRelyingPartyTrust @addParams
+                $cmd = Get-Command Add-AdfsRelyingPartyTrust
+                if ($module.Params.saml_endpoint -and $cmd.Module.PrivateData.ImplicitRemoting) {
+                    # The ADFS module is loaded via implicit remoting and
+                    # SamlEndpoint objects get deserialized crossing the
+                    # proxy boundary. Create them inside a WinPS session.
+                    $winPS = New-PSSession -UseWindowsPowerShell
+                    try {
+                        Invoke-Command -Session $winPS -ScriptBlock {
+                            param([hashtable]$Params, [string[]]$EndpointUris)
+                            $eps = foreach ($u in $EndpointUris) {
+                                New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $u
+                            }
+                            $Params['SamlEndpoint'] = @($eps)
+                            Add-AdfsRelyingPartyTrust @Params
+                        } -ArgumentList $addParams, [string[]]$module.Params.saml_endpoint
+                    }
+                    finally {
+                        $winPS | Remove-PSSession
+                    }
+                }
+                else {
+                    if ($module.Params.saml_endpoint) {
+                        $endpoints = @()
+                        foreach ($ep in $module.Params.saml_endpoint) {
+                            $endpoints += New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $ep
+                        }
+                        $addParams.SamlEndpoint = $endpoints
+                    }
+                    Add-AdfsRelyingPartyTrust @addParams
+                }
             }
             catch {
                 $module.FailJson("Failed to create relying party trust '$name': $_", $_)

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -52,12 +52,6 @@ $spec = @{
         access_control_policy_name = @{
             type = 'str'
         }
-        issuance_transform_rules = @{
-            type = 'str'
-        }
-        issuance_authorization_rules = @{
-            type = 'str'
-        }
         signature_algorithm = @{
             type = 'str'
             choices = @('rsa_sha1', 'rsa_sha256')
@@ -95,8 +89,6 @@ $propertyMap = @(
     @{ Param = 'token_lifetime'; Cmdlet = 'TokenLifetime' }
     @{ Param = 'notes'; Cmdlet = 'Notes' }
     @{ Param = 'access_control_policy_name'; Cmdlet = 'AccessControlPolicyName' }
-    @{ Param = 'issuance_transform_rules'; Cmdlet = 'IssuanceTransformRules' }
-    @{ Param = 'issuance_authorization_rules'; Cmdlet = 'IssuanceAuthorizationRules' }
     @{ Param = 'signature_algorithm'; Cmdlet = 'SignatureAlgorithm'; Cast = { param($v) $signatureAlgorithmMap[$v] } }
     @{ Param = 'encrypt_claims'; Cmdlet = 'EncryptClaims' }
 )

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -1,0 +1,253 @@
+#!powershell
+
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        name = @{
+            type = 'str'
+            required = $true
+        }
+        state = @{
+            type = 'str'
+            default = 'present'
+            choices = @('present', 'absent')
+        }
+        metadata_url = @{
+            type = 'str'
+        }
+        metadata_file = @{
+            type = 'str'
+        }
+        identifier = @{
+            type = 'list'
+            elements = 'str'
+        }
+        saml_endpoint = @{
+            type = 'list'
+            elements = 'str'
+        }
+        wsfed_endpoint = @{
+            type = 'str'
+        }
+        enabled = @{
+            type = 'bool'
+        }
+        monitoring_enabled = @{
+            type = 'bool'
+        }
+        auto_update_enabled = @{
+            type = 'bool'
+        }
+        token_lifetime = @{
+            type = 'int'
+        }
+        notes = @{
+            type = 'str'
+        }
+        access_control_policy_name = @{
+            type = 'str'
+        }
+        issuance_transform_rules = @{
+            type = 'str'
+        }
+        issuance_authorization_rules = @{
+            type = 'str'
+        }
+        signature_algorithm = @{
+            type = 'str'
+            choices = @('rsa_sha1', 'rsa_sha256')
+        }
+        encrypt_claims = @{
+            type = 'bool'
+        }
+    }
+    mutually_exclusive = @(
+        , @('metadata_url', 'metadata_file', 'identifier')
+    )
+    required_if = @(
+        , @('state', 'present', @('metadata_url', 'metadata_file', 'identifier'), $true)
+    )
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$module.Result.changed = $false
+$module.Result.name = $module.Params.name
+$module.Result.identifier = @()
+$module.Result.enabled = $null
+$module.Result.monitoring_enabled = $null
+$name = $module.Params.name
+$state = $module.Params.state
+
+$signatureAlgorithmMap = @{
+    'rsa_sha1' = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+    'rsa_sha256' = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+}
+
+$propertyMap = @(
+    @{ Param = 'monitoring_enabled'; Cmdlet = 'MonitoringEnabled' }
+    @{ Param = 'auto_update_enabled'; Cmdlet = 'AutoUpdateEnabled' }
+    @{ Param = 'token_lifetime'; Cmdlet = 'TokenLifetime' }
+    @{ Param = 'notes'; Cmdlet = 'Notes' }
+    @{ Param = 'access_control_policy_name'; Cmdlet = 'AccessControlPolicyName' }
+    @{ Param = 'issuance_transform_rules'; Cmdlet = 'IssuanceTransformRules' }
+    @{ Param = 'issuance_authorization_rules'; Cmdlet = 'IssuanceAuthorizationRules' }
+    @{ Param = 'signature_algorithm'; Cmdlet = 'SignatureAlgorithm'; Cast = { param($v) $signatureAlgorithmMap[$v] } }
+    @{ Param = 'encrypt_claims'; Cmdlet = 'EncryptClaims' }
+)
+
+try {
+    $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction Stop
+}
+catch {
+    $module.FailJson("Failed to retrieve relying party trust '$name': $_", $_)
+}
+
+if ($state -eq 'present') {
+    if (-not $existing) {
+        # CREATE
+        $addParams = @{
+            Name = $name
+            Confirm = $false
+        }
+
+        if ($module.Params.metadata_url) {
+            try {
+                $null = Invoke-WebRequest -Uri $module.Params.metadata_url -UseBasicParsing -ErrorAction Stop
+            }
+            catch {
+                $module.FailJson("Cannot reach metadata URL '$($module.Params.metadata_url)': $_", $_)
+            }
+            $addParams.MetadataUrl = [Uri]$module.Params.metadata_url
+        }
+        elseif ($module.Params.metadata_file) {
+            if (-not (Test-Path -LiteralPath $module.Params.metadata_file)) {
+                $module.FailJson("Metadata file not found: '$($module.Params.metadata_file)'")
+            }
+            $addParams.MetadataFile = $module.Params.metadata_file
+        }
+        else {
+            $addParams.Identifier = $module.Params.identifier
+            if ($module.Params.saml_endpoint) {
+                $endpoints = @()
+                foreach ($ep in $module.Params.saml_endpoint) {
+                    $endpoints += New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $ep
+                }
+                $addParams.SamlEndpoint = $endpoints
+            }
+            if ($module.Params.wsfed_endpoint) {
+                $addParams.WSFedEndpoint = [Uri]$module.Params.wsfed_endpoint
+            }
+        }
+
+        if ($null -ne $module.Params.enabled) {
+            $addParams.Enabled = $module.Params.enabled
+        }
+
+        foreach ($prop in $propertyMap) {
+            $val = $module.Params[$prop.Param]
+            if ($null -ne $val) {
+                if ($prop.Cast) { $val = & $prop.Cast $val }
+                $addParams[$prop.Cmdlet] = $val
+            }
+        }
+
+        $module.Result.changed = $true
+
+        if (-not $module.CheckMode) {
+            try {
+                Add-AdfsRelyingPartyTrust @addParams
+            }
+            catch {
+                $module.FailJson("Failed to create relying party trust '$name': $_", $_)
+            }
+
+            try {
+                $existing = Get-AdfsRelyingPartyTrust -Name $name
+            }
+            catch {
+                $module.FailJson("Failed to retrieve newly created trust '$name': $_", $_)
+            }
+        }
+    }
+    else {
+        # UPDATE
+        $updateParams = @{}
+
+        foreach ($prop in $propertyMap) {
+            $desired = $module.Params[$prop.Param]
+            if ($null -eq $desired) { continue }
+
+            if ($prop.Cast) { $desired = & $prop.Cast $desired }
+            $current = $existing.($prop.Cmdlet)
+            if ($desired -ne $current) {
+                $updateParams[$prop.Cmdlet] = $desired
+            }
+        }
+
+        if ($updateParams.Count -gt 0) {
+            $module.Result.changed = $true
+            if (-not $module.CheckMode) {
+                try {
+                    Set-AdfsRelyingPartyTrust -TargetName $name @updateParams
+                }
+                catch {
+                    $module.FailJson("Failed to update relying party trust '$name': $_", $_)
+                }
+            }
+        }
+
+        if ($null -ne $module.Params.enabled -and $module.Params.enabled -ne $existing.Enabled) {
+            $module.Result.changed = $true
+            if (-not $module.CheckMode) {
+                try {
+                    if ($module.Params.enabled) {
+                        Enable-AdfsRelyingPartyTrust -TargetName $name
+                    }
+                    else {
+                        Disable-AdfsRelyingPartyTrust -TargetName $name
+                    }
+                }
+                catch {
+                    $module.FailJson("Failed to set enabled state for relying party trust '$name': $_", $_)
+                }
+            }
+        }
+
+        if ($module.Result.changed -and -not $module.CheckMode) {
+            try {
+                $existing = Get-AdfsRelyingPartyTrust -Name $name
+            }
+            catch {
+                $module.FailJson("Failed to retrieve updated trust '$name': $_", $_)
+            }
+        }
+    }
+
+    if ($existing) {
+        $module.Result.identifier = @($existing.Identifier)
+        $module.Result.enabled = $existing.Enabled
+        $module.Result.monitoring_enabled = $existing.MonitoringEnabled
+    }
+}
+else {
+    # ABSENT
+    if ($existing) {
+        $module.Result.changed = $true
+
+        if (-not $module.CheckMode) {
+            try {
+                Remove-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false
+            }
+            catch {
+                $module.FailJson("Failed to remove relying party trust '$name': $_", $_)
+            }
+        }
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -159,16 +159,17 @@ if ($state -eq 'present') {
                     # The ADFS module is loaded via implicit remoting and
                     # SamlEndpoint objects get deserialized crossing the
                     # proxy boundary. Create them inside a WinPS session.
+                    $addTrustWithEndpoints = {
+                        param([hashtable]$Params, [string[]]$EndpointUris)
+                        $eps = foreach ($u in $EndpointUris) {
+                            New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $u
+                        }
+                        $Params['SamlEndpoint'] = @($eps)
+                        Add-AdfsRelyingPartyTrust @Params
+                    }
                     $winPS = New-PSSession -UseWindowsPowerShell
                     try {
-                        Invoke-Command -Session $winPS -ScriptBlock {
-                            param([hashtable]$Params, [string[]]$EndpointUris)
-                            $eps = foreach ($u in $EndpointUris) {
-                                New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $u
-                            }
-                            $Params['SamlEndpoint'] = @($eps)
-                            Add-AdfsRelyingPartyTrust @Params
-                        } -ArgumentList $addParams, [string[]]$module.Params.saml_endpoint
+                        Invoke-Command -Session $winPS -ScriptBlock $addTrustWithEndpoints -ArgumentList $addParams, [string[]]$module.Params.saml_endpoint
                     }
                     finally {
                         $winPS | Remove-PSSession

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -44,6 +44,7 @@ $spec = @{
         }
         token_lifetime = @{
             type = 'int'
+            no_log = $false
         }
         notes = @{
             type = 'str'

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -71,7 +71,6 @@ $spec = @{
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 $module.Result.changed = $false
-$module.Result.name = $module.Params.name
 $module.Result.identifier = @()
 $module.Result.enabled = $null
 $module.Result.monitoring_enabled = $null

--- a/plugins/modules/fs_trust.yml
+++ b/plugins/modules/fs_trust.yml
@@ -1,0 +1,199 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: fs_trust
+  short_description: Manage AD FS Relying Party Trusts
+  version_added: 1.11.0
+  description:
+    - Create, update, or remove AD FS Relying Party Trusts on a Windows
+      server running the AD FS role.
+    - Trusts can be created from a federation metadata URL, a local
+      metadata XML file, or by specifying identifiers and endpoints
+      manually.
+    - The module validates internet connectivity when O(metadata_url) is
+      used.
+  options:
+    name:
+      description:
+        - The display name of the relying party trust.
+        - This is the primary key used to identify the trust.
+      type: str
+      required: true
+    state:
+      description:
+        - Whether the relying party trust should be present or absent.
+      type: str
+      default: present
+      choices: [present, absent]
+    metadata_url:
+      description:
+        - URL pointing to the federation metadata document for the
+          relying party.
+        - The module tests connectivity to this URL before creating
+          the trust.
+        - Mutually exclusive with O(metadata_file) and O(identifier).
+      type: str
+    metadata_file:
+      description:
+        - Local file path to a federation metadata XML document.
+        - Mutually exclusive with O(metadata_url) and O(identifier).
+      type: str
+    identifier:
+      description:
+        - List of unique identifiers (URIs) for the relying party trust.
+        - Used for manual trust setup without a metadata document.
+        - Mutually exclusive with O(metadata_url) and O(metadata_file).
+      type: list
+      elements: str
+    saml_endpoint:
+      description:
+        - List of SAML Assertion Consumer Service endpoint URLs.
+        - Only used when creating a trust with O(identifier) for
+          manual setup.
+        - Each URL is registered as a SAML POST binding endpoint.
+      type: list
+      elements: str
+    wsfed_endpoint:
+      description:
+        - WS-Federation passive endpoint URL for the relying party.
+        - Only used when creating a trust with O(identifier) for
+          manual setup.
+      type: str
+    enabled:
+      description:
+        - Whether the relying party trust is enabled.
+      type: bool
+    monitoring_enabled:
+      description:
+        - Whether periodic monitoring of the relying party federation
+          metadata is enabled.
+        - Requires that the trust was created with O(metadata_url).
+      type: bool
+    auto_update_enabled:
+      description:
+        - Whether changes in the federation metadata are automatically
+          applied to the trust configuration.
+      type: bool
+    token_lifetime:
+      description:
+        - Token validity duration in minutes.
+      type: int
+    notes:
+      description:
+        - Freeform notes for the relying party trust.
+      type: str
+    access_control_policy_name:
+      description:
+        - Name of the access control policy to assign.
+      type: str
+    issuance_transform_rules:
+      description:
+        - Claim issuance transform rules as a rule language string.
+      type: str
+    issuance_authorization_rules:
+      description:
+        - Issuance authorization rules as a rule language string.
+      type: str
+    signature_algorithm:
+      description:
+        - Signature algorithm used for signing and verification.
+        - V(rsa_sha1) uses RSA-SHA1
+          (C(http://www.w3.org/2000/09/xmldsig#rsa-sha1)).
+        - V(rsa_sha256) uses RSA-SHA256
+          (C(http://www.w3.org/2001/04/xmldsig-more#rsa-sha256)).
+      type: str
+      choices: [rsa_sha1, rsa_sha256]
+    encrypt_claims:
+      description:
+        - Whether claims sent to the relying party should be encrypted.
+      type: bool
+
+  notes:
+    - This module must be run on a Windows server with the AD FS role
+      installed.
+    - The AD FS PowerShell module (ADFS) must be available on the target.
+    - Requires AD FS administrator permissions.
+    - Supports AD FS on Windows Server 2019 and later.
+  seealso:
+    - name: Add-AdfsRelyingPartyTrust
+      description: Microsoft documentation for the underlying cmdlet.
+      link: https://learn.microsoft.com/en-us/powershell/module/adfs/add-adfsrelyingpartytrust
+  extends_documentation_fragment:
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: none
+    platform:
+      platforms:
+        - windows
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Create a relying party trust from a metadata URL
+    microsoft.ad.fs_trust:
+      name: MyApp
+      metadata_url: https://app.example.com/federationmetadata/2007-06/federationmetadata.xml
+      monitoring_enabled: true
+      auto_update_enabled: true
+
+  - name: Create a relying party trust from a local metadata file
+    microsoft.ad.fs_trust:
+      name: InternalApp
+      metadata_file: C:\metadata\internal_app.xml
+      enabled: true
+
+  - name: Create a trust with manual identifiers and SAML endpoint
+    microsoft.ad.fs_trust:
+      name: CustomSaaS
+      identifier:
+        - https://app.example.com/saml
+      saml_endpoint:
+        - https://app.example.com/saml/acs
+      enabled: true
+      token_lifetime: 60
+
+  - name: Create a trust with a WS-Federation endpoint
+    microsoft.ad.fs_trust:
+      name: WsFedApp
+      identifier:
+        - https://wsfed.example.com/
+      wsfed_endpoint: https://wsfed.example.com/auth
+      access_control_policy_name: Permit everyone
+
+  - name: Update monitoring on an existing trust
+    microsoft.ad.fs_trust:
+      name: MyApp
+      metadata_url: https://app.example.com/federationmetadata/2007-06/federationmetadata.xml
+      monitoring_enabled: true
+
+  - name: Remove a relying party trust
+    microsoft.ad.fs_trust:
+      name: MyApp
+      state: absent
+
+RETURN:
+  name:
+    description: The display name of the relying party trust.
+    returned: always
+    type: str
+    sample: MyApp
+  identifier:
+    description: The list of identifiers for the relying party trust.
+    returned: success and state is present
+    type: list
+    elements: str
+    sample: ["https://app.example.com"]
+  enabled:
+    description: Whether the trust is enabled.
+    returned: success and state is present
+    type: bool
+    sample: true
+  monitoring_enabled:
+    description: Whether metadata monitoring is enabled.
+    returned: success and state is present
+    type: bool
+    sample: true

--- a/plugins/modules/fs_trust.yml
+++ b/plugins/modules/fs_trust.yml
@@ -87,14 +87,6 @@ DOCUMENTATION:
       description:
         - Name of the access control policy to assign.
       type: str
-    issuance_transform_rules:
-      description:
-        - Claim issuance transform rules as a rule language string.
-      type: str
-    issuance_authorization_rules:
-      description:
-        - Issuance authorization rules as a rule language string.
-      type: str
     signature_algorithm:
       description:
         - Signature algorithm used for signing and verification.

--- a/plugins/modules/fs_trust.yml
+++ b/plugins/modules/fs_trust.yml
@@ -11,8 +11,6 @@ DOCUMENTATION:
     - Trusts can be created from a federation metadata URL, a local
       metadata XML file, or by specifying identifiers and endpoints
       manually.
-    - The module validates internet connectivity when O(metadata_url) is
-      used.
   options:
     name:
       description:
@@ -168,11 +166,6 @@ EXAMPLES: |
       state: absent
 
 RETURN:
-  name:
-    description: The display name of the relying party trust.
-    returned: always
-    type: str
-    sample: MyApp
   identifier:
     description: The list of identifiers for the relying party trust.
     returned: success and state is present

--- a/tests/integration/targets/fs_trust/aliases
+++ b/tests/integration/targets/fs_trust/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/fs_trust/meta/main.yml
+++ b/tests/integration/targets/fs_trust/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - setup_domain
+  - setup_adfs

--- a/tests/integration/targets/fs_trust/tasks/main.yml
+++ b/tests/integration/targets/fs_trust/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 - name: Test fs_trust
   block:
+    - name: Pre-cleanup - ensure TestTrust does not exist
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        state: absent
+
     - name: Create trust from identifier - check mode
       microsoft.ad.fs_trust:
         name: TestTrust

--- a/tests/integration/targets/fs_trust/tasks/main.yml
+++ b/tests/integration/targets/fs_trust/tasks/main.yml
@@ -1,0 +1,141 @@
+---
+- name: Test fs_trust
+  block:
+    - name: Create trust from identifier - check mode
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+        enabled: true
+      register: _create_check
+      check_mode: true
+
+    - name: Assert check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _create_check is changed
+
+    - name: Create trust from identifier
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+        enabled: true
+      register: _create
+
+    - name: Assert created
+      ansible.builtin.assert:
+        that:
+          - _create is changed
+          - _create.name == 'TestTrust'
+          - _create.enabled == true
+          - _create.identifier | length > 0
+
+    - name: Create trust from identifier again - idempotency
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        enabled: true
+      register: _create_idem
+
+    - name: Assert no change on idempotent run
+      ansible.builtin.assert:
+        that:
+          - _create_idem is not changed
+
+    - name: Update trust - set notes - check mode
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        notes: Test notes for integration
+      register: _update_check
+      check_mode: true
+
+    - name: Assert update check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _update_check is changed
+
+    - name: Update trust - set notes
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        notes: Test notes for integration
+      register: _update
+
+    - name: Assert updated
+      ansible.builtin.assert:
+        that:
+          - _update is changed
+
+    - name: Update trust - set notes again - idempotency
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        notes: Test notes for integration
+      register: _update_idem
+
+    - name: Assert no change on idempotent update
+      ansible.builtin.assert:
+        that:
+          - _update_idem is not changed
+
+    - name: Remove trust - check mode
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        state: absent
+      register: _remove_check
+      check_mode: true
+
+    - name: Assert removal check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _remove_check is changed
+
+    - name: Remove trust
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        state: absent
+      register: _remove
+
+    - name: Assert removed
+      ansible.builtin.assert:
+        that:
+          - _remove is changed
+
+    - name: Remove trust again - idempotency
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        state: absent
+      register: _remove_idem
+
+    - name: Assert no change on idempotent removal
+      ansible.builtin.assert:
+        that:
+          - _remove_idem is not changed
+
+    - name: Remove non-existent trust - no error
+      microsoft.ad.fs_trust:
+        name: TrustThatDoesNotExist
+        state: absent
+      register: _remove_missing
+
+    - name: Assert no change for missing trust
+      ansible.builtin.assert:
+        that:
+          - _remove_missing is not changed
+
+  always:
+    - name: Cleanup - remove TestTrust
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/fs_trust/tasks/main.yml
+++ b/tests/integration/targets/fs_trust/tasks/main.yml
@@ -36,7 +36,6 @@
       ansible.builtin.assert:
         that:
           - _create is changed
-          - _create.name == 'TestTrust'
           - _create.enabled == true
           - _create.identifier | length > 0
 

--- a/tests/integration/targets/setup_adfs/tasks/main.yml
+++ b/tests/integration/targets/setup_adfs/tasks/main.yml
@@ -14,7 +14,7 @@
   ansible.windows.win_powershell:
     parameters:
       DomainRealm: '{{ domain_realm }}'
-      AdminPassword: '{{ ansible_password }}'
+      AdminPassword: '{{ domain_password }}'
     script: |
       [CmdletBinding()]
       param(

--- a/tests/integration/targets/setup_adfs/tasks/main.yml
+++ b/tests/integration/targets/setup_adfs/tasks/main.yml
@@ -82,27 +82,35 @@
 - name: Wait for AD FS service to come online
   ansible.windows.win_powershell:
     parameters:
-      Delay: 5
-      Retries: 60
+      Timeout: 5
+      Retries: 120
     script: |
       [CmdletBinding()]
       param(
-          [int]$Delay,
+          [int]$Timeout,
           [int]$Retries
       )
       $Ansible.Changed = $false
       $attempts = 0
       while ($true) {
           $attempts++
-          try {
+          $job = Start-Job -ScriptBlock {
               Get-AdfsRelyingPartyTrust -ErrorAction Stop | Out-Null
+          }
+          try {
+              if (-not (Wait-Job $job -Timeout $Timeout)) {
+                  throw 'ADFS cmdlet timed out'
+              }
+              Receive-Job $job -ErrorAction Stop
               break
           }
           catch {
               if ($attempts -eq $Retries) {
                   throw
               }
-              Start-Sleep -Seconds $Delay
+          }
+          finally {
+              Remove-Job $job -Force
           }
       }
       $attempts

--- a/tests/integration/targets/setup_adfs/tasks/main.yml
+++ b/tests/integration/targets/setup_adfs/tasks/main.yml
@@ -1,4 +1,22 @@
 ---
+- name: Reset Administrator password to known value
+  ansible.windows.win_powershell:
+    parameters:
+      Password: '{{ domain_password }}'
+    script: |
+      [CmdletBinding()]
+      param([string]$Password)
+      $Ansible.Changed = $false
+      $secure = ConvertTo-SecureString $Password -AsPlainText -Force
+      Set-ADAccountPassword -Identity Administrator -NewPassword $secure -Reset
+      $Ansible.Changed = $true
+  when: ansible_password is not defined
+
+- name: Update connection password
+  ansible.builtin.set_fact:
+    ansible_password: '{{ domain_password }}'
+  when: ansible_password is not defined
+
 - name: Ensure AD FS feature is installed
   ansible.windows.win_feature:
     name: ADFS-Federation

--- a/tests/integration/targets/setup_adfs/tasks/main.yml
+++ b/tests/integration/targets/setup_adfs/tasks/main.yml
@@ -32,7 +32,7 @@
   ansible.windows.win_powershell:
     parameters:
       DomainRealm: '{{ domain_realm }}'
-      AdminPassword: '{{ domain_password }}'
+      AdminPassword: '{{ ansible_password }}'
     script: |
       [CmdletBinding()]
       param(

--- a/tests/integration/targets/setup_adfs/tasks/main.yml
+++ b/tests/integration/targets/setup_adfs/tasks/main.yml
@@ -1,0 +1,90 @@
+---
+- name: Ensure AD FS feature is installed
+  ansible.windows.win_feature:
+    name: ADFS-Federation
+    include_management_tools: true
+    state: present
+  register: _adfs_feature
+
+- name: Reboot after AD FS install
+  ansible.windows.win_reboot:
+  when: _adfs_feature.reboot_required
+
+- name: Configure AD FS farm
+  ansible.windows.win_powershell:
+    parameters:
+      DomainRealm: '{{ domain_realm }}'
+      AdminPassword: '{{ ansible_password }}'
+    script: |
+      [CmdletBinding()]
+      param(
+          [string]$DomainRealm,
+          [string]$AdminPassword
+      )
+      $ErrorActionPreference = 'Stop'
+      $Ansible.Changed = $false
+
+      try {
+          Get-AdfsFarmInformation -ErrorAction Stop
+          return
+      }
+      catch {}
+
+      $certSubject = "CN=adfs.$DomainRealm"
+      $cert = Get-ChildItem -Path Cert:\LocalMachine\My |
+          Where-Object { $_.Subject -eq $certSubject } |
+          Select-Object -First 1
+
+      if (-not $cert) {
+          $cert = New-SelfSignedCertificate `
+              -DnsName "adfs.$DomainRealm" `
+              -CertStoreLocation Cert:\LocalMachine\My
+      }
+
+      $securePassword = ConvertTo-SecureString $AdminPassword -AsPlainText -Force
+      $credential = New-Object System.Management.Automation.PSCredential(
+          "$DomainRealm\Administrator", $securePassword
+      )
+
+      Install-AdfsFarm `
+          -CertificateThumbprint $cert.Thumbprint `
+          -FederationServiceDisplayName 'Test ADFS' `
+          -FederationServiceName "adfs.$DomainRealm" `
+          -ServiceAccountCredential $credential `
+          -OverwriteConfiguration `
+          -Confirm:$false
+
+      $Ansible.Changed = $true
+  register: _adfs_farm_config
+
+- name: Reboot after AD FS farm configuration
+  ansible.windows.win_reboot:
+  when: _adfs_farm_config is changed
+
+- name: Wait for AD FS service to come online
+  ansible.windows.win_powershell:
+    parameters:
+      Delay: 5
+      Retries: 60
+    script: |
+      [CmdletBinding()]
+      param(
+          [int]$Delay,
+          [int]$Retries
+      )
+      $Ansible.Changed = $false
+      $attempts = 0
+      while ($true) {
+          $attempts++
+          try {
+              Get-AdfsRelyingPartyTrust -ErrorAction Stop | Out-Null
+              break
+          }
+          catch {
+              if ($attempts -eq $Retries) {
+                  throw
+              }
+              Start-Sleep -Seconds $Delay
+          }
+      }
+      $attempts

--- a/tests/integration/targets/setup_adfs/tasks/main.yml
+++ b/tests/integration/targets/setup_adfs/tasks/main.yml
@@ -82,35 +82,35 @@
 - name: Wait for AD FS service to come online
   ansible.windows.win_powershell:
     parameters:
-      Timeout: 5
+      Delay: 5
       Retries: 120
     script: |
       [CmdletBinding()]
       param(
-          [int]$Timeout,
+          [int]$Delay,
           [int]$Retries
       )
       $Ansible.Changed = $false
       $attempts = 0
       while ($true) {
           $attempts++
-          $job = Start-Job -ScriptBlock {
-              Get-AdfsRelyingPartyTrust -ErrorAction Stop | Out-Null
-          }
           try {
-              if (-not (Wait-Job $job -Timeout $Timeout)) {
-                  throw 'ADFS cmdlet timed out'
-              }
-              Receive-Job $job -ErrorAction Stop
+              Get-AdfsRelyingPartyTrust -ErrorAction Stop | Out-Null
               break
           }
           catch {
               if ($attempts -eq $Retries) {
                   throw
               }
-          }
-          finally {
-              Remove-Job $job -Force
+              Start-Sleep -Seconds $Delay
           }
       }
       $attempts
+  async: 600
+  poll: 10
+  register: _adfs_wait
+
+- name: Verify ADFS came online
+  ansible.builtin.assert:
+    that:
+      - _adfs_wait is not failed


### PR DESCRIPTION
#### SUMMARY
- New `fs_trust` module to create, update, and remove AD FS Relying Party Trusts
- Supports three creation modes: metadata URL, metadata file, or manual identifiers with SAML/WS-Fed endpoints

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/fs_trust.ps1
- plugins/modules/fs_trust.yml
- tests/integration/targets/fs_trust/
- tests/integration/targets/setup_adfs/

#### ADDITIONAL INFORMATION
- Includes `setup_adfs` test target that installs and configures the AD FS farm for CI
- Wraps Add/Get/Set/Remove/Enable/Disable-AdfsRelyingPartyTrust cmdlets
