### PR TITLE
feat(fs_claim_rule): add module to manage AD FS claim rules

### DIFF
--- a/plugins/modules/fs_claim_rule.ps1
+++ b/plugins/modules/fs_claim_rule.ps1
@@ -75,7 +75,7 @@ $ruleMap = @(
     }
 )
 
-Function Normalize-RuleString {
+Function ConvertTo-NormalizedRuleString {
     <#
     .SYNOPSIS
     Normalizes a claim rule string for comparison. AD FS reformats
@@ -107,8 +107,8 @@ foreach ($rule in $ruleMap) {
         $joined = ($paramValue.value -join "`n").Trim()
 
         if ($paramValue.update -eq 'append') {
-            $currentNorm = Normalize-RuleString $current
-            $joinedNorm = Normalize-RuleString $joined
+            $currentNorm = ConvertTo-NormalizedRuleString $current
+            $joinedNorm = ConvertTo-NormalizedRuleString $joined
             if ($currentNorm.Contains($joinedNorm)) {
                 $desired = $current
             }
@@ -128,7 +128,7 @@ foreach ($rule in $ruleMap) {
     $module.Diff.before[$rule.Param] = $current
     $module.Diff.after[$rule.Param] = $desired
 
-    if ((Normalize-RuleString $current) -ne (Normalize-RuleString $desired)) {
+    if ((ConvertTo-NormalizedRuleString $current) -ne (ConvertTo-NormalizedRuleString $desired)) {
         $updateParams[$rule.CmdletParam] = $desired
     }
 

--- a/plugins/modules/fs_claim_rule.ps1
+++ b/plugins/modules/fs_claim_rule.ps1
@@ -1,0 +1,150 @@
+#!powershell
+
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$ruleSubSpec = @{
+    type = 'dict'
+    options = @{
+        value = @{
+            type = 'list'
+            elements = 'str'
+            required = $true
+        }
+        update = @{
+            type = 'str'
+            default = 'set'
+            choices = @('set', 'append')
+        }
+    }
+}
+
+$spec = @{
+    options = @{
+        name = @{
+            type = 'str'
+            required = $true
+        }
+        transform_rules = $ruleSubSpec
+        authorization_rules = $ruleSubSpec
+        state = @{
+            type = 'str'
+            default = 'present'
+            choices = @('present', 'absent')
+        }
+    }
+    required_if = @(
+        , @('state', 'present', @('transform_rules', 'authorization_rules'), $true)
+    )
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$module.Result.changed = $false
+$module.Result.transform_rules = $null
+$module.Result.authorization_rules = $null
+$module.Diff.before = @{}
+$module.Diff.after = @{}
+
+$name = $module.Params.name
+$state = $module.Params.state
+
+try {
+    $trust = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction Stop
+}
+catch {
+    $module.FailJson("Failed to retrieve relying party trust '$name': $_", $_)
+}
+
+if (-not $trust) {
+    $module.FailJson("Relying party trust '$name' not found.")
+}
+
+$ruleMap = @(
+    @{
+        Param = 'transform_rules'
+        CmdletParam = 'IssuanceTransformRules'
+        TrustProp = 'IssuanceTransformRules'
+    }
+    @{
+        Param = 'authorization_rules'
+        CmdletParam = 'IssuanceAuthorizationRules'
+        TrustProp = 'IssuanceAuthorizationRules'
+    }
+)
+
+Function Normalize-RuleString {
+    <#
+    .SYNOPSIS
+    Normalizes a claim rule string for comparison. AD FS reformats
+    rules when storing them (adds leading spaces, joins continuation
+    lines, changes line breaks). Collapsing all whitespace into
+    single spaces produces a canonical form that matches regardless
+    of how AD FS chose to format the stored text.
+    #>
+    param([string]$Value)
+    ($Value -replace '\s+', ' ').Trim()
+}
+
+$updateParams = @{}
+
+foreach ($rule in $ruleMap) {
+    $currentRaw = $trust.($rule.TrustProp)
+    if ($null -ne $currentRaw) {
+        $current = $currentRaw.Replace("`r`n", "`n").Trim()
+    }
+    else {
+        $current = ''
+    }
+    $paramValue = $module.Params[$rule.Param]
+
+    if ($state -eq 'absent') {
+        $desired = ''
+    }
+    elseif ($null -ne $paramValue) {
+        $joined = ($paramValue.value -join "`n").Trim()
+
+        if ($paramValue.update -eq 'append') {
+            $currentNorm = Normalize-RuleString $current
+            $joinedNorm = Normalize-RuleString $joined
+            if ($currentNorm.Contains($joinedNorm)) {
+                $desired = $current
+            }
+            else {
+                $desired = "$current`n$joined"
+            }
+        }
+        else {
+            $desired = $joined
+        }
+    }
+    else {
+        $module.Result[$rule.Param] = $current
+        continue
+    }
+
+    $module.Diff.before[$rule.Param] = $current
+    $module.Diff.after[$rule.Param] = $desired
+
+    if ((Normalize-RuleString $current) -ne (Normalize-RuleString $desired)) {
+        $updateParams[$rule.CmdletParam] = $desired
+    }
+
+    $module.Result[$rule.Param] = $desired
+}
+
+if ($updateParams.Count -gt 0) {
+    $module.Result.changed = $true
+    if (-not $module.CheckMode) {
+        try {
+            Set-AdfsRelyingPartyTrust -TargetName $name @updateParams
+        }
+        catch {
+            $module.FailJson("Failed to set claim rules on '$name': $_", $_)
+        }
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/fs_claim_rule.yml
+++ b/plugins/modules/fs_claim_rule.yml
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: fs_claim_rule
+  short_description: Manage AD FS claim rules on a Relying Party Trust
+  version_added: 1.11.0
+  description:
+    - Set, append, or clear Issuance Transform Rules and Issuance
+      Authorization Rules on an existing AD FS Relying Party Trust.
+    - The Relying Party Trust must already exist; use
+      M(microsoft.ad.fs_trust) to create it.
+  options:
+    name:
+      description:
+        - The display name of the Relying Party Trust to manage rules on.
+      type: str
+      required: true
+    transform_rules:
+      description:
+        - Issuance Transform Rules to apply to the trust.
+        - These rules define how incoming identity claims are mapped or
+          transformed before being sent to the relying party.
+      type: dict
+      suboptions:
+        value:
+          description:
+            - List of claim rule strings in the AD FS claim rule
+              language.
+            - Each item is one rule block. Multiple items are joined
+              with newlines before being applied.
+          type: list
+          elements: str
+          required: true
+        update:
+          description:
+            - How to apply the rules.
+            - V(set) replaces all existing transform rules with the
+              provided value.
+            - V(append) adds the provided rules after any existing
+              transform rules.
+          type: str
+          default: set
+          choices: [set, append]
+    authorization_rules:
+      description:
+        - Issuance Authorization Rules to apply to the trust.
+        - These rules define who is authorized to receive a token
+          for the relying party.
+      type: dict
+      suboptions:
+        value:
+          description:
+            - List of claim rule strings in the AD FS claim rule
+              language.
+            - Each item is one rule block. Multiple items are joined
+              with newlines before being applied.
+          type: list
+          elements: str
+          required: true
+        update:
+          description:
+            - How to apply the rules.
+            - V(set) replaces all existing authorization rules with
+              the provided value.
+            - V(append) adds the provided rules after any existing
+              authorization rules.
+          type: str
+          default: set
+          choices: [set, append]
+    state:
+      description:
+        - When V(present), the specified rules are set or appended.
+        - When V(absent), all issuance transform and authorization
+          rules are cleared from the trust.
+      type: str
+      default: present
+      choices: [present, absent]
+
+  notes:
+    - This module must be run on a Windows host with the AD FS role
+      installed.
+    - The AD FS PowerShell module (ADFS) must be available on the
+      target.
+    - The Relying Party Trust must already exist.
+    - AD FS validates claim rule syntax strictly. Syntax errors from
+      the server are surfaced in the module failure message.
+  seealso:
+    - module: microsoft.ad.fs_trust
+    - name: Set-AdfsRelyingPartyTrust
+      description: Microsoft documentation for the underlying cmdlet.
+      link: https://learn.microsoft.com/en-us/powershell/module/adfs/set-adfsrelyingpartytrust
+  extends_documentation_fragment:
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms:
+        - windows
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Set issuance transform rules (overwrites existing)
+    microsoft.ad.fs_claim_rule:
+      name: MyApp
+      transform_rules:
+        value:
+          - |
+            @RuleName = "Send Email as NameID"
+            c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname",
+               Issuer == "AD AUTHORITY"]
+            => issue(store = "Active Directory",
+                     types = ("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"),
+                     query = ";mail;{0}", param = c.Value);
+
+  - name: Set multiple transform rules at once
+    microsoft.ad.fs_claim_rule:
+      name: MyApp
+      transform_rules:
+        value:
+          - |
+            @RuleName = "Pass Through UPN"
+            c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+            => issue(claim = c);
+          - |
+            @RuleName = "Pass Through Email"
+            c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]
+            => issue(claim = c);
+
+  - name: Append a rule to existing transform rules
+    microsoft.ad.fs_claim_rule:
+      name: MyApp
+      transform_rules:
+        update: append
+        value:
+          - |
+            @RuleName = "Send Group Membership"
+            c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+               Value =~ "^S-1-5-21-"]
+            => issue(claim = c);
+
+  - name: Set authorization rules
+    microsoft.ad.fs_claim_rule:
+      name: MyApp
+      authorization_rules:
+        value:
+          - |
+            @RuleTemplate = "AllowAllAuthzRule"
+            => issue(Type = "http://schemas.microsoft.com/authorization/claims/permit",
+                     Value = "true");
+
+  - name: Set both transform and authorization rules
+    microsoft.ad.fs_claim_rule:
+      name: MyApp
+      transform_rules:
+        value:
+          - |
+            @RuleName = "Pass Through UPN"
+            c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+            => issue(claim = c);
+      authorization_rules:
+        value:
+          - |
+            @RuleTemplate = "AllowAllAuthzRule"
+            => issue(Type = "http://schemas.microsoft.com/authorization/claims/permit",
+                     Value = "true");
+
+  - name: Clear all claim rules from a trust
+    microsoft.ad.fs_claim_rule:
+      name: MyApp
+      state: absent
+
+RETURN:
+  transform_rules:
+    description:
+      - The issuance transform rules on the trust after the module runs.
+    returned: always
+    type: str
+    sample: '@RuleName = "Send Email" ...'
+  authorization_rules:
+    description:
+      - The issuance authorization rules on the trust after the module
+        runs.
+    returned: always
+    type: str
+    sample: '@RuleTemplate = "AllowAllAuthzRule" ...'

--- a/tests/integration/targets/fs_claim_rule/aliases
+++ b/tests/integration/targets/fs_claim_rule/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/fs_claim_rule/meta/main.yml
+++ b/tests/integration/targets/fs_claim_rule/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - setup_domain
+  - setup_adfs

--- a/tests/integration/targets/fs_claim_rule/tasks/main.yml
+++ b/tests/integration/targets/fs_claim_rule/tasks/main.yml
@@ -1,0 +1,246 @@
+---
+
+# TODO: Replace win_powershell trust setup/cleanup with microsoft.ad.fs_trust
+# once PR #235 is merged.
+#
+# - name: Pre-cleanup - ensure test trust does not exist
+#   microsoft.ad.fs_trust:
+#     name: AnsibleTestClaimRule
+#     state: absent
+#
+# - name: Create test relying party trust
+#   microsoft.ad.fs_trust:
+#     name: AnsibleTestClaimRule
+#     identifier:
+#       - https://ansible-test-claim-rule.example.com
+#     enabled: true
+
+- name: Pre-cleanup - ensure test trust does not exist
+  ansible.windows.win_powershell:
+    script: |
+      $name = 'AnsibleTestClaimRule'
+      $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction SilentlyContinue
+      if ($existing) {
+          Remove-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false
+      }
+      $Ansible.Changed = [bool]$existing
+
+- name: Create test relying party trust
+  ansible.windows.win_powershell:
+    script: |
+      $name = 'AnsibleTestClaimRule'
+      Add-AdfsRelyingPartyTrust -Name $name -Identifier 'https://ansible-test-claim-rule.example.com'
+      $Ansible.Changed = $true
+
+- name: Test fs_claim_rule
+  block:
+    - name: Set transform rules - check mode
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        transform_rules:
+          value:
+            - |
+              @RuleName = "PassThroughUPN"
+              c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+              => issue(claim = c);
+      register: _set_check
+      check_mode: true
+
+    - name: Assert check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _set_check is changed
+
+    - name: Verify rules were not actually set in check mode
+      ansible.windows.win_powershell:
+        script: |
+          $trust = Get-AdfsRelyingPartyTrust -Name 'AnsibleTestClaimRule'
+          $rules = $trust.IssuanceTransformRules
+          if ($null -eq $rules) { $rules = '' }
+          $Ansible.Result = $rules.Trim()
+      register: _check_verify
+
+    - name: Assert rules are still empty after check mode
+      ansible.builtin.assert:
+        that:
+          - _check_verify.result == ''
+
+    - name: Set transform rules
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        transform_rules:
+          value:
+            - |
+              @RuleName = "PassThroughUPN"
+              c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+              => issue(claim = c);
+      register: _set
+
+    - name: Assert rules were set
+      ansible.builtin.assert:
+        that:
+          - _set is changed
+          - _set.transform_rules is defined
+          - _set.transform_rules | length > 0
+
+    - name: Set same transform rules again (idempotency)
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        transform_rules:
+          value:
+            - |
+              @RuleName = "PassThroughUPN"
+              c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+              => issue(claim = c);
+      register: _set_idem
+
+    - name: Assert no change on idempotent run
+      ansible.builtin.assert:
+        that:
+          - _set_idem is not changed
+
+    - name: Set multiple transform rules as a list
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        transform_rules:
+          value:
+            - |
+              @RuleName = "PassThroughUPN"
+              c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+              => issue(claim = c);
+            - |
+              @RuleName = "PassThroughEmail"
+              c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]
+              => issue(claim = c);
+      register: _set_multi
+
+    - name: Assert multiple rules were set
+      ansible.builtin.assert:
+        that:
+          - _set_multi is changed
+          - '"PassThroughUPN" in _set_multi.transform_rules'
+          - '"PassThroughEmail" in _set_multi.transform_rules'
+
+    - name: Append a transform rule
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        transform_rules:
+          update: append
+          value:
+            - |
+              @RuleName = "PassThroughGroups"
+              c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid"]
+              => issue(claim = c);
+      register: _append
+
+    - name: Assert append reported changed
+      ansible.builtin.assert:
+        that:
+          - _append is changed
+          - '"PassThroughUPN" in _append.transform_rules'
+          - '"PassThroughEmail" in _append.transform_rules'
+          - '"PassThroughGroups" in _append.transform_rules'
+
+    - name: Append same rule again (idempotency)
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        transform_rules:
+          update: append
+          value:
+            - |
+              @RuleName = "PassThroughGroups"
+              c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid"]
+              => issue(claim = c);
+      register: _append_idem
+
+    - name: Assert no change on idempotent append
+      ansible.builtin.assert:
+        that:
+          - _append_idem is not changed
+
+    - name: Set authorization rules
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        authorization_rules:
+          value:
+            - |
+              @RuleTemplate = "AllowAllAuthzRule"
+              => issue(Type = "http://schemas.microsoft.com/authorization/claims/permit",
+                       Value = "true");
+      register: _set_authz
+
+    - name: Assert authorization rules were set
+      ansible.builtin.assert:
+        that:
+          - _set_authz is changed
+          - _set_authz.authorization_rules is defined
+          - _set_authz.authorization_rules | length > 0
+
+    - name: Set same authorization rules again (idempotency)
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        authorization_rules:
+          value:
+            - |
+              @RuleTemplate = "AllowAllAuthzRule"
+              => issue(Type = "http://schemas.microsoft.com/authorization/claims/permit",
+                       Value = "true");
+      register: _set_authz_idem
+
+    - name: Assert no change on idempotent authorization rules
+      ansible.builtin.assert:
+        that:
+          - _set_authz_idem is not changed
+
+    - name: Clear all rules - check mode
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        state: absent
+      register: _clear_check
+      check_mode: true
+
+    - name: Assert clear check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _clear_check is changed
+
+    - name: Clear all rules
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        state: absent
+      register: _clear
+
+    - name: Assert clear reported changed
+      ansible.builtin.assert:
+        that:
+          - _clear is changed
+
+    - name: Clear all rules again (idempotency)
+      microsoft.ad.fs_claim_rule:
+        name: AnsibleTestClaimRule
+        state: absent
+      register: _clear_idem
+
+    - name: Assert no change on idempotent clear
+      ansible.builtin.assert:
+        that:
+          - _clear_idem is not changed
+
+  always:
+    # TODO: Replace with microsoft.ad.fs_trust once PR #235 is merged.
+    #
+    # - name: Cleanup - remove test relying party trust
+    #   microsoft.ad.fs_trust:
+    #     name: AnsibleTestClaimRule
+    #     state: absent
+    #   failed_when: false
+
+    - name: Cleanup - remove test relying party trust
+      ansible.windows.win_powershell:
+        script: |
+          $name = 'AnsibleTestClaimRule'
+          $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction SilentlyContinue
+          if ($existing) {
+              Remove-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false
+          }
+      failed_when: false

--- a/tests/integration/targets/fs_claim_rule/tasks/main.yml
+++ b/tests/integration/targets/fs_claim_rule/tasks/main.yml
@@ -1,36 +1,16 @@
 ---
 
-# TODO: Replace win_powershell trust setup/cleanup with microsoft.ad.fs_trust
-# once PR #235 is merged.
-#
-# - name: Pre-cleanup - ensure test trust does not exist
-#   microsoft.ad.fs_trust:
-#     name: AnsibleTestClaimRule
-#     state: absent
-#
-# - name: Create test relying party trust
-#   microsoft.ad.fs_trust:
-#     name: AnsibleTestClaimRule
-#     identifier:
-#       - https://ansible-test-claim-rule.example.com
-#     enabled: true
-
 - name: Pre-cleanup - ensure test trust does not exist
-  ansible.windows.win_powershell:
-    script: |
-      $name = 'AnsibleTestClaimRule'
-      $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction SilentlyContinue
-      if ($existing) {
-          Remove-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false
-      }
-      $Ansible.Changed = [bool]$existing
+  microsoft.ad.fs_trust:
+    name: AnsibleTestClaimRule
+    state: absent
 
 - name: Create test relying party trust
-  ansible.windows.win_powershell:
-    script: |
-      $name = 'AnsibleTestClaimRule'
-      Add-AdfsRelyingPartyTrust -Name $name -Identifier 'https://ansible-test-claim-rule.example.com'
-      $Ansible.Changed = $true
+  microsoft.ad.fs_trust:
+    name: AnsibleTestClaimRule
+    identifier:
+      - https://ansible-test-claim-rule.example.com
+    enabled: true
 
 - name: Test fs_claim_rule
   block:
@@ -227,20 +207,8 @@
           - _clear_idem is not changed
 
   always:
-    # TODO: Replace with microsoft.ad.fs_trust once PR #235 is merged.
-    #
-    # - name: Cleanup - remove test relying party trust
-    #   microsoft.ad.fs_trust:
-    #     name: AnsibleTestClaimRule
-    #     state: absent
-    #   failed_when: false
-
     - name: Cleanup - remove test relying party trust
-      ansible.windows.win_powershell:
-        script: |
-          $name = 'AnsibleTestClaimRule'
-          $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction SilentlyContinue
-          if ($existing) {
-              Remove-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false
-          }
-      failed_when: false
+      microsoft.ad.fs_trust:
+        name: AnsibleTestClaimRule
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
#### SUMMARY
- New `fs_claim_rule` module to manage AD FS Issuance Transform Rules and Issuance Authorization Rules on a Relying Party Trust

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/fs_claim_rule.ps1
- plugins/modules/fs_claim_rule.yml
- tests/integration/targets/fs_claim_rule/
- tests/integration/targets/setup_adfs/

#### ADDITIONAL INFORMATION
- Wraps `Get-AdfsRelyingPartyTrust` and `Set-AdfsRelyingPartyTrust` cmdlets
- Integration tests needs updating once fs_trsut module #235 is merged.
