### PR TITLE
feat(site): add new module to manage AD replication sites

### DIFF
--- a/plugins/modules/site.ps1
+++ b/plugins/modules/site.ps1
@@ -1,0 +1,189 @@
+#!powershell
+
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        name = @{
+            type = 'str'
+            required = $true
+        }
+        state = @{
+            type = 'str'
+            default = 'present'
+            choices = @('present', 'absent')
+        }
+        description = @{
+            type = 'str'
+        }
+        managed_by = @{
+            type = 'str'
+        }
+        protected_from_accidental_deletion = @{
+            type = 'bool'
+        }
+        automatic_inter_site_topology_generation_enabled = @{
+            type = 'bool'
+        }
+        automatic_topology_generation_enabled = @{
+            type = 'bool'
+        }
+        universal_group_caching_enabled = @{
+            type = 'bool'
+        }
+        domain_server = @{
+            type = 'str'
+        }
+    }
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Result.changed = $false
+$module.Result.distinguished_name = $null
+$module.Result.name = $module.Params.name
+$module.Result.description = $null
+$module.Diff.before = @{}
+$module.Diff.after = @{}
+
+$name = $module.Params.name
+$state = $module.Params.state
+
+$adParams = @{}
+if ($module.Params.domain_server) {
+    $adParams.Server = $module.Params.domain_server
+}
+
+$propertyMap = @(
+    @{ Param = 'description'; CmdletParam = 'Description' }
+    @{ Param = 'managed_by'; CmdletParam = 'ManagedBy' }
+    @{ Param = 'protected_from_accidental_deletion'; CmdletParam = 'ProtectedFromAccidentalDeletion' }
+    @{ Param = 'automatic_inter_site_topology_generation_enabled'; CmdletParam = 'AutomaticInterSiteTopologyGenerationEnabled' }
+    @{ Param = 'automatic_topology_generation_enabled'; CmdletParam = 'AutomaticTopologyGenerationEnabled' }
+    @{ Param = 'universal_group_caching_enabled'; CmdletParam = 'UniversalGroupCachingEnabled' }
+)
+
+$getProperties = @($propertyMap | ForEach-Object { $_.CmdletParam })
+
+try {
+    $existing = Get-ADReplicationSite @adParams -Identity $name -Properties $getProperties
+}
+catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+    $existing = $null
+}
+catch {
+    $module.FailJson("Failed to get replication site '$name': $_", $_)
+}
+
+Function Get-SiteState {
+    param($Site)
+    $s = @{}
+    foreach ($p in $propertyMap) {
+        $s[$p.Param] = $Site.($p.CmdletParam)
+    }
+    $s
+}
+
+if ($state -eq 'present') {
+    if (-not $existing) {
+        # CREATE
+        $module.Diff.before = @{}
+        $module.Result.changed = $true
+
+        $newParams = @{}
+        foreach ($p in $propertyMap) {
+            $val = $module.Params[$p.Param]
+            if ($null -ne $val) {
+                $newParams[$p.CmdletParam] = $val
+            }
+        }
+
+        if (-not $module.CheckMode) {
+            try {
+                New-ADReplicationSite @adParams @newParams -Name $name
+            }
+            catch {
+                $module.FailJson("Failed to create replication site '$name': $_", $_)
+            }
+
+            $existing = Get-ADReplicationSite @adParams -Identity $name -Properties $getProperties
+            $module.Result.distinguished_name = $existing.DistinguishedName
+            $module.Result.description = $existing.Description
+        }
+
+        $module.Diff.after = @{ name = $name }
+        foreach ($p in $propertyMap) {
+            $val = $module.Params[$p.Param]
+            if ($null -ne $val) {
+                $module.Diff.after[$p.Param] = $val
+            }
+        }
+    }
+    else {
+        # UPDATE
+        $module.Result.distinguished_name = $existing.DistinguishedName
+        $module.Result.description = $existing.Description
+
+        $beforeState = Get-SiteState -Site $existing
+        $module.Diff.before = @{ name = $existing.Name } + $beforeState
+
+        $setParams = @{}
+        foreach ($p in $propertyMap) {
+            $desired = $module.Params[$p.Param]
+            if ($null -eq $desired) { continue }
+
+            $current = $existing.($p.CmdletParam)
+            if ($desired -ne $current) {
+                $setParams[$p.CmdletParam] = $desired
+            }
+        }
+
+        if ($setParams.Count -gt 0) {
+            $module.Result.changed = $true
+            if (-not $module.CheckMode) {
+                try {
+                    Set-ADReplicationSite @adParams -Identity $name @setParams
+                }
+                catch {
+                    $module.FailJson("Failed to update replication site '$name': $_", $_)
+                }
+
+                $existing = Get-ADReplicationSite @adParams -Identity $name -Properties $getProperties
+                $module.Result.description = $existing.Description
+            }
+        }
+
+        $afterState = @{ name = $existing.Name }
+        foreach ($p in $propertyMap) {
+            $desired = $module.Params[$p.Param]
+            $afterState[$p.Param] = if ($null -ne $desired) { $desired } else { $existing.($p.CmdletParam) }
+        }
+        $module.Diff.after = $afterState
+    }
+}
+else {
+    # ABSENT
+    if ($existing) {
+        $beforeState = Get-SiteState -Site $existing
+        $module.Diff.before = @{ name = $existing.Name } + $beforeState
+        $module.Result.distinguished_name = $existing.DistinguishedName
+        $module.Result.description = $existing.Description
+        $module.Result.changed = $true
+
+        if (-not $module.CheckMode) {
+            try {
+                Remove-ADReplicationSite @adParams -Identity $name -Confirm:$false
+            }
+            catch {
+                $module.FailJson("Failed to remove replication site '$name': $_", $_)
+            }
+        }
+    }
+    $module.Diff.after = @{}
+}
+
+$module.ExitJson()

--- a/plugins/modules/site.ps1
+++ b/plugins/modules/site.ps1
@@ -72,11 +72,13 @@ $getProperties = @($propertyMap | ForEach-Object { $_.CmdletParam })
 try {
     $existing = Get-ADReplicationSite @adParams -Identity $name -Properties $getProperties
 }
-catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-    $existing = $null
-}
 catch {
-    $module.FailJson("Failed to get replication site '$name': $_", $_)
+    if ($_.Exception.GetType().Name -eq 'ADIdentityNotFoundException') {
+        $existing = $null
+    }
+    else {
+        $module.FailJson("Failed to get replication site '$name': $_", $_)
+    }
 }
 
 Function Get-SiteState {

--- a/plugins/modules/site.ps1
+++ b/plugins/modules/site.ps1
@@ -4,188 +4,37 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ..module_utils._ADObject
 
-$spec = @{
-    options = @{
-        name = @{
-            type = 'str'
-            required = $true
+$setParams = @{
+    PropertyInfo = @(
+        [PSCustomObject]@{
+            Name = 'managed_by'
+            Option = @{ type = 'raw' }
+            Attribute = 'ManagedBy'
+            DNLookup = $true
         }
-        state = @{
-            type = 'str'
-            default = 'present'
-            choices = @('present', 'absent')
+        [PSCustomObject]@{
+            Name = 'automatic_inter_site_topology_generation_enabled'
+            Option = @{ type = 'bool' }
+            Attribute = 'AutomaticInterSiteTopologyGenerationEnabled'
         }
-        description = @{
-            type = 'str'
+        [PSCustomObject]@{
+            Name = 'automatic_topology_generation_enabled'
+            Option = @{ type = 'bool' }
+            Attribute = 'AutomaticTopologyGenerationEnabled'
         }
-        managed_by = @{
-            type = 'str'
+        [PSCustomObject]@{
+            Name = 'universal_group_caching_enabled'
+            Option = @{ type = 'bool' }
+            Attribute = 'UniversalGroupCachingEnabled'
         }
-        protected_from_accidental_deletion = @{
-            type = 'bool'
-        }
-        automatic_inter_site_topology_generation_enabled = @{
-            type = 'bool'
-        }
-        automatic_topology_generation_enabled = @{
-            type = 'bool'
-        }
-        universal_group_caching_enabled = @{
-            type = 'bool'
-        }
-        domain_server = @{
-            type = 'str'
-        }
-    }
-    supports_check_mode = $true
-}
-
-$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
-
-$module.Result.changed = $false
-$module.Result.distinguished_name = $null
-$module.Result.name = $module.Params.name
-$module.Result.description = $null
-$module.Diff.before = @{}
-$module.Diff.after = @{}
-
-$name = $module.Params.name
-$state = $module.Params.state
-
-$adParams = @{}
-if ($module.Params.domain_server) {
-    $adParams.Server = $module.Params.domain_server
-}
-
-$propertyMap = @(
-    @{ Param = 'description'; CmdletParam = 'Description' }
-    @{ Param = 'managed_by'; CmdletParam = 'ManagedBy' }
-    @{ Param = 'protected_from_accidental_deletion'; CmdletParam = 'ProtectedFromAccidentalDeletion' }
-    @{ Param = 'automatic_inter_site_topology_generation_enabled'; CmdletParam = 'AutomaticInterSiteTopologyGenerationEnabled' }
-    @{ Param = 'automatic_topology_generation_enabled'; CmdletParam = 'AutomaticTopologyGenerationEnabled' }
-    @{ Param = 'universal_group_caching_enabled'; CmdletParam = 'UniversalGroupCachingEnabled' }
-)
-
-$getProperties = @($propertyMap | ForEach-Object { $_.CmdletParam })
-
-try {
-    $existing = Get-ADReplicationSite @adParams -Identity $name -Properties $getProperties
-}
-catch {
-    if ($_.Exception.GetType().Name -eq 'ADIdentityNotFoundException') {
-        $existing = $null
-    }
-    else {
-        $module.FailJson("Failed to get replication site '$name': $_", $_)
+    )
+    ModuleNoun = 'ADReplicationSite'
+    DefaultPath = {
+        param($Module, $ADParams)
+        $configNC = (Get-ADRootDSE @ADParams -Properties configurationNamingContext).configurationNamingContext
+        "CN=Sites,$configNC"
     }
 }
-
-Function Get-SiteState {
-    param($Site)
-    $s = @{}
-    foreach ($p in $propertyMap) {
-        $s[$p.Param] = $Site.($p.CmdletParam)
-    }
-    $s
-}
-
-if ($state -eq 'present') {
-    if (-not $existing) {
-        # CREATE
-        $module.Diff.before = @{}
-        $module.Result.changed = $true
-
-        $newParams = @{}
-        foreach ($p in $propertyMap) {
-            $val = $module.Params[$p.Param]
-            if ($null -ne $val) {
-                $newParams[$p.CmdletParam] = $val
-            }
-        }
-
-        if (-not $module.CheckMode) {
-            try {
-                New-ADReplicationSite @adParams @newParams -Name $name
-            }
-            catch {
-                $module.FailJson("Failed to create replication site '$name': $_", $_)
-            }
-
-            $existing = Get-ADReplicationSite @adParams -Identity $name -Properties $getProperties
-            $module.Result.distinguished_name = $existing.DistinguishedName
-            $module.Result.description = $existing.Description
-        }
-
-        $module.Diff.after = @{ name = $name }
-        foreach ($p in $propertyMap) {
-            $val = $module.Params[$p.Param]
-            if ($null -ne $val) {
-                $module.Diff.after[$p.Param] = $val
-            }
-        }
-    }
-    else {
-        # UPDATE
-        $module.Result.distinguished_name = $existing.DistinguishedName
-        $module.Result.description = $existing.Description
-
-        $beforeState = Get-SiteState -Site $existing
-        $module.Diff.before = @{ name = $existing.Name } + $beforeState
-
-        $setParams = @{}
-        foreach ($p in $propertyMap) {
-            $desired = $module.Params[$p.Param]
-            if ($null -eq $desired) { continue }
-
-            $current = $existing.($p.CmdletParam)
-            if ($desired -ne $current) {
-                $setParams[$p.CmdletParam] = $desired
-            }
-        }
-
-        if ($setParams.Count -gt 0) {
-            $module.Result.changed = $true
-            if (-not $module.CheckMode) {
-                try {
-                    Set-ADReplicationSite @adParams -Identity $name @setParams
-                }
-                catch {
-                    $module.FailJson("Failed to update replication site '$name': $_", $_)
-                }
-
-                $existing = Get-ADReplicationSite @adParams -Identity $name -Properties $getProperties
-                $module.Result.description = $existing.Description
-            }
-        }
-
-        $afterState = @{ name = $existing.Name }
-        foreach ($p in $propertyMap) {
-            $desired = $module.Params[$p.Param]
-            $afterState[$p.Param] = if ($null -ne $desired) { $desired } else { $existing.($p.CmdletParam) }
-        }
-        $module.Diff.after = $afterState
-    }
-}
-else {
-    # ABSENT
-    if ($existing) {
-        $beforeState = Get-SiteState -Site $existing
-        $module.Diff.before = @{ name = $existing.Name } + $beforeState
-        $module.Result.distinguished_name = $existing.DistinguishedName
-        $module.Result.description = $existing.Description
-        $module.Result.changed = $true
-
-        if (-not $module.CheckMode) {
-            try {
-                Remove-ADReplicationSite @adParams -Identity $name -Confirm:$false
-            }
-            catch {
-                $module.FailJson("Failed to remove replication site '$name': $_", $_)
-            }
-        }
-    }
-    $module.Diff.after = @{}
-}
-
-$module.ExitJson()
+Invoke-AnsibleADObject @setParams

--- a/plugins/modules/site.yml
+++ b/plugins/modules/site.yml
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: site
+  short_description: Manage Active Directory replication sites
+  version_added: 1.11.0
+  description:
+    - Create, modify, or remove Active Directory replication sites.
+    - Sites are used to control replication traffic and help clients
+      discover nearby network resources such as domain controllers.
+  options:
+    name:
+      description:
+        - The name of the replication site.
+      type: str
+      required: true
+    state:
+      description:
+        - Whether the site should be present or absent.
+      type: str
+      default: present
+      choices: [present, absent]
+    description:
+      description:
+        - A description for the site.
+      type: str
+    managed_by:
+      description:
+        - The distinguished name of the principal that manages the site.
+      type: str
+    protected_from_accidental_deletion:
+      description:
+        - Whether the site is protected from accidental deletion.
+        - When V(true), a deny ACE is placed on the object that prevents
+          it from being deleted without first removing the protection.
+      type: bool
+    automatic_inter_site_topology_generation_enabled:
+      description:
+        - Whether the KCC inter-site topology generator (ISTG) creates
+          connections for inter-site replication automatically.
+        - Set to V(false) to manage inter-site connections manually while
+          retaining automatic intra-site connections.
+      type: bool
+    automatic_topology_generation_enabled:
+      description:
+        - Whether the KCC generates intra-site replication connections
+          automatically.
+        - Set to V(false) to manage intra-site connections manually.
+      type: bool
+    universal_group_caching_enabled:
+      description:
+        - Whether Universal Group Membership Caching (UGMC) is enabled
+          for the site.
+        - Useful in branch-office sites without a Global Catalog server
+          to reduce authentication latency.
+      type: bool
+    domain_server:
+      description:
+        - The FQDN of the domain controller to target for all AD operations.
+        - When not specified, the module will use the default domain
+          controller discovery.
+      type: str
+
+  notes:
+    - This module must be run on a Windows target host with the
+      ActiveDirectory PowerShell module available.
+    - Replication sites are stored in the AD Configuration partition
+      and replicated forest-wide.
+  seealso:
+    - module: microsoft.ad.object_info
+  extends_documentation_fragment:
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms:
+        - windows
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Create a replication site for the London branch office
+    microsoft.ad.site:
+      name: London-Branch
+      description: London branch office site
+      state: present
+
+  - name: Create a site with deletion protection
+    microsoft.ad.site:
+      name: NYC-HQ
+      description: New York City headquarters
+      protected_from_accidental_deletion: true
+      state: present
+
+  - name: Enable Universal Group Caching on a branch site
+    microsoft.ad.site:
+      name: London-Branch
+      universal_group_caching_enabled: true
+      state: present
+
+  - name: Disable automatic inter-site topology generation
+    microsoft.ad.site:
+      name: London-Branch
+      automatic_inter_site_topology_generation_enabled: false
+      state: present
+
+  - name: Remove a replication site
+    microsoft.ad.site:
+      name: London-Branch
+      state: absent
+
+RETURN:
+  distinguished_name:
+    description:
+      - The distinguished name of the site object.
+    returned: always
+    type: str
+    sample: "CN=London-Branch,CN=Sites,CN=Configuration,DC=contoso,DC=com"
+  name:
+    description:
+      - The name of the site.
+    returned: always
+    type: str
+    sample: "London-Branch"
+  description:
+    description:
+      - The description of the site.
+    returned: always
+    type: str
+    sample: "London branch office site"

--- a/plugins/modules/site.yml
+++ b/plugins/modules/site.yml
@@ -10,31 +10,17 @@ DOCUMENTATION:
     - Sites are used to control replication traffic and help clients
       discover nearby network resources such as domain controllers.
   options:
-    name:
-      description:
-        - The name of the replication site.
-      type: str
-      required: true
-    state:
-      description:
-        - Whether the site should be present or absent.
-      type: str
-      default: present
-      choices: [present, absent]
-    description:
-      description:
-        - A description for the site.
-      type: str
     managed_by:
       description:
-        - The distinguished name of the principal that manages the site.
-      type: str
-    protected_from_accidental_deletion:
-      description:
-        - Whether the site is protected from accidental deletion.
-        - When V(true), a deny ACE is placed on the object that prevents
-          it from being deleted without first removing the protection.
-      type: bool
+        - The user or group that manages the object.
+        - The value can be in the form of a C(distinguishedName), C(objectGUID),
+          C(objectSid), C(sAMAccountName), or C(userPrincipalName) string or a
+          dictionary with the I(name) and optional I(server) key.
+        - This is the value set on the C(managedBy) LDAP attribute.
+        - See
+          R(DN Lookup Attributes,ansible_collections.microsoft.ad.docsite.guide_attributes.dn_lookup_attributes)
+          for more information on how DN lookups work.
+      type: raw
     automatic_inter_site_topology_generation_enabled:
       description:
         - Whether the KCC inter-site topology generator (ISTG) creates
@@ -55,21 +41,14 @@ DOCUMENTATION:
         - Useful in branch-office sites without a Global Catalog server
           to reduce authentication latency.
       type: bool
-    domain_server:
-      description:
-        - The FQDN of the domain controller to target for all AD operations.
-        - When not specified, the module will use the default domain
-          controller discovery.
-      type: str
-
   notes:
+    - The I(path) option for sites defaults to the
+      C(CN=Sites,CN=Configuration,...) container. Sites cannot be moved to
+      a different container.
     - This module must be run on a Windows target host with the
-      ActiveDirectory PowerShell module available.
-    - Replication sites are stored in the AD Configuration partition
-      and replicated forest-wide.
-  seealso:
-    - module: microsoft.ad.object_info
+      C(ActiveDirectory) module installed.
   extends_documentation_fragment:
+    - microsoft.ad.ad_object
     - ansible.builtin.action_common_attributes
   attributes:
     check_mode:
@@ -79,6 +58,8 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+  seealso:
+    - module: microsoft.ad.object_info
   author:
     - Ron Gershburg (@rgershbu)
 
@@ -93,7 +74,7 @@ EXAMPLES: |
     microsoft.ad.site:
       name: NYC-HQ
       description: New York City headquarters
-      protected_from_accidental_deletion: true
+      protect_from_deletion: true
       state: present
 
   - name: Enable Universal Group Caching on a branch site
@@ -108,27 +89,31 @@ EXAMPLES: |
       automatic_inter_site_topology_generation_enabled: false
       state: present
 
+  - name: Set managedBy using an identity from another DC
+    microsoft.ad.site:
+      name: London-Branch
+      managed_by:
+        name: manager-user
+        server: OtherDC
+
   - name: Remove a replication site
     microsoft.ad.site:
       name: London-Branch
       state: absent
 
 RETURN:
+  object_guid:
+    description:
+      - The C(objectGUID) of the AD object that was created, removed, or edited.
+      - If a new object was created in check mode, a GUID of 0s will be
+        returned.
+    returned: always
+    type: str
+    sample: d84a141f-2b99-4f08-9da0-ed2d26864ba1
   distinguished_name:
     description:
-      - The distinguished name of the site object.
+      - The C(distinguishedName) of the AD object that was created, removed, or
+        edited.
     returned: always
     type: str
-    sample: "CN=London-Branch,CN=Sites,CN=Configuration,DC=contoso,DC=com"
-  name:
-    description:
-      - The name of the site.
-    returned: always
-    type: str
-    sample: "London-Branch"
-  description:
-    description:
-      - The description of the site.
-    returned: always
-    type: str
-    sample: "London branch office site"
+    sample: CN=London-Branch,CN=Sites,CN=Configuration,DC=contoso,DC=com

--- a/tests/integration/targets/site/aliases
+++ b/tests/integration/targets/site/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/site/meta/main.yml
+++ b/tests/integration/targets/site/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_domain

--- a/tests/integration/targets/site/tasks/main.yml
+++ b/tests/integration/targets/site/tasks/main.yml
@@ -1,0 +1,280 @@
+---
+
+- name: Test site module
+  block:
+    - name: Create site - check mode
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        description: Ansible integration test site
+        state: present
+      register: _create_check
+      check_mode: true
+
+    - name: Assert create check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _create_check is changed
+
+    - name: Verify site was not actually created in check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              $s = Get-ADReplicationSite -Identity 'AnsibleTestSite'
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _check_mode_verify
+
+    - name: Assert site does not exist after check mode
+      ansible.builtin.assert:
+        that:
+          - not _check_mode_verify.result
+
+    - name: Create site
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        description: Ansible integration test site
+        state: present
+      register: _create
+
+    - name: Assert site was created
+      ansible.builtin.assert:
+        that:
+          - _create is changed
+          - _create.distinguished_name is defined
+          - _create.distinguished_name | length > 0
+          - _create.name == 'AnsibleTestSite'
+          - _create.description == 'Ansible integration test site'
+
+    - name: Create same site again (idempotency)
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        description: Ansible integration test site
+        state: present
+      register: _create_idem
+
+    - name: Assert no change on idempotent run
+      ansible.builtin.assert:
+        that:
+          - _create_idem is not changed
+
+    - name: Update site description
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        description: Updated description
+        state: present
+      register: _update_desc
+
+    - name: Assert description change
+      ansible.builtin.assert:
+        that:
+          - _update_desc is changed
+          - _update_desc.description == 'Updated description'
+
+    - name: Update site description again (idempotency)
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        description: Updated description
+        state: present
+      register: _update_desc_idem
+
+    - name: Assert no change on idempotent description update
+      ansible.builtin.assert:
+        that:
+          - _update_desc_idem is not changed
+
+    - name: Enable deletion protection
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        protected_from_accidental_deletion: true
+        state: present
+      register: _update_protect
+
+    - name: Assert protection change
+      ansible.builtin.assert:
+        that:
+          - _update_protect is changed
+
+    - name: Enable deletion protection again (idempotency)
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        protected_from_accidental_deletion: true
+        state: present
+      register: _update_protect_idem
+
+    - name: Assert no change on idempotent protection update
+      ansible.builtin.assert:
+        that:
+          - _update_protect_idem is not changed
+
+    - name: Disable deletion protection for cleanup
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        protected_from_accidental_deletion: false
+        state: present
+
+    - name: Enable universal group caching
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        universal_group_caching_enabled: true
+        state: present
+      register: _update_ugc
+
+    - name: Assert UGC change
+      ansible.builtin.assert:
+        that:
+          - _update_ugc is changed
+
+    - name: Enable universal group caching again (idempotency)
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        universal_group_caching_enabled: true
+        state: present
+      register: _update_ugc_idem
+
+    - name: Assert no change on idempotent UGC update
+      ansible.builtin.assert:
+        that:
+          - _update_ugc_idem is not changed
+
+    - name: Remove site - check mode
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        state: absent
+      register: _remove_check
+      check_mode: true
+
+    - name: Assert remove check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _remove_check is changed
+
+    - name: Verify site still exists after remove check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              $s = Get-ADReplicationSite -Identity 'AnsibleTestSite'
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _remove_check_verify
+
+    - name: Assert site still exists after remove check mode
+      ansible.builtin.assert:
+        that:
+          - _remove_check_verify.result
+
+    - name: Remove site
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        state: absent
+      register: _remove
+
+    - name: Assert remove reported changed
+      ansible.builtin.assert:
+        that:
+          - _remove is changed
+
+    - name: Remove site again (idempotency)
+      microsoft.ad.site:
+        name: AnsibleTestSite
+        state: absent
+      register: _remove_idem
+
+    - name: Assert no change on idempotent remove
+      ansible.builtin.assert:
+        that:
+          - _remove_idem is not changed
+
+    - name: Get DC FQDN
+      ansible.windows.win_powershell:
+        script: |
+          $Ansible.Result = (Get-ADDomainController).HostName
+      register: _dc_fqdn
+
+    - name: Create site via domain_server
+      microsoft.ad.site:
+        name: AnsibleTestSiteDS
+        description: domain_server test
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: present
+      register: _ds_create
+
+    - name: Assert created via domain_server
+      ansible.builtin.assert:
+        that:
+          - _ds_create is changed
+
+    - name: Create site via domain_server again (idempotency)
+      microsoft.ad.site:
+        name: AnsibleTestSiteDS
+        description: domain_server test
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: present
+      register: _ds_create_idem
+
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - _ds_create_idem is not changed
+
+    - name: Update site via domain_server
+      microsoft.ad.site:
+        name: AnsibleTestSiteDS
+        description: domain_server updated
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: present
+      register: _ds_update
+
+    - name: Assert updated via domain_server
+      ansible.builtin.assert:
+        that:
+          - _ds_update is changed
+
+    - name: Remove site via domain_server
+      microsoft.ad.site:
+        name: AnsibleTestSiteDS
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: absent
+      register: _ds_remove
+
+    - name: Assert removed via domain_server
+      ansible.builtin.assert:
+        that:
+          - _ds_remove is changed
+
+    - name: Remove site via domain_server again (idempotency)
+      microsoft.ad.site:
+        name: AnsibleTestSiteDS
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: absent
+      register: _ds_remove_idem
+
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - _ds_remove_idem is not changed
+
+  always:
+    - name: Cleanup - disable deletion protection if set
+      microsoft.ad.site:
+        name: "{{ item }}"
+        protected_from_accidental_deletion: false
+        state: present
+      loop:
+        - AnsibleTestSite
+        - AnsibleTestSiteDS
+      ignore_errors: true
+
+    - name: Cleanup - remove test sites
+      microsoft.ad.site:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - AnsibleTestSite
+        - AnsibleTestSiteDS
+      failed_when: false

--- a/tests/integration/targets/site/tasks/main.yml
+++ b/tests/integration/targets/site/tasks/main.yml
@@ -45,8 +45,7 @@
           - _create is changed
           - _create.distinguished_name is defined
           - _create.distinguished_name | length > 0
-          - _create.name == 'AnsibleTestSite'
-          - _create.description == 'Ansible integration test site'
+          - _create.object_guid is defined
 
     - name: Create same site again (idempotency)
       microsoft.ad.site:
@@ -71,7 +70,6 @@
       ansible.builtin.assert:
         that:
           - _update_desc is changed
-          - _update_desc.description == 'Updated description'
 
     - name: Update site description again (idempotency)
       microsoft.ad.site:
@@ -88,7 +86,7 @@
     - name: Enable deletion protection
       microsoft.ad.site:
         name: AnsibleTestSite
-        protected_from_accidental_deletion: true
+        protect_from_deletion: true
         state: present
       register: _update_protect
 
@@ -100,7 +98,7 @@
     - name: Enable deletion protection again (idempotency)
       microsoft.ad.site:
         name: AnsibleTestSite
-        protected_from_accidental_deletion: true
+        protect_from_deletion: true
         state: present
       register: _update_protect_idem
 
@@ -112,7 +110,7 @@
     - name: Disable deletion protection for cleanup
       microsoft.ad.site:
         name: AnsibleTestSite
-        protected_from_accidental_deletion: false
+        protect_from_deletion: false
         state: present
 
     - name: Enable universal group caching
@@ -260,16 +258,6 @@
           - _ds_remove_idem is not changed
 
   always:
-    - name: Cleanup - disable deletion protection if set
-      microsoft.ad.site:
-        name: "{{ item }}"
-        protected_from_accidental_deletion: false
-        state: present
-      loop:
-        - AnsibleTestSite
-        - AnsibleTestSiteDS
-      ignore_errors: true
-
     - name: Cleanup - remove test sites
       microsoft.ad.site:
         name: "{{ item }}"
@@ -277,4 +265,4 @@
       loop:
         - AnsibleTestSite
         - AnsibleTestSiteDS
-      failed_when: false
+      ignore_errors: true


### PR DESCRIPTION
#### SUMMARY
- New standalone PowerShell module `microsoft.ad.site` to create, modify, and remove Active Directory replication sites.
- Supports all common site properties: description, managed_by, protected_from_accidental_deletion, automatic_inter_site_topology_generation_enabled, automatic_topology_generation_enabled, universal_group_caching_enabled, and domain_server.

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/site.ps1
- plugins/modules/site.yml
- tests/integration/targets/site/aliases
- tests/integration/targets/site/tasks/main.yml

#### ADDITIONAL INFORMATION
