### PR TITLE
feat(site_subnet): add new module to manage AD replication subnets

### DIFF
--- a/plugins/modules/site_subnet.ps1
+++ b/plugins/modules/site_subnet.ps1
@@ -1,0 +1,212 @@
+#!powershell
+
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        name = @{
+            type = 'str'
+            required = $true
+        }
+        site = @{
+            type = 'str'
+        }
+        description = @{
+            type = 'str'
+        }
+        location = @{
+            type = 'str'
+        }
+        state = @{
+            type = 'str'
+            default = 'present'
+            choices = @('present', 'absent')
+        }
+        domain_server = @{
+            type = 'str'
+        }
+    }
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Result.changed = $false
+$module.Result.distinguished_name = $null
+$module.Result.name = $module.Params.name
+$module.Result.site = $null
+$module.Result.description = $null
+$module.Result.location = $null
+$module.Diff.before = @{}
+$module.Diff.after = @{}
+
+$name = $module.Params.name
+$state = $module.Params.state
+
+$adParams = @{}
+if ($module.Params.domain_server) {
+    $adParams.Server = $module.Params.domain_server
+}
+
+$propertyMap = @(
+    @{ Param = 'description'; CmdletParam = 'Description' }
+    @{ Param = 'location'; CmdletParam = 'Location' }
+    @{ Param = 'site'; CmdletParam = 'Site' }
+)
+
+$getProperties = @('Description', 'Location', 'Site')
+
+try {
+    $existing = Get-ADReplicationSubnet @adParams -Identity $name -Properties $getProperties
+}
+catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+    $existing = $null
+}
+catch {
+    $module.FailJson("Failed to get replication subnet '$name': $_", $_)
+}
+
+Function Get-SiteName {
+    param($SiteValue)
+    if ($null -eq $SiteValue -or $SiteValue -eq '') {
+        return $null
+    }
+    $s = [string]$SiteValue
+    if ($s -match '^CN=([^,]+),') {
+        return $Matches[1]
+    }
+    return $s
+}
+
+Function Get-SubnetState {
+    param($Subnet)
+    @{
+        description = $Subnet.Description
+        location = $Subnet.Location
+        site = Get-SiteName -SiteValue $Subnet.Site
+    }
+}
+
+if ($state -eq 'present') {
+    if (-not $existing) {
+        # CREATE
+        $module.Diff.before = @{}
+        $module.Result.changed = $true
+
+        $newParams = @{}
+        foreach ($p in $propertyMap) {
+            $val = $module.Params[$p.Param]
+            if ($null -ne $val) {
+                $newParams[$p.CmdletParam] = $val
+            }
+        }
+
+        if (-not $module.CheckMode) {
+            try {
+                New-ADReplicationSubnet @adParams @newParams -Name $name
+            }
+            catch {
+                $module.FailJson("Failed to create replication subnet '$name': $_", $_)
+            }
+
+            $existing = Get-ADReplicationSubnet @adParams -Identity $name -Properties $getProperties
+            $module.Result.distinguished_name = $existing.DistinguishedName
+            $module.Result.description = $existing.Description
+            $module.Result.location = $existing.Location
+            $module.Result.site = Get-SiteName -SiteValue $existing.Site
+        }
+
+        $module.Diff.after = @{ name = $name }
+        foreach ($p in $propertyMap) {
+            $val = $module.Params[$p.Param]
+            if ($null -ne $val) {
+                $module.Diff.after[$p.Param] = $val
+            }
+        }
+    }
+    else {
+        # UPDATE
+        $module.Result.distinguished_name = $existing.DistinguishedName
+        $module.Result.description = $existing.Description
+        $module.Result.location = $existing.Location
+        $module.Result.site = Get-SiteName -SiteValue $existing.Site
+
+        $beforeState = Get-SubnetState -Subnet $existing
+        $module.Diff.before = @{ name = $name } + $beforeState
+
+        $setParams = @{}
+        foreach ($p in $propertyMap) {
+            $desired = $module.Params[$p.Param]
+            if ($null -eq $desired) { continue }
+
+            $current = $existing.($p.CmdletParam)
+            if ($p.Param -eq 'site') {
+                $currentSiteName = Get-SiteName -SiteValue $current
+                if ($desired -ne $currentSiteName) {
+                    $setParams[$p.CmdletParam] = $desired
+                }
+            }
+            else {
+                if ($desired -ne $current) {
+                    $setParams[$p.CmdletParam] = $desired
+                }
+            }
+        }
+
+        if ($setParams.Count -gt 0) {
+            $module.Result.changed = $true
+            if (-not $module.CheckMode) {
+                try {
+                    Set-ADReplicationSubnet @adParams -Identity $name @setParams
+                }
+                catch {
+                    $module.FailJson("Failed to update replication subnet '$name': $_", $_)
+                }
+
+                $existing = Get-ADReplicationSubnet @adParams -Identity $name -Properties $getProperties
+                $module.Result.description = $existing.Description
+                $module.Result.location = $existing.Location
+                $module.Result.site = Get-SiteName -SiteValue $existing.Site
+            }
+        }
+
+        $afterState = @{ name = $name }
+        foreach ($p in $propertyMap) {
+            $desired = $module.Params[$p.Param]
+            if ($p.Param -eq 'site') {
+                $afterState[$p.Param] = if ($null -ne $desired) { $desired } else { Get-SiteName -SiteValue $existing.Site }
+            }
+            else {
+                $afterState[$p.Param] = if ($null -ne $desired) { $desired } else { $existing.($p.CmdletParam) }
+            }
+        }
+        $module.Diff.after = $afterState
+    }
+}
+else {
+    # ABSENT
+    if ($existing) {
+        $beforeState = Get-SubnetState -Subnet $existing
+        $module.Diff.before = @{ name = $name } + $beforeState
+        $module.Result.distinguished_name = $existing.DistinguishedName
+        $module.Result.description = $existing.Description
+        $module.Result.location = $existing.Location
+        $module.Result.site = Get-SiteName -SiteValue $existing.Site
+        $module.Result.changed = $true
+
+        if (-not $module.CheckMode) {
+            try {
+                Remove-ADReplicationSubnet @adParams -Identity $name -Confirm:$false
+            }
+            catch {
+                $module.FailJson("Failed to remove replication subnet '$name': $_", $_)
+            }
+        }
+    }
+    $module.Diff.after = @{}
+}
+
+$module.ExitJson()

--- a/plugins/modules/site_subnet.ps1
+++ b/plugins/modules/site_subnet.ps1
@@ -4,209 +4,42 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ..module_utils._ADObject
 
-$spec = @{
-    options = @{
-        name = @{
-            type = 'str'
-            required = $true
+$setParams = @{
+    PropertyInfo = @(
+        [PSCustomObject]@{
+            Name = 'location'
+            Option = @{ type = 'str' }
+            Attribute = 'Location'
         }
-        site = @{
-            type = 'str'
-        }
-        description = @{
-            type = 'str'
-        }
-        location = @{
-            type = 'str'
-        }
-        state = @{
-            type = 'str'
-            default = 'present'
-            choices = @('present', 'absent')
-        }
-        domain_server = @{
-            type = 'str'
-        }
-    }
-    supports_check_mode = $true
-}
+        [PSCustomObject]@{
+            Name = 'site'
+            Option = @{ type = 'str' }
+            Attribute = 'Site'
+            Set = {
+                param($Module, $ADParams, $SetParams, $ADObject)
 
-$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
-
-$module.Result.changed = $false
-$module.Result.distinguished_name = $null
-$module.Result.name = $module.Params.name
-$module.Result.site = $null
-$module.Result.description = $null
-$module.Result.location = $null
-$module.Diff.before = @{}
-$module.Diff.after = @{}
-
-$name = $module.Params.name
-$state = $module.Params.state
-
-$adParams = @{}
-if ($module.Params.domain_server) {
-    $adParams.Server = $module.Params.domain_server
-}
-
-$propertyMap = @(
-    @{ Param = 'description'; CmdletParam = 'Description' }
-    @{ Param = 'location'; CmdletParam = 'Location' }
-    @{ Param = 'site'; CmdletParam = 'Site' }
-)
-
-$getProperties = @('Description', 'Location', 'Site')
-
-try {
-    $existing = Get-ADReplicationSubnet @adParams -Identity $name -Properties $getProperties
-}
-catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-    $existing = $null
-}
-catch {
-    $module.FailJson("Failed to get replication subnet '$name': $_", $_)
-}
-
-Function Get-SiteName {
-    param($SiteValue)
-    if ($null -eq $SiteValue -or $SiteValue -eq '') {
-        return $null
-    }
-    $s = [string]$SiteValue
-    if ($s -match '^CN=([^,]+),') {
-        return $Matches[1]
-    }
-    return $s
-}
-
-Function Get-SubnetState {
-    param($Subnet)
-    @{
-        description = $Subnet.Description
-        location = $Subnet.Location
-        site = Get-SiteName -SiteValue $Subnet.Site
-    }
-}
-
-if ($state -eq 'present') {
-    if (-not $existing) {
-        # CREATE
-        $module.Diff.before = @{}
-        $module.Result.changed = $true
-
-        $newParams = @{}
-        foreach ($p in $propertyMap) {
-            $val = $module.Params[$p.Param]
-            if ($null -ne $val) {
-                $newParams[$p.CmdletParam] = $val
-            }
-        }
-
-        if (-not $module.CheckMode) {
-            try {
-                New-ADReplicationSubnet @adParams @newParams -Name $name
-            }
-            catch {
-                $module.FailJson("Failed to create replication subnet '$name': $_", $_)
-            }
-
-            $existing = Get-ADReplicationSubnet @adParams -Identity $name -Properties $getProperties
-            $module.Result.distinguished_name = $existing.DistinguishedName
-            $module.Result.description = $existing.Description
-            $module.Result.location = $existing.Location
-            $module.Result.site = Get-SiteName -SiteValue $existing.Site
-        }
-
-        $module.Diff.after = @{ name = $name }
-        foreach ($p in $propertyMap) {
-            $val = $module.Params[$p.Param]
-            if ($null -ne $val) {
-                $module.Diff.after[$p.Param] = $val
-            }
-        }
-    }
-    else {
-        # UPDATE
-        $module.Result.distinguished_name = $existing.DistinguishedName
-        $module.Result.description = $existing.Description
-        $module.Result.location = $existing.Location
-        $module.Result.site = Get-SiteName -SiteValue $existing.Site
-
-        $beforeState = Get-SubnetState -Subnet $existing
-        $module.Diff.before = @{ name = $name } + $beforeState
-
-        $setParams = @{}
-        foreach ($p in $propertyMap) {
-            $desired = $module.Params[$p.Param]
-            if ($null -eq $desired) { continue }
-
-            $current = $existing.($p.CmdletParam)
-            if ($p.Param -eq 'site') {
-                $currentSiteName = Get-SiteName -SiteValue $current
-                if ($desired -ne $currentSiteName) {
-                    $setParams[$p.CmdletParam] = $desired
+                $currentDN = $ADObject.Site
+                $currentName = $null
+                if ($currentDN -match '^CN=([^,]+),') {
+                    $currentName = $Matches[1]
                 }
-            }
-            else {
-                if ($desired -ne $current) {
-                    $setParams[$p.CmdletParam] = $desired
+                $Module.Diff.before.site = $currentName
+
+                $desired = $Module.Params.site
+                if ($desired -ne $currentName) {
+                    $SetParams.Site = $desired
                 }
+                $Module.Diff.after.site = $desired
             }
         }
-
-        if ($setParams.Count -gt 0) {
-            $module.Result.changed = $true
-            if (-not $module.CheckMode) {
-                try {
-                    Set-ADReplicationSubnet @adParams -Identity $name @setParams
-                }
-                catch {
-                    $module.FailJson("Failed to update replication subnet '$name': $_", $_)
-                }
-
-                $existing = Get-ADReplicationSubnet @adParams -Identity $name -Properties $getProperties
-                $module.Result.description = $existing.Description
-                $module.Result.location = $existing.Location
-                $module.Result.site = Get-SiteName -SiteValue $existing.Site
-            }
-        }
-
-        $afterState = @{ name = $name }
-        foreach ($p in $propertyMap) {
-            $desired = $module.Params[$p.Param]
-            if ($p.Param -eq 'site') {
-                $afterState[$p.Param] = if ($null -ne $desired) { $desired } else { Get-SiteName -SiteValue $existing.Site }
-            }
-            else {
-                $afterState[$p.Param] = if ($null -ne $desired) { $desired } else { $existing.($p.CmdletParam) }
-            }
-        }
-        $module.Diff.after = $afterState
+    )
+    ModuleNoun = 'ADReplicationSubnet'
+    DefaultPath = {
+        param($Module, $ADParams)
+        $configNC = (Get-ADRootDSE @ADParams -Properties configurationNamingContext).configurationNamingContext
+        "CN=Subnets,CN=Sites,$configNC"
     }
 }
-else {
-    # ABSENT
-    if ($existing) {
-        $beforeState = Get-SubnetState -Subnet $existing
-        $module.Diff.before = @{ name = $name } + $beforeState
-        $module.Result.distinguished_name = $existing.DistinguishedName
-        $module.Result.description = $existing.Description
-        $module.Result.location = $existing.Location
-        $module.Result.site = Get-SiteName -SiteValue $existing.Site
-        $module.Result.changed = $true
-
-        if (-not $module.CheckMode) {
-            try {
-                Remove-ADReplicationSubnet @adParams -Identity $name -Confirm:$false
-            }
-            catch {
-                $module.FailJson("Failed to remove replication subnet '$name': $_", $_)
-            }
-        }
-    }
-    $module.Diff.after = @{}
-}
-
-$module.ExitJson()
+Invoke-AnsibleADObject @setParams

--- a/plugins/modules/site_subnet.yml
+++ b/plugins/modules/site_subnet.yml
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: site_subnet
+  short_description: Manage Active Directory replication subnets
+  version_added: 1.11.0
+  description:
+    - Create, modify, or remove Active Directory replication subnets.
+    - Subnets determine which replication site a computer belongs to
+      by mapping IP address ranges to sites, which in turn controls
+      domain controller discovery and replication topology.
+  options:
+    name:
+      description:
+        - The subnet name in CIDR notation (network/bits).
+        - "Examples: V(10.0.0.0/24), V(172.16.0.0/16),
+          V(2001:db8::/32)."
+      type: str
+      required: true
+    site:
+      description:
+        - The name of the AD replication site to associate with the
+          subnet.
+        - This controls which site computers in this subnet are
+          assigned to.
+      type: str
+    description:
+      description:
+        - A description for the subnet object.
+      type: str
+    location:
+      description:
+        - A string describing the physical location of the subnet.
+      type: str
+    state:
+      description:
+        - Whether the subnet should be present or absent.
+      type: str
+      default: present
+      choices: [present, absent]
+    domain_server:
+      description:
+        - The FQDN of the domain controller to target for all AD
+          operations.
+        - When not specified, the module will use the default domain
+          controller discovery.
+      type: str
+
+  notes:
+    - This module must be run on a Windows target host with the
+      ActiveDirectory PowerShell module available.
+    - Replication subnets are stored in the AD Configuration partition
+      and replicated forest-wide.
+    - Subnet names must use valid CIDR notation. Both IPv4 and IPv6
+      subnets are supported.
+  seealso:
+    - module: microsoft.ad.object_info
+  extends_documentation_fragment:
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms:
+        - windows
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Create a subnet associated with a site
+    microsoft.ad.site_subnet:
+      name: 10.10.0.0/16
+      site: London-Branch
+      location: "London, UK"
+      description: London branch office subnet
+      state: present
+
+  - name: Create a subnet without a site association
+    microsoft.ad.site_subnet:
+      name: 192.168.1.0/24
+      description: Lab network
+      state: present
+
+  - name: Change the site association for a subnet
+    microsoft.ad.site_subnet:
+      name: 10.10.0.0/16
+      site: NYC-HQ
+      state: present
+
+  - name: Update the location of a subnet
+    microsoft.ad.site_subnet:
+      name: 10.10.0.0/16
+      location: "New York, US"
+      state: present
+
+  - name: Remove a subnet
+    microsoft.ad.site_subnet:
+      name: 10.10.0.0/16
+      state: absent
+
+RETURN:
+  distinguished_name:
+    description:
+      - The distinguished name of the subnet object.
+    returned: always
+    type: str
+    sample: "CN=10.10.0.0/16,CN=Subnets,CN=Sites,CN=Configuration,DC=contoso,DC=com"
+  name:
+    description:
+      - The subnet name in CIDR notation.
+    returned: always
+    type: str
+    sample: "10.10.0.0/16"
+  site:
+    description:
+      - The name of the associated replication site.
+    returned: always
+    type: str
+    sample: "London-Branch"
+  description:
+    description:
+      - The description of the subnet.
+    returned: always
+    type: str
+    sample: "London branch office subnet"
+  location:
+    description:
+      - The physical location of the subnet.
+    returned: always
+    type: str
+    sample: "London, UK"

--- a/plugins/modules/site_subnet.yml
+++ b/plugins/modules/site_subnet.yml
@@ -11,13 +11,6 @@ DOCUMENTATION:
       by mapping IP address ranges to sites, which in turn controls
       domain controller discovery and replication topology.
   options:
-    name:
-      description:
-        - The subnet name in CIDR notation (network/bits).
-        - "Examples: V(10.0.0.0/24), V(172.16.0.0/16),
-          V(2001:db8::/32)."
-      type: str
-      required: true
     site:
       description:
         - The name of the AD replication site to associate with the
@@ -25,38 +18,20 @@ DOCUMENTATION:
         - This controls which site computers in this subnet are
           assigned to.
       type: str
-    description:
-      description:
-        - A description for the subnet object.
-      type: str
     location:
       description:
         - A string describing the physical location of the subnet.
       type: str
-    state:
-      description:
-        - Whether the subnet should be present or absent.
-      type: str
-      default: present
-      choices: [present, absent]
-    domain_server:
-      description:
-        - The FQDN of the domain controller to target for all AD
-          operations.
-        - When not specified, the module will use the default domain
-          controller discovery.
-      type: str
-
   notes:
-    - This module must be run on a Windows target host with the
-      ActiveDirectory PowerShell module available.
-    - Replication subnets are stored in the AD Configuration partition
-      and replicated forest-wide.
+    - The I(path) option for subnets defaults to the
+      C(CN=Subnets,CN=Sites,CN=Configuration,...) container. Subnets
+      cannot be moved to a different container.
     - Subnet names must use valid CIDR notation. Both IPv4 and IPv6
       subnets are supported.
-  seealso:
-    - module: microsoft.ad.object_info
+    - This module must be run on a Windows target host with the
+      C(ActiveDirectory) module installed.
   extends_documentation_fragment:
+    - microsoft.ad.ad_object
     - ansible.builtin.action_common_attributes
   attributes:
     check_mode:
@@ -66,6 +41,8 @@ DOCUMENTATION:
     platform:
       platforms:
         - windows
+  seealso:
+    - module: microsoft.ad.object_info
   author:
     - Ron Gershburg (@rgershbu)
 
@@ -102,33 +79,18 @@ EXAMPLES: |
       state: absent
 
 RETURN:
+  object_guid:
+    description:
+      - The C(objectGUID) of the AD object that was created, removed, or edited.
+      - If a new object was created in check mode, a GUID of 0s will be
+        returned.
+    returned: always
+    type: str
+    sample: d84a141f-2b99-4f08-9da0-ed2d26864ba1
   distinguished_name:
     description:
-      - The distinguished name of the subnet object.
+      - The C(distinguishedName) of the AD object that was created, removed, or
+        edited.
     returned: always
     type: str
-    sample: "CN=10.10.0.0/16,CN=Subnets,CN=Sites,CN=Configuration,DC=contoso,DC=com"
-  name:
-    description:
-      - The subnet name in CIDR notation.
-    returned: always
-    type: str
-    sample: "10.10.0.0/16"
-  site:
-    description:
-      - The name of the associated replication site.
-    returned: always
-    type: str
-    sample: "London-Branch"
-  description:
-    description:
-      - The description of the subnet.
-    returned: always
-    type: str
-    sample: "London branch office subnet"
-  location:
-    description:
-      - The physical location of the subnet.
-    returned: always
-    type: str
-    sample: "London, UK"
+    sample: CN=10.10.0.0/16,CN=Subnets,CN=Sites,CN=Configuration,DC=contoso,DC=com

--- a/tests/integration/targets/site_subnet/aliases
+++ b/tests/integration/targets/site_subnet/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/site_subnet/meta/main.yml
+++ b/tests/integration/targets/site_subnet/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_domain

--- a/tests/integration/targets/site_subnet/tasks/main.yml
+++ b/tests/integration/targets/site_subnet/tasks/main.yml
@@ -1,0 +1,438 @@
+---
+
+- name: Test site_subnet module
+  block:
+    # =================================================================
+    #  SETUP - create test sites using native PowerShell
+    #  After rebase of site module (PR #237), replace with:
+    #
+    #  - name: Create test site
+    #    microsoft.ad.site:
+    #      name: AnsibleSubnetTestSite
+    #      description: Site for subnet integration tests
+    #      state: present
+    #
+    #  - name: Create second test site
+    #    microsoft.ad.site:
+    #      name: AnsibleSubnetTestSite2
+    #      description: Second site for subnet reassignment tests
+    #      state: present
+    # =================================================================
+    - name: Create test site via PowerShell
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSite -Identity 'AnsibleSubnetTestSite'
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              New-ADReplicationSite -Name 'AnsibleSubnetTestSite' -Description 'Site for subnet integration tests'
+              $Ansible.Changed = $true
+          }
+
+    - name: Create second test site via PowerShell
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSite -Identity 'AnsibleSubnetTestSite2'
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              New-ADReplicationSite -Name 'AnsibleSubnetTestSite2' -Description 'Second site for subnet reassignment tests'
+              $Ansible.Changed = $true
+          }
+
+    - name: Create subnet - check mode
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        site: AnsibleSubnetTestSite
+        description: Ansible integration test subnet
+        location: "Test Lab"
+        state: present
+      register: _create_check
+      check_mode: true
+
+    - name: Assert create check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _create_check is changed
+
+    - name: Verify subnet was not actually created in check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSubnet -Identity '10.20.0.0/16'
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _check_mode_verify
+
+    - name: Assert subnet does not exist after check mode
+      ansible.builtin.assert:
+        that:
+          - not _check_mode_verify.result
+
+    - name: Create subnet
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        site: AnsibleSubnetTestSite
+        description: Ansible integration test subnet
+        location: "Test Lab"
+        state: present
+      register: _create
+
+    - name: Assert subnet was created
+      ansible.builtin.assert:
+        that:
+          - _create is changed
+          - _create.distinguished_name is defined
+          - _create.distinguished_name | length > 0
+          - _create.name == '10.20.0.0/16'
+          - _create.site == 'AnsibleSubnetTestSite'
+          - _create.description == 'Ansible integration test subnet'
+          - _create.location == 'Test Lab'
+
+    - name: Create same subnet again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        site: AnsibleSubnetTestSite
+        description: Ansible integration test subnet
+        location: "Test Lab"
+        state: present
+      register: _create_idem
+
+    - name: Assert no change on idempotent run
+      ansible.builtin.assert:
+        that:
+          - _create_idem is not changed
+
+    - name: Update subnet description
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        description: Updated description
+        state: present
+      register: _update_desc
+
+    - name: Assert description change
+      ansible.builtin.assert:
+        that:
+          - _update_desc is changed
+
+    - name: Update subnet description again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        description: Updated description
+        state: present
+      register: _update_desc_idem
+
+    - name: Assert no change on idempotent description update
+      ansible.builtin.assert:
+        that:
+          - _update_desc_idem is not changed
+
+    - name: Update subnet location
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        location: "New York, US"
+        state: present
+      register: _update_loc
+
+    - name: Assert location change
+      ansible.builtin.assert:
+        that:
+          - _update_loc is changed
+
+    - name: Update subnet location again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        location: "New York, US"
+        state: present
+      register: _update_loc_idem
+
+    - name: Assert no change on idempotent location update
+      ansible.builtin.assert:
+        that:
+          - _update_loc_idem is not changed
+
+    - name: Reassign subnet to a different site
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        site: AnsibleSubnetTestSite2
+        state: present
+      register: _update_site
+
+    - name: Assert site reassignment changed
+      ansible.builtin.assert:
+        that:
+          - _update_site is changed
+          - _update_site.site == 'AnsibleSubnetTestSite2'
+
+    - name: Reassign subnet to same site again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        site: AnsibleSubnetTestSite2
+        state: present
+      register: _update_site_idem
+
+    - name: Assert no change on idempotent site reassignment
+      ansible.builtin.assert:
+        that:
+          - _update_site_idem is not changed
+
+    - name: Update multiple properties simultaneously
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        site: AnsibleSubnetTestSite
+        description: Multi-update test
+        location: "London, UK"
+        state: present
+      register: _update_multi
+
+    - name: Assert multiple changes
+      ansible.builtin.assert:
+        that:
+          - _update_multi is changed
+
+    - name: Update multiple properties again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        site: AnsibleSubnetTestSite
+        description: Multi-update test
+        location: "London, UK"
+        state: present
+      register: _update_multi_idem
+
+    - name: Assert no change on idempotent multi-update
+      ansible.builtin.assert:
+        that:
+          - _update_multi_idem is not changed
+
+    - name: Create new subnet with diff
+      microsoft.ad.site_subnet:
+        name: 172.16.0.0/12
+        site: AnsibleSubnetTestSite
+        description: Diff test
+        state: present
+      register: _diff_create
+      diff: true
+
+    - name: Assert diff after has expected keys on create
+      ansible.builtin.assert:
+        that:
+          - _diff_create is changed
+          - _diff_create.diff.before == {}
+          - _diff_create.diff.after.name == '172.16.0.0/12'
+          - _diff_create.diff.after.description == 'Diff test'
+
+    - name: Update subnet with diff
+      microsoft.ad.site_subnet:
+        name: 172.16.0.0/12
+        description: Diff updated
+        state: present
+      register: _diff_update
+      diff: true
+
+    - name: Assert diff shows before and after
+      ansible.builtin.assert:
+        that:
+          - _diff_update is changed
+          - _diff_update.diff.before.description == 'Diff test'
+          - _diff_update.diff.after.description == 'Diff updated'
+
+    - name: Remove subnet with diff
+      microsoft.ad.site_subnet:
+        name: 172.16.0.0/12
+        state: absent
+      register: _diff_remove
+      diff: true
+
+    - name: Assert diff shows before populated and after empty
+      ansible.builtin.assert:
+        that:
+          - _diff_remove is changed
+          - _diff_remove.diff.before.name == '172.16.0.0/12'
+          - _diff_remove.diff.after == {}
+
+    - name: Create subnet without site
+      microsoft.ad.site_subnet:
+        name: 192.168.100.0/24
+        description: No site subnet
+        state: present
+      register: _create_nosite
+
+    - name: Assert created without site
+      ansible.builtin.assert:
+        that:
+          - _create_nosite is changed
+          - _create_nosite.name == '192.168.100.0/24'
+
+    - name: Create subnet without site again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 192.168.100.0/24
+        description: No site subnet
+        state: present
+      register: _create_nosite_idem
+
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - _create_nosite_idem is not changed
+
+    - name: Remove subnet - check mode
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        state: absent
+      register: _remove_check
+      check_mode: true
+
+    - name: Assert remove check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _remove_check is changed
+
+    - name: Verify subnet still exists after remove check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSubnet -Identity '10.20.0.0/16'
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _remove_check_verify
+
+    - name: Assert subnet still exists after remove check mode
+      ansible.builtin.assert:
+        that:
+          - _remove_check_verify.result
+
+    - name: Remove subnet
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        state: absent
+      register: _remove
+
+    - name: Assert remove reported changed
+      ansible.builtin.assert:
+        that:
+          - _remove is changed
+
+    - name: Remove subnet again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 10.20.0.0/16
+        state: absent
+      register: _remove_idem
+
+    - name: Assert no change on idempotent remove
+      ansible.builtin.assert:
+        that:
+          - _remove_idem is not changed
+
+    - name: Get DC FQDN
+      ansible.windows.win_powershell:
+        script: |
+          $Ansible.Result = (Get-ADDomainController).HostName
+      register: _dc_fqdn
+
+    - name: Create subnet via domain_server
+      microsoft.ad.site_subnet:
+        name: 10.30.0.0/16
+        site: AnsibleSubnetTestSite
+        description: domain_server test
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: present
+      register: _ds_create
+
+    - name: Assert created via domain_server
+      ansible.builtin.assert:
+        that:
+          - _ds_create is changed
+
+    - name: Create subnet via domain_server again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 10.30.0.0/16
+        site: AnsibleSubnetTestSite
+        description: domain_server test
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: present
+      register: _ds_create_idem
+
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - _ds_create_idem is not changed
+
+    - name: Update subnet via domain_server
+      microsoft.ad.site_subnet:
+        name: 10.30.0.0/16
+        description: domain_server updated
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: present
+      register: _ds_update
+
+    - name: Assert updated via domain_server
+      ansible.builtin.assert:
+        that:
+          - _ds_update is changed
+
+    - name: Remove subnet via domain_server
+      microsoft.ad.site_subnet:
+        name: 10.30.0.0/16
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: absent
+      register: _ds_remove
+
+    - name: Assert removed via domain_server
+      ansible.builtin.assert:
+        that:
+          - _ds_remove is changed
+
+    - name: Remove subnet via domain_server again (idempotency)
+      microsoft.ad.site_subnet:
+        name: 10.30.0.0/16
+        domain_server: "{{ _dc_fqdn.result }}"
+        state: absent
+      register: _ds_remove_idem
+
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - _ds_remove_idem is not changed
+
+  always:
+    #  CLEANUP - remove all test subnets then test sites
+    - name: Cleanup - remove test subnets
+      microsoft.ad.site_subnet:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - 10.20.0.0/16
+        - 10.30.0.0/16
+        - 172.16.0.0/12
+        - 192.168.100.0/24
+      failed_when: false
+
+    # After rebase of site module (PR #237), replace with:
+    #
+    # - name: Cleanup - remove test sites
+    #   microsoft.ad.site:
+    #     name: "{{ item }}"
+    #     state: absent
+    #   loop:
+    #     - AnsibleSubnetTestSite
+    #     - AnsibleSubnetTestSite2
+    #   failed_when: false
+    - name: Cleanup - remove test sites via PowerShell
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Remove-ADReplicationSite -Identity '{{ item }}' -Confirm:$false
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              # Already gone
+          }
+      loop:
+        - AnsibleSubnetTestSite
+        - AnsibleSubnetTestSite2
+      failed_when: false

--- a/tests/integration/targets/site_subnet/tasks/main.yml
+++ b/tests/integration/targets/site_subnet/tasks/main.yml
@@ -87,10 +87,7 @@
           - _create is changed
           - _create.distinguished_name is defined
           - _create.distinguished_name | length > 0
-          - _create.name == '10.20.0.0/16'
-          - _create.site == 'AnsibleSubnetTestSite'
-          - _create.description == 'Ansible integration test subnet'
-          - _create.location == 'Test Lab'
+          - _create.object_guid is defined
 
     - name: Create same subnet again (idempotency)
       microsoft.ad.site_subnet:
@@ -165,7 +162,6 @@
       ansible.builtin.assert:
         that:
           - _update_site is changed
-          - _update_site.site == 'AnsibleSubnetTestSite2'
 
     - name: Reassign subnet to same site again (idempotency)
       microsoft.ad.site_subnet:
@@ -220,7 +216,7 @@
       ansible.builtin.assert:
         that:
           - _diff_create is changed
-          - _diff_create.diff.before == {}
+          - _diff_create.diff.before == None
           - _diff_create.diff.after.name == '172.16.0.0/12'
           - _diff_create.diff.after.description == 'Diff test'
 
@@ -251,7 +247,7 @@
         that:
           - _diff_remove is changed
           - _diff_remove.diff.before.name == '172.16.0.0/12'
-          - _diff_remove.diff.after == {}
+          - _diff_remove.diff.after == None
 
     - name: Create subnet without site
       microsoft.ad.site_subnet:
@@ -264,7 +260,6 @@
       ansible.builtin.assert:
         that:
           - _create_nosite is changed
-          - _create_nosite.name == '192.168.100.0/24'
 
     - name: Create subnet without site again (idempotency)
       microsoft.ad.site_subnet:


### PR DESCRIPTION
#### SUMMARY
- New standalone PowerShell module `microsoft.ad.site_subnet` to create, modify, and remove Active Directory replication subnets.
- Supports all subnet properties: name (CIDR notation), site association, description, and location.
- Subnets determine which AD replication site a computer belongs to, controlling DC discovery and replication topology.

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/site_subnet.ps1
- plugins/modules/site_subnet.yml
- tests/integration/targets/site_subnet/aliases
- tests/integration/targets/site_subnet/meta/main.yml
- tests/integration/targets/site_subnet/tasks/main.yml

#### ADDITIONAL INFORMATION
- Integration tests cover: check mode, create/update/remove, idempotency, diff mode, site reassignment, domain_server targeting, and cleanup.
- Follows the standalone module pattern from the `site` module (PR #237); the integration tests use native PowerShell for site setup with commented `microsoft.ad.site` equivalents ready for rebase.
