### PR TITLE
feat(site_link): add new module to manage AD replication site links

### DIFF
--- a/plugins/modules/site_link.ps1
+++ b/plugins/modules/site_link.ps1
@@ -1,0 +1,89 @@
+#!powershell
+
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ..module_utils._ADObject
+
+$transportMap = @{
+    [int]0 = 'IP'
+    [int]1 = 'SMTP'
+}
+
+$setParams = @{
+    PropertyInfo = @(
+        [PSCustomObject]@{
+            Name = 'cost'
+            Option = @{ type = 'int' }
+            Attribute = 'Cost'
+        }
+        [PSCustomObject]@{
+            Name = 'replication_frequency'
+            Option = @{ type = 'int' }
+            Attribute = 'ReplicationFrequencyInMinutes'
+        }
+        [PSCustomObject]@{
+            Name = 'sites_included'
+            Option = @{ type = 'list'; elements = 'str' }
+            Attribute = 'SitesIncluded'
+            Set = {
+                param($Module, $ADParams, $SetParams, $ADObject)
+
+                $desired = $Module.Params.sites_included
+                $currentDNs = @($ADObject.SitesIncluded)
+                $currentNames = @($currentDNs | ForEach-Object {
+                        $_ -replace '^CN=([^,]+),.*$', '$1'
+                    } | Sort-Object)
+                $desiredSorted = @($desired | Sort-Object)
+
+                $Module.Diff.before['sites_included'] = $currentNames
+                $Module.Diff.after['sites_included'] = $desiredSorted
+
+                $diff = Compare-Object -ReferenceObject $currentNames -DifferenceObject $desiredSorted
+                if ($diff) {
+                    $siteChanges = @{}
+                    $toAdd = @($diff | Where-Object { $_.SideIndicator -eq '=>' } | ForEach-Object { $_.InputObject })
+                    $toRemove = @($diff | Where-Object { $_.SideIndicator -eq '<=' } | ForEach-Object { $_.InputObject })
+                    if ($toAdd.Count) { $siteChanges['Add'] = $toAdd }
+                    if ($toRemove.Count) { $siteChanges['Remove'] = $toRemove }
+                    $SetParams.SitesIncluded = $siteChanges
+                }
+            }
+        }
+        [PSCustomObject]@{
+            Name = 'intersite_transport_protocol'
+            Option = @{
+                type = 'str'
+                choices = 'IP', 'SMTP'
+                default = 'IP'
+            }
+            Attribute = 'InterSiteTransportProtocol'
+            Set = {
+                param($Module, $ADParams, $SetParams, $ADObject)
+
+                $current = $transportMap[[int]$ADObject.InterSiteTransportProtocol]
+                $desired = $Module.Params.intersite_transport_protocol
+
+                $Module.Diff.before['intersite_transport_protocol'] = $current
+                $Module.Diff.after['intersite_transport_protocol'] = $current
+
+                if ($current -ne $desired) {
+                    $Module.Warn("intersite_transport_protocol cannot be changed after creation (current: $current, requested: $desired)")
+                }
+            }
+        }
+    )
+    ModuleNoun = 'ADReplicationSiteLink'
+    DefaultPath = {
+        param($Module, $Params)
+
+        $configNC = (Get-ADRootDSE @Params -Properties configurationNamingContext).configurationNamingContext
+        $protocol = if ($Module.Params.intersite_transport_protocol) {
+            $Module.Params.intersite_transport_protocol
+        }
+        else { 'IP' }
+        "CN=$protocol,CN=Inter-Site Transports,CN=Sites,$configNC"
+    }
+}
+Invoke-AnsibleADObject @setParams

--- a/plugins/modules/site_link.ps1
+++ b/plugins/modules/site_link.ps1
@@ -6,11 +6,6 @@
 #AnsibleRequires -CSharpUtil Ansible.Basic
 #AnsibleRequires -PowerShell ..module_utils._ADObject
 
-$transportMap = @{
-    [int]0 = 'IP'
-    [int]1 = 'SMTP'
-}
-
 $setParams = @{
     PropertyInfo = @(
         [PSCustomObject]@{
@@ -62,6 +57,10 @@ $setParams = @{
             Set = {
                 param($Module, $ADParams, $SetParams, $ADObject)
 
+                $transportMap = @{
+                    0 = 'IP'
+                    1 = 'SMTP'
+                }
                 $current = $transportMap[[int]$ADObject.InterSiteTransportProtocol]
                 $desired = $Module.Params.intersite_transport_protocol
 

--- a/plugins/modules/site_link.yml
+++ b/plugins/modules/site_link.yml
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: site_link
+  short_description: Manage Active Directory replication site links
+  description:
+    - Create, modify, or remove AD replication site links.
+    - Site links define the replication topology between AD sites,
+      controlling replication cost, frequency, and transport protocol.
+  version_added: "1.11.0"
+  options:
+    cost:
+      description:
+        - The cost assigned to the site link.
+        - Lower cost links are preferred for replication routing.
+        - This is the value set on the C(cost) LDAP attribute.
+      type: int
+    replication_frequency:
+      description:
+        - Replication interval in minutes.
+        - Defines how often replication occurs over this site link.
+        - This is the value set on the C(replInterval) LDAP attribute.
+      type: int
+    sites_included:
+      description:
+        - List of AD site names to include in this site link.
+        - When specified, the site link will contain exactly these
+          sites (replace semantics).
+        - At least two sites are required when creating a new site link.
+      type: list
+      elements: str
+    intersite_transport_protocol:
+      description:
+        - The transport protocol for the site link.
+        - This can only be set when creating a new site link and
+          cannot be changed after creation.
+      type: str
+      choices: [IP, SMTP]
+      default: IP
+  notes:
+    - Site links are stored in the AD Configuration partition under
+      C(CN=Inter-Site Transports,CN=Sites).
+    - O(intersite_transport_protocol) can only be set at creation time
+      and cannot be changed afterwards.
+    - This module must be run on a Windows target host with the
+      C(ActiveDirectory) module installed.
+  extends_documentation_fragment:
+    - microsoft.ad.ad_object
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms:
+        - windows
+  seealso:
+    - module: microsoft.ad.object_info
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Create a site link between NY and London with 15-min replication
+    microsoft.ad.site_link:
+      name: NY-London
+      sites_included:
+        - NewYork
+        - London
+      cost: 100
+      replication_frequency: 15
+      state: present
+
+  - name: Update replication frequency on an existing site link
+    microsoft.ad.site_link:
+      name: NY-London
+      replication_frequency: 30
+      state: present
+
+  - name: Remove a site link
+    microsoft.ad.site_link:
+      name: NY-London
+      state: absent
+
+RETURN:
+  object_guid:
+    description:
+      - The C(objectGUID) of the AD object that was created, removed, or edited.
+      - If a new object was created in check mode, a GUID of 0s will be
+        returned.
+    returned: always
+    type: str
+    sample: d84a141f-2c99-4e08-9ca0-eb2b26864ba1
+  distinguished_name:
+    description:
+      - The C(distinguishedName) of the AD object that was created, removed, or
+        edited.
+    returned: always
+    type: str
+    sample: CN=NY-London,CN=IP,CN=Inter-Site Transports,CN=Sites,CN=Configuration,DC=domain,DC=test

--- a/tests/integration/targets/site_link/aliases
+++ b/tests/integration/targets/site_link/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/site_link/meta/main.yml
+++ b/tests/integration/targets/site_link/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_domain

--- a/tests/integration/targets/site_link/tasks/main.yml
+++ b/tests/integration/targets/site_link/tasks/main.yml
@@ -2,57 +2,14 @@
 
 - name: Test site_link
   block:
-    # =================================================================
-    #  SETUP - create test sites using native PowerShell
-    #  After rebase of site module (PR #237), replace with:
-    #
-    #  - name: Create test site 1
-    #    microsoft.ad.site:
-    #      name: AnsibleSLSite1
-    #      state: present
-    #
-    #  - name: Create test site 2
-    #    microsoft.ad.site:
-    #      name: AnsibleSLSite2
-    #      state: present
-    #
-    #  - name: Create test site 3
-    #    microsoft.ad.site:
-    #      name: AnsibleSLSite3
-    #      state: present
-    # =================================================================
-    - name: Create test site 1 via PowerShell
-      ansible.windows.win_powershell:
-        script: |
-          try {
-              Get-ADReplicationSite -Identity 'AnsibleSLSite1'
-          }
-          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-              New-ADReplicationSite -Name 'AnsibleSLSite1'
-              $Ansible.Changed = $true
-          }
-
-    - name: Create test site 2 via PowerShell
-      ansible.windows.win_powershell:
-        script: |
-          try {
-              Get-ADReplicationSite -Identity 'AnsibleSLSite2'
-          }
-          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-              New-ADReplicationSite -Name 'AnsibleSLSite2'
-              $Ansible.Changed = $true
-          }
-
-    - name: Create test site 3 via PowerShell
-      ansible.windows.win_powershell:
-        script: |
-          try {
-              Get-ADReplicationSite -Identity 'AnsibleSLSite3'
-          }
-          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-              New-ADReplicationSite -Name 'AnsibleSLSite3'
-              $Ansible.Changed = $true
-          }
+    - name: Create test sites
+      microsoft.ad.site:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - AnsibleSLSite1
+        - AnsibleSLSite2
+        - AnsibleSLSite3
 
     - name: Create site link - check mode
       microsoft.ad.site_link:
@@ -316,26 +273,10 @@
         state: absent
       failed_when: false
 
-    # After rebase of site module (PR #237), replace with:
-    #
-    # - name: Cleanup - remove test sites
-    #   microsoft.ad.site:
-    #     name: "{{ item }}"
-    #     state: absent
-    #   loop:
-    #     - AnsibleSLSite1
-    #     - AnsibleSLSite2
-    #     - AnsibleSLSite3
-    #   failed_when: false
-    - name: Cleanup - remove test sites via PowerShell
-      ansible.windows.win_powershell:
-        script: |
-          try {
-              Remove-ADReplicationSite -Identity '{{ item }}' -Confirm:$false
-          }
-          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-              # Already gone
-          }
+    - name: Cleanup - remove test sites
+      microsoft.ad.site:
+        name: "{{ item }}"
+        state: absent
       loop:
         - AnsibleSLSite1
         - AnsibleSLSite2

--- a/tests/integration/targets/site_link/tasks/main.yml
+++ b/tests/integration/targets/site_link/tasks/main.yml
@@ -1,0 +1,343 @@
+---
+
+- name: Test site_link
+  block:
+    # =================================================================
+    #  SETUP - create test sites using native PowerShell
+    #  After rebase of site module (PR #237), replace with:
+    #
+    #  - name: Create test site 1
+    #    microsoft.ad.site:
+    #      name: AnsibleSLSite1
+    #      state: present
+    #
+    #  - name: Create test site 2
+    #    microsoft.ad.site:
+    #      name: AnsibleSLSite2
+    #      state: present
+    #
+    #  - name: Create test site 3
+    #    microsoft.ad.site:
+    #      name: AnsibleSLSite3
+    #      state: present
+    # =================================================================
+    - name: Create test site 1 via PowerShell
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSite -Identity 'AnsibleSLSite1'
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              New-ADReplicationSite -Name 'AnsibleSLSite1'
+              $Ansible.Changed = $true
+          }
+
+    - name: Create test site 2 via PowerShell
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSite -Identity 'AnsibleSLSite2'
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              New-ADReplicationSite -Name 'AnsibleSLSite2'
+              $Ansible.Changed = $true
+          }
+
+    - name: Create test site 3 via PowerShell
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSite -Identity 'AnsibleSLSite3'
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              New-ADReplicationSite -Name 'AnsibleSLSite3'
+              $Ansible.Changed = $true
+          }
+
+    - name: Create site link - check mode
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        sites_included:
+          - AnsibleSLSite1
+          - AnsibleSLSite2
+        cost: 100
+        replication_frequency: 15
+        state: present
+      register: _create_check
+      check_mode: true
+
+    - name: Verify site link was not created in check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSiteLink -Identity 'AnsibleTestSiteLink' -ErrorAction Stop
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _create_check_actual
+
+    - name: Assert create check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _create_check is changed
+          - _create_check.object_guid == '00000000-0000-0000-0000-000000000000'
+          - not _create_check_actual.result
+
+    - name: Create site link
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        sites_included:
+          - AnsibleSLSite1
+          - AnsibleSLSite2
+        cost: 100
+        replication_frequency: 15
+        state: present
+      register: _create
+
+    - name: Set object identity fact
+      ansible.builtin.set_fact:
+        object_identity: '{{ _create.object_guid }}'
+
+    - name: Get result of create site link
+      ansible.windows.win_powershell:
+        script: |
+          $link = Get-ADReplicationSiteLink -Identity 'AnsibleTestSiteLink' -Properties Cost, ReplicationFrequencyInMinutes, SitesIncluded
+          @{
+              Cost = $link.Cost
+              ReplicationFrequencyInMinutes = $link.ReplicationFrequencyInMinutes
+              SiteCount = $link.SitesIncluded.Count
+              ObjectGUID = $link.ObjectGUID.ToString()
+          } | ConvertTo-Json
+      register: _create_actual
+
+    - name: Assert site link was created
+      ansible.builtin.assert:
+        that:
+          - _create is changed
+          - _create.object_guid != '00000000-0000-0000-0000-000000000000'
+          - _create.distinguished_name is defined
+          - (_create_actual.output[0] | from_json).Cost == 100
+          - (_create_actual.output[0] | from_json).ReplicationFrequencyInMinutes == 15
+          - (_create_actual.output[0] | from_json).SiteCount == 2
+
+    - name: Create same site link again (idempotency)
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        sites_included:
+          - AnsibleSLSite1
+          - AnsibleSLSite2
+        cost: 100
+        replication_frequency: 15
+        state: present
+      register: _create_idem
+
+    - name: Assert no change on idempotent create
+      ansible.builtin.assert:
+        that:
+          - _create_idem is not changed
+
+    - name: Update cost - check mode
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        cost: 200
+      register: _update_cost_check
+      check_mode: true
+
+    - name: Verify cost was not changed in check mode
+      ansible.windows.win_powershell:
+        script: |
+          (Get-ADReplicationSiteLink -Identity 'AnsibleTestSiteLink' -Properties Cost).Cost
+      register: _update_cost_check_actual
+
+    - name: Assert update cost check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _update_cost_check is changed
+          - _update_cost_check_actual.output[0] == 100
+
+    - name: Update cost
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        cost: 200
+      register: _update_cost
+
+    - name: Get result of update cost
+      ansible.windows.win_powershell:
+        script: |
+          (Get-ADReplicationSiteLink -Identity 'AnsibleTestSiteLink' -Properties Cost).Cost
+      register: _update_cost_actual
+
+    - name: Assert cost was updated
+      ansible.builtin.assert:
+        that:
+          - _update_cost is changed
+          - _update_cost_actual.output[0] == 200
+
+    - name: Update cost again (idempotency)
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        cost: 200
+      register: _update_cost_idem
+
+    - name: Assert no change on idempotent cost update
+      ansible.builtin.assert:
+        that:
+          - _update_cost_idem is not changed
+
+    - name: Update replication frequency
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        replication_frequency: 30
+      register: _update_freq
+
+    - name: Get result of update replication frequency
+      ansible.windows.win_powershell:
+        script: |
+          (Get-ADReplicationSiteLink -Identity 'AnsibleTestSiteLink' -Properties ReplicationFrequencyInMinutes).ReplicationFrequencyInMinutes
+      register: _update_freq_actual
+
+    - name: Assert replication frequency was updated
+      ansible.builtin.assert:
+        that:
+          - _update_freq is changed
+          - _update_freq_actual.output[0] == 30
+
+    - name: Update replication frequency again (idempotency)
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        replication_frequency: 30
+      register: _update_freq_idem
+
+    - name: Assert no change on idempotent frequency update
+      ansible.builtin.assert:
+        that:
+          - _update_freq_idem is not changed
+
+    - name: Update sites included
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        sites_included:
+          - AnsibleSLSite1
+          - AnsibleSLSite3
+      register: _update_sites
+
+    - name: Get result of update sites included
+      ansible.windows.win_powershell:
+        script: |
+          $sites = (Get-ADReplicationSiteLink -Identity 'AnsibleTestSiteLink' -Properties SitesIncluded).SitesIncluded
+          @($sites | ForEach-Object { $_ -replace '^CN=([^,]+),.*$', '$1' } | Sort-Object) | ConvertTo-Json
+      register: _update_sites_actual
+
+    - name: Assert sites included was updated
+      ansible.builtin.assert:
+        that:
+          - _update_sites is changed
+          - (_update_sites_actual.output[0] | from_json) == ['AnsibleSLSite1', 'AnsibleSLSite3']
+
+    - name: Update sites included again (idempotency)
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        sites_included:
+          - AnsibleSLSite1
+          - AnsibleSLSite3
+      register: _update_sites_idem
+
+    - name: Assert no change on idempotent sites update
+      ansible.builtin.assert:
+        that:
+          - _update_sites_idem is not changed
+
+    - name: Remove site link - check mode
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        state: absent
+      register: _remove_check
+      check_mode: true
+
+    - name: Verify site link still exists after check mode remove
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSiteLink -Identity 'AnsibleTestSiteLink' -ErrorAction Stop | Out-Null
+              $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $false
+          }
+      register: _remove_check_actual
+
+    - name: Assert remove check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _remove_check is changed
+          - _remove_check_actual.output[0] == true
+
+    - name: Remove site link
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        state: absent
+      register: _remove
+
+    - name: Verify site link was removed
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Get-ADReplicationSiteLink -Identity 'AnsibleTestSiteLink' -ErrorAction Stop | Out-Null
+              $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $false
+          }
+      register: _remove_actual
+
+    - name: Assert site link was removed
+      ansible.builtin.assert:
+        that:
+          - _remove is changed
+          - _remove_actual.output[0] == false
+
+    - name: Remove site link again (idempotency)
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        state: absent
+      register: _remove_idem
+
+    - name: Assert no change on idempotent remove
+      ansible.builtin.assert:
+        that:
+          - _remove_idem is not changed
+
+  always:
+    - name: Cleanup - remove test site link
+      microsoft.ad.site_link:
+        name: AnsibleTestSiteLink
+        state: absent
+      failed_when: false
+
+    # After rebase of site module (PR #237), replace with:
+    #
+    # - name: Cleanup - remove test sites
+    #   microsoft.ad.site:
+    #     name: "{{ item }}"
+    #     state: absent
+    #   loop:
+    #     - AnsibleSLSite1
+    #     - AnsibleSLSite2
+    #     - AnsibleSLSite3
+    #   failed_when: false
+    - name: Cleanup - remove test sites via PowerShell
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              Remove-ADReplicationSite -Identity '{{ item }}' -Confirm:$false
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              # Already gone
+          }
+      loop:
+        - AnsibleSLSite1
+        - AnsibleSLSite2
+        - AnsibleSLSite3
+      failed_when: false

--- a/tests/integration/targets/site_subnet/tasks/main.yml
+++ b/tests/integration/targets/site_subnet/tasks/main.yml
@@ -2,43 +2,13 @@
 
 - name: Test site_subnet module
   block:
-    # =================================================================
-    #  SETUP - create test sites using native PowerShell
-    #  After rebase of site module (PR #237), replace with:
-    #
-    #  - name: Create test site
-    #    microsoft.ad.site:
-    #      name: AnsibleSubnetTestSite
-    #      description: Site for subnet integration tests
-    #      state: present
-    #
-    #  - name: Create second test site
-    #    microsoft.ad.site:
-    #      name: AnsibleSubnetTestSite2
-    #      description: Second site for subnet reassignment tests
-    #      state: present
-    # =================================================================
-    - name: Create test site via PowerShell
-      ansible.windows.win_powershell:
-        script: |
-          try {
-              Get-ADReplicationSite -Identity 'AnsibleSubnetTestSite'
-          }
-          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-              New-ADReplicationSite -Name 'AnsibleSubnetTestSite' -Description 'Site for subnet integration tests'
-              $Ansible.Changed = $true
-          }
-
-    - name: Create second test site via PowerShell
-      ansible.windows.win_powershell:
-        script: |
-          try {
-              Get-ADReplicationSite -Identity 'AnsibleSubnetTestSite2'
-          }
-          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-              New-ADReplicationSite -Name 'AnsibleSubnetTestSite2' -Description 'Second site for subnet reassignment tests'
-              $Ansible.Changed = $true
-          }
+    - name: Create test sites
+      microsoft.ad.site:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - AnsibleSubnetTestSite
+        - AnsibleSubnetTestSite2
 
     - name: Create subnet - check mode
       microsoft.ad.site_subnet:
@@ -408,25 +378,10 @@
         - 192.168.100.0/24
       failed_when: false
 
-    # After rebase of site module (PR #237), replace with:
-    #
-    # - name: Cleanup - remove test sites
-    #   microsoft.ad.site:
-    #     name: "{{ item }}"
-    #     state: absent
-    #   loop:
-    #     - AnsibleSubnetTestSite
-    #     - AnsibleSubnetTestSite2
-    #   failed_when: false
-    - name: Cleanup - remove test sites via PowerShell
-      ansible.windows.win_powershell:
-        script: |
-          try {
-              Remove-ADReplicationSite -Identity '{{ item }}' -Confirm:$false
-          }
-          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
-              # Already gone
-          }
+    - name: Cleanup - remove test sites
+      microsoft.ad.site:
+        name: "{{ item }}"
+        state: absent
       loop:
         - AnsibleSubnetTestSite
         - AnsibleSubnetTestSite2


### PR DESCRIPTION
#### SUMMARY
- Add new `microsoft.ad.site_link` module for managing Active Directory replication site links
- Supports create, update, and remove operations with full check mode and diff mode support
- Module options: `cost`, `replication_frequency`, `sites_included`, `intersite_transport_protocol`, plus all common `ad_object` options (`description`, `display_name`, `domain_server`, `protect_from_deletion`, `attributes`, etc.)

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- `plugins/modules/site_link.ps1`
- `plugins/modules/site_link.yml`
- `tests/integration/targets/site_link/`

#### ADDITIONAL INFORMATION
- Integration tests cover: create (check mode + actual + idempotency), update each property individually and combined, remove (check mode + actual + idempotency), and cleanup
