### PR TITLE
feat: add domain_trust module for AD forest and external trusts

### DIFF
--- a/plugins/modules/domain_trust.ps1
+++ b/plugins/modules/domain_trust.ps1
@@ -1,0 +1,234 @@
+#!powershell
+
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        name = @{
+            type = 'str'
+            required = $true
+        }
+        state = @{
+            type = 'str'
+            default = 'present'
+            choices = @('present', 'absent')
+        }
+        direction = @{
+            type = 'str'
+            choices = @('inbound', 'outbound', 'bidirectional')
+        }
+        type = @{
+            type = 'str'
+            choices = @('external', 'forest')
+        }
+        trust_password = @{
+            type = 'str'
+            no_log = $true
+        }
+        selective_authentication = @{
+            type = 'bool'
+        }
+        domain_server = @{
+            type = 'str'
+        }
+    }
+    required_if = @(
+        , @('state', 'present', @('direction', 'type', 'trust_password'))
+    )
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Result.changed = $false
+$module.Result.distinguished_name = $null
+
+$name = $module.Params.name
+$state = $module.Params.state
+
+$directionMap = @{
+    'inbound' = [System.DirectoryServices.ActiveDirectory.TrustDirection]::Inbound
+    'outbound' = [System.DirectoryServices.ActiveDirectory.TrustDirection]::Outbound
+    'bidirectional' = [System.DirectoryServices.ActiveDirectory.TrustDirection]::Bidirectional
+}
+
+$directionDisplayMap = @{
+    'inbound' = 'Inbound'
+    'outbound' = 'Outbound'
+    'bidirectional' = 'BiDirectional'
+}
+
+# Get-ADTrust uses ForestTransitive (bool) to distinguish forest vs external,
+# not TrustType (which returns Uplevel/Downlevel/MIT).
+Function Get-TrustTypeDisplay {
+    param($ADTrust)
+    if ($ADTrust.ForestTransitive) { 'Forest' } else { 'External' }
+}
+
+Function Test-IsForestTrust {
+    param($ADTrust)
+    [bool]$ADTrust.ForestTransitive
+}
+
+$adParams = @{}
+if ($module.Params.domain_server) {
+    $adParams.Server = $module.Params.domain_server
+}
+
+try {
+    $existing = Get-ADTrust @adParams -Identity $name -ErrorAction SilentlyContinue
+}
+catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+    $existing = $null
+}
+catch {
+    $module.FailJson("Failed to retrieve trust '$name': $_", $_)
+}
+
+if ($state -eq 'present') {
+    $desiredDirection = $directionDisplayMap[$module.Params.direction]
+    $desiredType = if ($module.Params.type -eq 'forest') { 'Forest' } else { 'External' }
+    $trustDirection = $directionMap[$module.Params.direction]
+
+    if (-not $existing) {
+        $module.Result.changed = $true
+        $module.Diff.before = @{}
+        $module.Diff.after = @{
+            name = $name
+            direction = $desiredDirection
+            trust_type = $desiredType
+            selective_authentication = [bool]$module.Params.selective_authentication
+        }
+
+        if (-not $module.CheckMode) {
+            try {
+                $null = Resolve-DnsName -Name $name -ErrorAction Stop
+            }
+            catch {
+                $module.FailJson("DNS resolution failed for '$name'. Ensure DNS conditional forwarders are configured before creating a trust: $_", $_)
+            }
+
+            try {
+                if ($module.Params.type -eq 'forest') {
+                    $localForest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+                    $localForest.CreateLocalSideOfTrustRelationship($name, $trustDirection, $module.Params.trust_password)
+                }
+                else {
+                    $localDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
+                    $localDomain.CreateLocalSideOfTrustRelationship($name, $trustDirection, $module.Params.trust_password)
+                }
+            }
+            catch {
+                $module.FailJson("Failed to create trust '$name': $_", $_)
+            }
+
+            if ($module.Params.type -eq 'forest' -and
+                $null -ne $module.Params.selective_authentication -and
+                $module.Params.selective_authentication) {
+                try {
+                    $localForest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+                    $localForest.SetSelectiveAuthenticationStatus($name, $true)
+                }
+                catch {
+                    $module.FailJson("Trust created but failed to enable selective authentication on '$name': $_", $_)
+                }
+            }
+
+            try {
+                $existing = Get-ADTrust @adParams -Identity $name
+            }
+            catch {
+                $module.FailJson("Trust creation succeeded but validation failed for '$name': $_", $_)
+            }
+
+            $module.Result.distinguished_name = $existing.DistinguishedName
+        }
+    }
+    else {
+        # UPDATE
+        $module.Result.distinguished_name = $existing.DistinguishedName
+        $currentType = Get-TrustTypeDisplay $existing
+
+        $module.Diff.before = @{
+            name = $name
+            direction = [string]$existing.Direction
+            trust_type = $currentType
+            selective_authentication = [bool]$existing.SelectiveAuthentication
+        }
+
+        if ($desiredDirection -ne [string]$existing.Direction) {
+            $module.FailJson(
+                "Trust '$name' exists with direction '$($existing.Direction)' but '$desiredDirection' was requested. " +
+                "Direction cannot be changed in-place. Remove the trust first (state=absent) and recreate it."
+            )
+        }
+        if ($desiredType -ne $currentType) {
+            $module.FailJson(
+                "Trust '$name' exists with type '$currentType' but '$desiredType' was requested. " +
+                "Type cannot be changed in-place. Remove the trust first (state=absent) and recreate it."
+            )
+        }
+
+        $after = $module.Diff.before.Clone()
+
+        if ($null -ne $module.Params.selective_authentication -and
+            $module.Params.selective_authentication -ne [bool]$existing.SelectiveAuthentication) {
+
+            if (-not (Test-IsForestTrust $existing)) {
+                $module.FailJson("Selective authentication can only be set on forest trusts, not external trusts.")
+            }
+
+            $after.selective_authentication = $module.Params.selective_authentication
+            $module.Result.changed = $true
+
+            if (-not $module.CheckMode) {
+                try {
+                    $localForest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+                    $localForest.SetSelectiveAuthenticationStatus($name, $module.Params.selective_authentication)
+                }
+                catch {
+                    $module.FailJson("Failed to update selective authentication on trust '$name': $_", $_)
+                }
+            }
+        }
+
+        $module.Diff.after = $after
+    }
+}
+else {
+    # ABSENT
+    if ($existing) {
+        $currentType = Get-TrustTypeDisplay $existing
+        $module.Result.distinguished_name = $existing.DistinguishedName
+        $module.Result.changed = $true
+
+        $module.Diff.before = @{
+            name = $name
+            direction = [string]$existing.Direction
+            trust_type = $currentType
+            selective_authentication = [bool]$existing.SelectiveAuthentication
+        }
+        $module.Diff.after = @{}
+
+        if (-not $module.CheckMode) {
+            try {
+                if (Test-IsForestTrust $existing) {
+                    $localForest = [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest()
+                    $localForest.DeleteLocalSideOfTrustRelationship($name)
+                }
+                else {
+                    $localDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
+                    $localDomain.DeleteLocalSideOfTrustRelationship($name)
+                }
+            }
+            catch {
+                $module.FailJson("Failed to remove trust '$name': $_", $_)
+            }
+        }
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/domain_trust.yml
+++ b/plugins/modules/domain_trust.yml
@@ -60,7 +60,6 @@ DOCUMENTATION:
         - Required when O(state=present) and the trust does not yet
           exist.
       type: str
-      no_log: true
     selective_authentication:
       description:
         - Whether selective authentication is enabled on the trust.

--- a/plugins/modules/domain_trust.yml
+++ b/plugins/modules/domain_trust.yml
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: domain_trust
+  short_description: Manage Active Directory domain trusts
+  version_added: 1.11.0
+  description:
+    - Create or remove Active Directory domain trust relationships
+      between forests or domains.
+    - Supports Forest and External trust types with configurable
+      direction and selective authentication.
+    - Before creating a trust the module verifies that the target domain
+      name resolves via DNS. This catches missing conditional forwarders
+      early and avoids cryptic trust-creation errors.
+  options:
+    name:
+      description:
+        - The fully qualified domain name (FQDN) of the target domain
+          to trust (e.g. V(example.com)).
+        - This is the primary key used to identify the trust.
+      type: str
+      required: true
+    state:
+      description:
+        - Whether the trust should be present or absent.
+      type: str
+      default: present
+      choices: [present, absent]
+    direction:
+      description:
+        - The direction of the trust relationship.
+        - V(inbound) allows users in the target domain to authenticate
+          in the local domain.
+        - V(outbound) allows users in the local domain to authenticate
+          in the target domain.
+        - V(bidirectional) allows authentication in both directions.
+        - Required when O(state=present) and the trust does not yet
+          exist.
+        - Cannot be changed on an existing trust; remove and recreate
+          the trust to change direction.
+      type: str
+      choices: [inbound, outbound, bidirectional]
+    type:
+      description:
+        - The type of trust relationship to create.
+        - V(forest) creates a transitive trust between two AD forests.
+        - V(external) creates a non-transitive trust between two
+          domains that may be in different forests.
+        - Required when O(state=present) and the trust does not yet
+          exist.
+        - Cannot be changed on an existing trust; remove and recreate
+          the trust to change type.
+      type: str
+      choices: [external, forest]
+    trust_password:
+      description:
+        - The shared secret used to establish the trust.
+        - Both sides of the trust must use the same password.
+        - Required when O(state=present) and the trust does not yet
+          exist.
+      type: str
+      no_log: true
+    selective_authentication:
+      description:
+        - Whether selective authentication is enabled on the trust.
+        - When V(true), users in the trusted domain are not
+          automatically authenticated. Permissions must be granted
+          explicitly on each resource.
+        - This is the only property that can be updated on an existing
+          trust without removing it first.
+      type: bool
+    domain_server:
+      description:
+        - The FQDN of the domain controller to target for all AD
+          operations.
+        - When not specified the module uses default domain controller
+          discovery.
+      type: str
+
+  notes:
+    - This module must be run on a Windows domain controller.
+    - The C(ActiveDirectory) PowerShell module must be available on the
+      target (present on domain controllers by default).
+    - Domain Administrator or Enterprise Administrator permissions are
+      typically required to create or remove trusts.
+    - DNS conditional forwarders for the target domain must be
+      configured before creating a trust. The module will verify DNS
+      resolution and fail early if the target domain cannot be resolved.
+    - Trust creation and removal use the
+      C(System.DirectoryServices.ActiveDirectory) .NET classes. The
+      current trust state is read via C(Get-ADTrust).
+    - The module creates only the local side of the trust using a
+      shared password. Run the module on both domain controllers with
+      the same O(trust_password) to establish a working trust.
+    - The O(direction) and O(type) of an existing trust cannot be
+      changed in-place. The module will fail with a descriptive message
+      if the requested values differ from the current trust. Remove the
+      trust first and recreate it with the desired settings.
+  seealso:
+    - module: microsoft.ad.domain
+    - module: microsoft.ad.domain_child
+    - name: Forest.CreateLocalSideOfTrustRelationship
+      description: .NET API used to create the local side of forest trusts.
+      link: https://learn.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.forest.createlocalsideoftrustrelationship
+  extends_documentation_fragment:
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms:
+        - windows
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Create a bidirectional forest trust
+    microsoft.ad.domain_trust:
+      name: example.com
+      direction: bidirectional
+      type: forest
+      trust_password: S3cretTru5t!
+      state: present
+
+  - name: Create a one-way outbound external trust
+    microsoft.ad.domain_trust:
+      name: partner.example.com
+      direction: outbound
+      type: external
+      trust_password: Tr0stP@ss
+      state: present
+
+  - name: Create a forest trust with selective authentication
+    microsoft.ad.domain_trust:
+      name: example.com
+      direction: bidirectional
+      type: forest
+      trust_password: S3cretTru5t!
+      selective_authentication: true
+      state: present
+
+  - name: Enable selective authentication on an existing trust
+    microsoft.ad.domain_trust:
+      name: example.com
+      direction: bidirectional
+      type: forest
+      trust_password: S3cretTru5t!
+      selective_authentication: true
+      state: present
+
+  - name: Remove a domain trust
+    microsoft.ad.domain_trust:
+      name: example.com
+      state: absent
+
+RETURN:
+  distinguished_name:
+    description:
+      - The distinguished name of the trusted domain object in AD.
+    returned: success and trust exists
+    type: str
+    sample: "CN=example.com,CN=System,DC=contoso,DC=com"

--- a/tests/integration/targets/domain_trust/README.md
+++ b/tests/integration/targets/domain_trust/README.md
@@ -1,0 +1,34 @@
+# microsoft.ad.domain_trust tests
+
+As this cannot be run in CI this is a brief guide on how to run these tests locally.
+Run the following:
+
+```bash
+vagrant up
+
+ansible-playbook setup.yml
+```
+
+It is a good idea to create a snapshot of both hosts before running the tests.
+This allows you to reset the host back to a blank starting state if the tests need to be rerun.
+To create a snapshot do the following:
+
+```bash
+virsh snapshot-create-as --domain "domain_trust_DC1" --name "pretest"
+virsh snapshot-create-as --domain "domain_trust_DC2" --name "pretest"
+```
+
+To restore these snapshots run the following:
+
+```bash
+virsh snapshot-revert --domain "domain_trust_DC1" --snapshotname "pretest" --running
+virsh snapshot-revert --domain "domain_trust_DC2" --snapshotname "pretest" --running
+```
+
+Once you are ready to run the tests run the following:
+
+```bash
+ansible-playbook test.yml
+```
+
+Run `vagrant destroy` to remove the test VMs.

--- a/tests/integration/targets/domain_trust/Vagrantfile
+++ b/tests/integration/targets/domain_trust/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+inventory = YAML.load_file('inventory.yml')
+
+Vagrant.configure("2") do |config|
+  inventory['all']['children'].each do |group,details|
+    details['hosts'].each do |server,host_details|
+      config.vm.define server do |srv|
+        srv.vm.box = host_details['vagrant_box']
+        srv.vm.hostname = server
+        srv.vm.network :private_network,
+          :ip => host_details['ansible_host'],
+          :libvirt__network_name => 'microsoft_ad_trust',
+          :libvirt__forward_mode => 'nat'
+
+        srv.vm.provider :libvirt do |l|
+          l.memory = 4096
+          l.cpus = 2
+          l.qemu_use_session = false
+        end
+      end
+    end
+  end
+end

--- a/tests/integration/targets/domain_trust/aliases
+++ b/tests/integration/targets/domain_trust/aliases
@@ -1,0 +1,2 @@
+windows
+unsupported  # can never run in CI, see README.md

--- a/tests/integration/targets/domain_trust/ansible.cfg
+++ b/tests/integration/targets/domain_trust/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+callback_result_format = yaml
+inventory = inventory.yml
+retry_files_enabled = False

--- a/tests/integration/targets/domain_trust/inventory.yml
+++ b/tests/integration/targets/domain_trust/inventory.yml
@@ -1,0 +1,21 @@
+all:
+  children:
+    windows:
+      hosts:
+        DC1:
+          ansible_host: 192.168.12.10
+          vagrant_box: jborean93/WindowsServer2022
+          domain_name: ad.test
+        DC2:
+          ansible_host: 192.168.12.11
+          vagrant_box: jborean93/WindowsServer2022
+          domain_name: trust.test
+      vars:
+        ansible_port: 5985
+        ansible_connection: psrp
+
+  vars:
+    ansible_user: vagrant
+    ansible_password: vagrant
+    domain_password: VagrantPass1
+    trust_password: TrustP@ss1

--- a/tests/integration/targets/domain_trust/setup.yml
+++ b/tests/integration/targets/domain_trust/setup.yml
@@ -1,0 +1,129 @@
+---
+- name: Setup common Windows information
+  hosts: windows
+  gather_facts: false
+
+  tasks:
+    - name: Get network connection names
+      ansible.windows.win_powershell:
+        parameters:
+          IPAddress: '{{ ansible_host }}'
+        script: |
+          param ($IPAddress)
+          $Ansible.Changed = $false
+          Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'" |
+              ForEach-Object -Process {
+                  $config = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "Index='$($_.Index)'"
+                  if ($config.IPAddress -contains $IPAddress) {
+                      $_.NetConnectionID
+                  }
+              }
+      register: connection_name
+
+- name: Setup forest 1 (DC1)
+  hosts: DC1
+  gather_facts: false
+
+  tasks:
+    - name: Set DNS for the internal adapter to localhost
+      ansible.windows.win_dns_client:
+        adapter_names:
+          - '{{ connection_name.output[0] }}'
+        dns_servers:
+          - 127.0.0.1
+
+    - name: Promote DC1 to domain controller
+      microsoft.ad.domain:
+        dns_domain_name: '{{ domain_name }}'
+        safe_mode_password: '{{ domain_password }}'
+        reboot: true
+
+    - name: Create domain admin user
+      microsoft.ad.user:
+        name: vagrant-domain
+        upn: 'vagrant-domain@{{ domain_name | upper }}'
+        password: '{{ domain_password }}'
+        password_never_expires: true
+        update_password: when_changed
+        groups:
+          add:
+            - Domain Admins
+            - Enterprise Admins
+        state: present
+
+- name: Setup forest 2 (DC2)
+  hosts: DC2
+  gather_facts: false
+
+  tasks:
+    - name: Set DNS for the internal adapter to localhost
+      ansible.windows.win_dns_client:
+        adapter_names:
+          - '{{ connection_name.output[0] }}'
+        dns_servers:
+          - 127.0.0.1
+
+    - name: Promote DC2 to domain controller in separate forest
+      microsoft.ad.domain:
+        dns_domain_name: '{{ domain_name }}'
+        safe_mode_password: '{{ domain_password }}'
+        reboot: true
+
+    - name: Create domain admin user
+      microsoft.ad.user:
+        name: vagrant-domain
+        upn: 'vagrant-domain@{{ domain_name | upper }}'
+        password: '{{ domain_password }}'
+        password_never_expires: true
+        update_password: when_changed
+        groups:
+          add:
+            - Domain Admins
+            - Enterprise Admins
+        state: present
+
+- name: Configure DNS conditional forwarders
+  hosts: windows
+  gather_facts: false
+
+  tasks:
+    - name: Set variables for the other DC
+      ansible.builtin.set_fact:
+        other_domain: "{{ hostvars[other_host].domain_name }}"
+        other_ip: "{{ hostvars[other_host].ansible_host }}"
+      vars:
+        other_host: "{{ (inventory_hostname == 'DC1') | ternary('DC2', 'DC1') }}"
+
+    - name: Add DNS conditional forwarder for the other forest
+      ansible.windows.win_powershell:
+        parameters:
+          ForwarderDomain: '{{ other_domain }}'
+          ForwarderIP: '{{ other_ip }}'
+        script: |
+          param($ForwarderDomain, $ForwarderIP)
+          $Ansible.Changed = $false
+          $existing = Get-DnsServerZone -Name $ForwarderDomain -ErrorAction SilentlyContinue
+          if (-not $existing) {
+              Add-DnsServerConditionalForwarderZone -Name $ForwarderDomain -MasterServers $ForwarderIP
+              $Ansible.Changed = $true
+          }
+
+    - name: Verify DNS resolution of the other forest
+      ansible.windows.win_powershell:
+        parameters:
+          TargetDomain: '{{ other_domain }}'
+        script: |
+          param($TargetDomain)
+          $Ansible.Changed = $false
+          $retries = 0
+          while ($retries -lt 30) {
+              try {
+                  Resolve-DnsName -Name $TargetDomain -ErrorAction Stop | Out-Null
+                  return
+              }
+              catch {
+                  $retries++
+                  Start-Sleep -Seconds 2
+              }
+          }
+          throw "DNS resolution for $TargetDomain failed after 30 retries"

--- a/tests/integration/targets/domain_trust/tasks/test_full.yml
+++ b/tests/integration/targets/domain_trust/tasks/test_full.yml
@@ -1,0 +1,262 @@
+---
+- name: Full lifecycle domain_trust tests
+  block:
+    - name: Create forest trust - check mode
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: bidirectional
+        type: forest
+        trust_password: '{{ trust_password }}'
+        state: present
+      register: _create_check
+      check_mode: true
+      diff: true
+
+    - name: Assert check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _create_check is changed
+          - _create_check.diff.before == {}
+          - _create_check.diff.after.direction == 'BiDirectional'
+
+    - name: Verify trust was not created in check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              $t = Get-ADTrust -Identity '{{ trust_target_domain }}'
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _check_verify
+
+    - name: Assert not created
+      ansible.builtin.assert:
+        that:
+          - not _check_verify.result
+
+    - name: Create local side of forest trust on DC1
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: bidirectional
+        type: forest
+        trust_password: '{{ trust_password }}'
+        state: present
+      register: _create
+
+    - name: Assert DC1 side was created
+      ansible.builtin.assert:
+        that:
+          - _create is changed
+          - _create.distinguished_name is defined
+          - _create.distinguished_name | length > 0
+
+    - name: Create local side of forest trust on DC2
+      microsoft.ad.domain_trust:
+        name: '{{ local_domain }}'
+        direction: bidirectional
+        type: forest
+        trust_password: '{{ trust_password }}'
+        state: present
+      delegate_to: DC2
+
+    - name: Verify trust via Get-ADTrust
+      ansible.windows.win_powershell:
+        script: |
+          $t = Get-ADTrust -Identity '{{ trust_target_domain }}'
+          $Ansible.Result = @{
+              direction = [string]$t.Direction
+              forest_transitive = [bool]$t.ForestTransitive
+              selective_auth = $t.SelectiveAuthentication
+          }
+      register: _create_verify
+
+    - name: Assert trust properties match
+      ansible.builtin.assert:
+        that:
+          - _create_verify.result.direction == 'BiDirectional'
+          - _create_verify.result.forest_transitive == true
+          - _create_verify.result.selective_auth == false
+
+    - name: Create same trust again (idempotency)
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: bidirectional
+        type: forest
+        trust_password: '{{ trust_password }}'
+        state: present
+      register: _create_idem
+
+    - name: Assert no change on idempotent run
+      ansible.builtin.assert:
+        that:
+          - _create_idem is not changed
+
+    - name: Enable selective authentication - check mode
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: bidirectional
+        type: forest
+        trust_password: '{{ trust_password }}'
+        selective_authentication: true
+        state: present
+      register: _sel_check
+      check_mode: true
+      diff: true
+
+    - name: Assert check mode reports changed with diff
+      ansible.builtin.assert:
+        that:
+          - _sel_check is changed
+          - _sel_check.diff.before.selective_authentication == false
+          - _sel_check.diff.after.selective_authentication == true
+
+    - name: Enable selective authentication
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: bidirectional
+        type: forest
+        trust_password: '{{ trust_password }}'
+        selective_authentication: true
+        state: present
+      register: _sel_on
+
+    - name: Assert selective auth enabled
+      ansible.builtin.assert:
+        that:
+          - _sel_on is changed
+
+    - name: Verify selective auth via Get-ADTrust
+      ansible.windows.win_powershell:
+        script: |
+          $t = Get-ADTrust -Identity '{{ trust_target_domain }}'
+          $Ansible.Result = $t.SelectiveAuthentication
+      register: _sel_on_verify
+
+    - name: Assert selective auth is true
+      ansible.builtin.assert:
+        that:
+          - _sel_on_verify.result == true
+
+    - name: Enable selective authentication again (idempotency)
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: bidirectional
+        type: forest
+        trust_password: '{{ trust_password }}'
+        selective_authentication: true
+        state: present
+      register: _sel_idem
+
+    - name: Assert no change on idempotent selective auth
+      ansible.builtin.assert:
+        that:
+          - _sel_idem is not changed
+
+    - name: Disable selective authentication
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: bidirectional
+        type: forest
+        trust_password: '{{ trust_password }}'
+        selective_authentication: false
+        state: present
+      register: _sel_off
+
+    - name: Assert selective auth disabled
+      ansible.builtin.assert:
+        that:
+          - _sel_off is changed
+
+    - name: Wrong direction on existing trust
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: outbound
+        type: forest
+        trust_password: '{{ trust_password }}'
+        state: present
+      register: _err_dir
+      ignore_errors: true
+
+    - name: Assert direction mismatch error
+      ansible.builtin.assert:
+        that:
+          - _err_dir is failed
+          - "'Direction cannot be changed in-place' in _err_dir.msg"
+
+    - name: Wrong type on existing trust
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        direction: bidirectional
+        type: external
+        trust_password: '{{ trust_password }}'
+        state: present
+      register: _err_type
+      ignore_errors: true
+
+    - name: Assert type mismatch error
+      ansible.builtin.assert:
+        that:
+          - _err_type is failed
+          - "'Type cannot be changed in-place' in _err_type.msg"
+
+    - name: Remove trust - check mode
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        state: absent
+      register: _remove_check
+      check_mode: true
+      diff: true
+
+    - name: Assert check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _remove_check is changed
+          - _remove_check.diff.after == {}
+
+    - name: Verify trust still exists after check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              $t = Get-ADTrust -Identity '{{ trust_target_domain }}'
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _remove_check_verify
+
+    - name: Assert trust still exists
+      ansible.builtin.assert:
+        that:
+          - _remove_check_verify.result
+
+    - name: Remove trust
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        state: absent
+      register: _remove
+
+    - name: Assert trust was removed
+      ansible.builtin.assert:
+        that:
+          - _remove is changed
+
+    - name: Remove trust again (idempotency)
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        state: absent
+      register: _remove_idem
+
+    - name: Assert no change on idempotent remove
+      ansible.builtin.assert:
+        that:
+          - _remove_idem is not changed
+
+  always:
+    - name: Cleanup - ensure trust is removed
+      microsoft.ad.domain_trust:
+        name: '{{ trust_target_domain }}'
+        state: absent
+      failed_when: false

--- a/tests/integration/targets/domain_trust/test.yml
+++ b/tests/integration/targets/domain_trust/test.yml
@@ -1,0 +1,46 @@
+---
+- name: Ensure time is in sync
+  hosts: windows
+  gather_facts: false
+  tasks:
+    - name: Get current host datetime
+      command: date +%s
+      changed_when: false
+      delegate_to: localhost
+      run_once: true
+      register: local_time
+
+    - name: Set datetime on Windows
+      ansible.windows.win_powershell:
+        parameters:
+          SecondsSinceEpoch: '{{ local_time.stdout | trim }}'
+        script: |
+          param($SecondsSinceEpoch)
+          $utc = [System.DateTimeKind]::Utc
+          $epoch = New-Object -TypeName System.DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0, $utc
+          $date = $epoch.AddSeconds($SecondsSinceEpoch)
+          Set-Date -Date $date
+
+- name: Run domain_trust tests from DC1
+  hosts: DC1
+  gather_facts: false
+
+  vars:
+    trust_target_domain: '{{ hostvars["DC2"].domain_name }}'
+    trust_password: TrustP@ss1
+    local_domain: '{{ hostvars["DC1"].domain_name }}'
+
+  tasks:
+    - name: Run domain_trust tests
+      ansible.builtin.include_tasks: tasks/test_full.yml
+
+- name: Clean up DC2 side of trust
+  hosts: DC2
+  gather_facts: false
+
+  tasks:
+    - name: Remove trust from DC2 side
+      microsoft.ad.domain_trust:
+        name: '{{ hostvars["DC1"].domain_name }}'
+        state: absent
+      failed_when: false


### PR DESCRIPTION
#### SUMMARY
- New `domain_trust` module to create, update, and remove Active Directory domain trust relationships (forest and external types)
- Uses `System.DirectoryServices.ActiveDirectory` .NET APIs for trust creation/removal and `Get-ADTrust` for state queries
- Supports bidirectional/inbound/outbound direction, selective authentication toggle, DNS pre-check, check mode, and diff mode
- Creates only the local side of the trust with a shared password -- run on both DCs to establish a working trust

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/domain_trust.ps1
- plugins/modules/domain_trust.yml
- tests/integration/targets/domain_trust/

#### ADDITIONAL INFORMATION
- Integration tests use a Vagrant-based two-forest setup (same pattern as domain_child) since trust testing requires two separate AD forests
- Same as in domain_child module, won't run in integration tests. I set up vagrant locally and tested.