### PR TITLE
feat: add pso module for managing Password Settings Objects

### DIFF
--- a/plugins/modules/pso.ps1
+++ b/plugins/modules/pso.ps1
@@ -1,0 +1,173 @@
+#!powershell
+
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ..module_utils._ADObject
+
+$setParams = @{
+    PropertyInfo = @(
+        [PSCustomObject]@{
+            Name = 'precedence'
+            Option = @{ type = 'int' }
+            Attribute = 'Precedence'
+        }
+        [PSCustomObject]@{
+            Name = 'min_password_length'
+            Option = @{ type = 'int' }
+            Attribute = 'MinPasswordLength'
+        }
+        [PSCustomObject]@{
+            Name = 'complexity_enabled'
+            Option = @{ type = 'bool' }
+            Attribute = 'ComplexityEnabled'
+        }
+        [PSCustomObject]@{
+            Name = 'lockout_threshold'
+            Option = @{ type = 'int' }
+            Attribute = 'LockoutThreshold'
+        }
+        [PSCustomObject]@{
+            Name = 'subjects'
+            Option = @{ type = 'list'; elements = 'str' }
+        }
+    )
+    ModuleNoun = 'ADFineGrainedPasswordPolicy'
+    ExtraProperties = @('AppliesTo')
+    DefaultPath = {
+        param($Module, $ADParams)
+        $domainNC = (Get-ADRootDSE @ADParams -Properties defaultNamingContext).defaultNamingContext
+        "CN=Password Settings Container,CN=System,$domainNC"
+    }
+    PreAction = {
+        param($Module, $ADParams, $ADObject)
+
+        if (
+            $Module.Params.state -eq 'present' -and
+            $null -eq $Module.Params.precedence -and
+            -not $ADObject
+        ) {
+            $Module.FailJson("precedence must be set when state=present and the PSO does not exist")
+        }
+
+        if (
+            $Module.Params.state -eq 'present' -and
+            $null -ne $Module.Params.subjects -and
+            @($Module.Params.subjects).Count -gt 0
+        ) {
+            $subjectDNs = @(
+                $Module.Params.subjects | ConvertTo-AnsibleADDistinguishedName @ADParams -Module $Module -Context 'subjects'
+            )
+            foreach ($dn in $subjectDNs) {
+                try {
+                    $obj = Get-ADObject @ADParams -Identity $dn -Properties objectClass
+                }
+                catch {
+                    $Module.FailJson("PSO subject '$dn' could not be found: $_", $_)
+                }
+
+                if ($obj.objectClass -contains 'group') {
+                    $group = Get-ADGroup @ADParams -Identity $dn
+                    if ($group.GroupScope -ne 'Global') {
+                        $Module.FailJson(
+                            "PSO subjects must be global security groups or users. '$($group.Name)' is a $($group.GroupScope) group."
+                        )
+                    }
+                }
+                elseif ($obj.objectClass -notcontains 'user') {
+                    $Module.FailJson("PSO subject '$dn' must be a global security group or user.")
+                }
+            }
+        }
+    }
+    PostAction = {
+        param($Module, $ADParams, $ADObject)
+
+        if ($Module.Params.state -eq 'present' -and $null -ne $Module.Params.subjects) {
+            $desiredSubjects = @($Module.Params.subjects)
+            $desiredSorted = @($desiredSubjects | Sort-Object)
+
+            $psoIdentity = if ($Module.Result.distinguished_name) {
+                $Module.Result.distinguished_name
+            }
+            elseif ($ADObject) {
+                $ADObject.DistinguishedName
+            }
+            else {
+                $Module.Params.name
+            }
+
+            $currentDNs = @()
+            if ($ADObject -and $null -ne $ADObject.AppliesTo) {
+                $currentDNs = @($ADObject.AppliesTo)
+            }
+            elseif (-not $Module.CheckMode) {
+                try {
+                    $pso = Get-ADFineGrainedPasswordPolicy @ADParams -Identity $psoIdentity -Properties AppliesTo
+                    if ($null -ne $pso.AppliesTo) {
+                        $currentDNs = @($pso.AppliesTo)
+                    }
+                }
+                catch {
+                    $Module.FailJson("Failed to get PSO subjects for '$psoIdentity': $_", $_)
+                }
+            }
+
+            $desiredDNs = @(
+                $desiredSubjects | ConvertTo-AnsibleADDistinguishedName @ADParams -Module $Module -Context 'subjects'
+            )
+
+            $currentNames = @($currentDNs | ForEach-Object {
+                    if ($_ -match '^CN=([^,]+),') { $Matches[1] } else { $_ }
+                } | Sort-Object)
+
+            $Module.Diff.after['subjects'] = $desiredSorted
+            if ($null -ne $Module.Diff.before) {
+                $Module.Diff.before['subjects'] = $currentNames
+            }
+
+            $currentSorted = @($currentDNs | Sort-Object)
+            $desiredDNSorted = @($desiredDNs | Sort-Object)
+
+            $toAdd = @($desiredDNSorted | Where-Object { $_ -notin $currentSorted })
+            $toRemove = @($currentSorted | Where-Object { $_ -notin $desiredDNSorted })
+
+            if ($toAdd.Count -gt 0 -or $toRemove.Count -gt 0) {
+                $Module.Result.changed = $true
+
+                if (-not ($Module.CheckMode -and -not $ADObject)) {
+                    $subjectParams = @{
+                        Identity = $psoIdentity
+                        WhatIf = $Module.CheckMode
+                        Confirm = $false
+                    }
+
+                    if ($toAdd.Count) {
+                        try {
+                            Add-ADFineGrainedPasswordPolicySubject @subjectParams @ADParams -Subjects $toAdd
+                        }
+                        catch {
+                            $Module.FailJson("Failed to add PSO subjects: $_", $_)
+                        }
+                    }
+
+                    if ($toRemove.Count) {
+                        try {
+                            Remove-ADFineGrainedPasswordPolicySubject @subjectParams @ADParams -Subjects $toRemove
+                        }
+                        catch {
+                            $Module.FailJson("Failed to remove PSO subjects: $_", $_)
+                        }
+                    }
+                }
+            }
+        }
+
+        # DN is derivable from I(name) and the fixed Password Settings Container path.
+        if ($Module.Result.ContainsKey('distinguished_name')) {
+            $Module.Result.Remove('distinguished_name') | Out-Null
+        }
+    }
+}
+Invoke-AnsibleADObject @setParams

--- a/plugins/modules/pso.ps1
+++ b/plugins/modules/pso.ps1
@@ -88,15 +88,7 @@ $setParams = @{
             $desiredSubjects = @($Module.Params.subjects)
             $desiredSorted = @($desiredSubjects | Sort-Object)
 
-            $psoIdentity = if ($Module.Result.distinguished_name) {
-                $Module.Result.distinguished_name
-            }
-            elseif ($ADObject) {
-                $ADObject.DistinguishedName
-            }
-            else {
-                $Module.Params.name
-            }
+            $psoIdentity = $Module.Result.distinguished_name
 
             $currentDNs = @()
             if ($ADObject -and $null -ne $ADObject.AppliesTo) {
@@ -164,10 +156,6 @@ $setParams = @{
             }
         }
 
-        # DN is derivable from I(name) and the fixed Password Settings Container path.
-        if ($Module.Result.ContainsKey('distinguished_name')) {
-            $Module.Result.Remove('distinguished_name') | Out-Null
-        }
     }
 }
 Invoke-AnsibleADObject @setParams

--- a/plugins/modules/pso.ps1
+++ b/plugins/modules/pso.ps1
@@ -15,7 +15,7 @@ $setParams = @{
         }
         [PSCustomObject]@{
             Name = 'min_password_length'
-            Option = @{ type = 'int' }
+            Option = @{ type = 'int'; no_log = $false }
             Attribute = 'MinPasswordLength'
         }
         [PSCustomObject]@{

--- a/plugins/modules/pso.yml
+++ b/plugins/modules/pso.yml
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: pso
+  short_description: Manage Active Directory Password Settings Objects
+  version_added: "1.12.0"
+  description:
+    - Create, modify, or remove Password Settings Objects (PSOs) in Active
+      Directory.
+    - PSOs implement fine-grained password policies that apply password and
+      account lockout settings to specific users and global security groups,
+      independently of the Default Domain Policy.
+  options:
+    precedence:
+      description:
+        - The precedence value of the PSO.
+        - Lower numbers take priority when multiple PSOs apply to the same subject.
+        - Required when creating a new PSO.
+      type: int
+    min_password_length:
+      description:
+        - The minimum password length enforced by the PSO.
+      type: int
+    complexity_enabled:
+      description:
+        - Whether password complexity requirements are enabled.
+      type: bool
+    lockout_threshold:
+      description:
+        - The number of failed logon attempts before an account is locked out.
+        - Set to V(0) to disable account lockout.
+      type: int
+    subjects:
+      description:
+        - List of users or global security groups the PSO should apply to.
+        - Each entry can be a C(sAMAccountName), C(distinguishedName), C(objectGUID),
+          C(objectSid), or C(userPrincipalName).
+        - When specified, the PSO applies to exactly these subjects (replace
+          semantics). Subjects not in the list are removed from the policy.
+        - When omitted, existing subject assignments are not changed.
+      type: list
+      elements: str
+  notes:
+    - PSOs are stored in the C(CN=Password Settings Container,CN=System,...)
+      container and cannot be moved to a different location.
+    - This module must be run on a Windows target host with the
+      C(ActiveDirectory) module installed.
+  extends_documentation_fragment:
+    - microsoft.ad.ad_object
+    - ansible.builtin.action_common_attributes
+  attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms:
+        - windows
+  seealso:
+    - module: microsoft.ad.object_info
+    - module: microsoft.ad.group
+  author:
+    - Ron Gershburg (@rgershbu)
+
+EXAMPLES: |
+  - name: Create a PSO for IT administrators
+    microsoft.ad.pso:
+      name: IT-Admins-PSO
+      description: Strong password policy for IT administrators
+      precedence: 100
+      min_password_length: 20
+      complexity_enabled: true
+      lockout_threshold: 5
+      subjects:
+        - IT-Admins
+      state: present
+
+  - name: Update lockout threshold on an existing PSO
+    microsoft.ad.pso:
+      name: IT-Admins-PSO
+      lockout_threshold: 10
+      state: present
+
+  - name: Remove a PSO
+    microsoft.ad.pso:
+      name: IT-Admins-PSO
+      state: absent
+
+RETURN:
+  object_guid:
+    description:
+      - The C(objectGUID) of the PSO that was created, removed, or edited.
+      - If a new object was created in check mode, a GUID of 0s will be
+        returned.
+    returned: always
+    type: str
+    sample: d84a141f-2b99-4f08-9da0-ed2d26864ba1

--- a/plugins/modules/pso.yml
+++ b/plugins/modules/pso.yml
@@ -96,3 +96,10 @@ RETURN:
     returned: always
     type: str
     sample: d84a141f-2b99-4f08-9da0-ed2d26864ba1
+  distinguished_name:
+    description:
+      - The C(distinguishedName) of the AD object that was created, removed, or
+        edited.
+    returned: always
+    type: str
+    sample: CN=IT-Admins-PSO,CN=Password Settings Container,CN=System,DC=example,DC=com

--- a/tests/integration/targets/pso/aliases
+++ b/tests/integration/targets/pso/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group2

--- a/tests/integration/targets/pso/aliases
+++ b/tests/integration/targets/pso/aliases
@@ -1,2 +1,2 @@
 windows
-shippable/windows/group2
+shippable/windows/group1

--- a/tests/integration/targets/pso/meta/main.yml
+++ b/tests/integration/targets/pso/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_domain

--- a/tests/integration/targets/pso/tasks/main.yml
+++ b/tests/integration/targets/pso/tasks/main.yml
@@ -62,6 +62,8 @@
       ansible.builtin.assert:
         that:
           - _create is changed
+          - _create.distinguished_name is defined
+          - _create.distinguished_name | length > 0
           - _create.object_guid is defined
           - _create.object_guid | length > 0
           - _create.object_guid != '00000000-0000-0000-0000-000000000000'

--- a/tests/integration/targets/pso/tasks/main.yml
+++ b/tests/integration/targets/pso/tasks/main.yml
@@ -1,0 +1,195 @@
+---
+
+- name: Test pso module
+  block:
+    - name: Create shadow test group for PSO assignment
+      microsoft.ad.group:
+        name: AnsibleTestPSOGroup
+        scope: global
+        category: security
+        state: present
+
+    - name: Create PSO - check mode
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        description: Ansible integration test PSO
+        precedence: 100
+        min_password_length: 20
+        complexity_enabled: true
+        lockout_threshold: 5
+        subjects:
+          - AnsibleTestPSOGroup
+        state: present
+      register: _create_check
+      check_mode: true
+
+    - name: Assert create check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _create_check is changed
+
+    - name: Verify PSO was not actually created in check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              $null = Get-ADFineGrainedPasswordPolicy -Identity 'AnsibleTestPSO'
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _check_mode_verify
+
+    - name: Assert PSO does not exist after check mode
+      ansible.builtin.assert:
+        that:
+          - not _check_mode_verify.result
+
+    - name: Create PSO
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        description: Ansible integration test PSO
+        precedence: 100
+        min_password_length: 20
+        complexity_enabled: true
+        lockout_threshold: 5
+        subjects:
+          - AnsibleTestPSOGroup
+        state: present
+      register: _create
+
+    - name: Assert PSO was created
+      ansible.builtin.assert:
+        that:
+          - _create is changed
+          - _create.object_guid is defined
+          - _create.object_guid | length > 0
+          - _create.object_guid != '00000000-0000-0000-0000-000000000000'
+
+    - name: Create same PSO again (idempotency)
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        description: Ansible integration test PSO
+        precedence: 100
+        min_password_length: 20
+        complexity_enabled: true
+        lockout_threshold: 5
+        subjects:
+          - AnsibleTestPSOGroup
+        state: present
+      register: _create_idem
+
+    - name: Assert no change on idempotent run
+      ansible.builtin.assert:
+        that:
+          - _create_idem is not changed
+
+    - name: Update PSO lockout threshold
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        lockout_threshold: 10
+        state: present
+      register: _update_lockout
+
+    - name: Assert lockout threshold change
+      ansible.builtin.assert:
+        that:
+          - _update_lockout is changed
+
+    - name: Update PSO lockout threshold again (idempotency)
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        lockout_threshold: 10
+        state: present
+      register: _update_lockout_idem
+
+    - name: Assert no change on idempotent lockout update
+      ansible.builtin.assert:
+        that:
+          - _update_lockout_idem is not changed
+
+    - name: Update PSO min password length
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        min_password_length: 24
+        state: present
+      register: _update_min_length
+
+    - name: Assert min password length change
+      ansible.builtin.assert:
+        that:
+          - _update_min_length is changed
+
+    - name: Update PSO min password length again (idempotency)
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        min_password_length: 24
+        state: present
+      register: _update_min_length_idem
+
+    - name: Assert no change on idempotent min length update
+      ansible.builtin.assert:
+        that:
+          - _update_min_length_idem is not changed
+
+    - name: Remove PSO - check mode
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        state: absent
+      register: _remove_check
+      check_mode: true
+
+    - name: Assert remove check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _remove_check is changed
+
+    - name: Verify PSO still exists after remove check mode
+      ansible.windows.win_powershell:
+        script: |
+          try {
+              $null = Get-ADFineGrainedPasswordPolicy -Identity 'AnsibleTestPSO'
+              $Ansible.Result = $true
+          }
+          catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
+              $Ansible.Result = $false
+          }
+      register: _remove_check_verify
+
+    - name: Assert PSO still exists after remove check mode
+      ansible.builtin.assert:
+        that:
+          - _remove_check_verify.result
+
+    - name: Remove PSO
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        state: absent
+      register: _remove
+
+    - name: Assert remove reported changed
+      ansible.builtin.assert:
+        that:
+          - _remove is changed
+
+    - name: Remove PSO again (idempotency)
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        state: absent
+      register: _remove_idem
+
+    - name: Assert no change on idempotent remove
+      ansible.builtin.assert:
+        that:
+          - _remove_idem is not changed
+
+  always:
+    - name: Cleanup - remove test PSO
+      microsoft.ad.pso:
+        name: AnsibleTestPSO
+        state: absent
+
+    - name: Cleanup - remove test group
+      microsoft.ad.group:
+        name: AnsibleTestPSOGroup
+        state: absent


### PR DESCRIPTION
#### SUMMARY
- Add new `microsoft.ad.pso` module to create, modify, and remove Active Directory Password Settings Objects (PSOs)
- Subject assignment (users and global security groups) handled via `Add-/Remove-ADFineGrainedPasswordPolicySubject` in PostAction with replace semantics
- PreAction validates precedence is required on create, and that subjects are global security groups or users

#### ISSUE TYPE
- New Module Pull Request

#### COMPONENT NAME
- plugins/modules/pso.ps1
- plugins/modules/pso.yml
- tests/integration/targets/pso/

#### ADDITIONAL INFORMATION