### PR TITLE
Fixes an issue where `microsoft.ad.user` module failed on first run when adding a `path` value

### DIFF
--- a/plugins/modules/user.ps1
+++ b/plugins/modules/user.ps1
@@ -456,7 +456,7 @@ $setParams = @{
                 if ($ADObject) {
                     try {
                         Set-ADObject -Identity $member -Add @{
-                            member = $ADObject.DistinguishedName
+                            member = $Module.Result.distinguished_name
                         } @lookupParams @commonParams
                     }
                     catch [Microsoft.ActiveDirectory.Management.ADException] {
@@ -482,7 +482,7 @@ $setParams = @{
                 if ($ADObject) {
                     try {
                         Set-ADObject -Identity $member -Remove @{
-                            member = $ADObject.DistinguishedName
+                            member = $Module.Result.distinguished_name
                         } @lookupParams @commonParams
                     }
                     catch [Microsoft.ActiveDirectory.Management.ADException] {


### PR DESCRIPTION
##### SUMMARY
This PR fixes an issue where the `microsoft.ad.user` module fails on first run when adding the `path` parameter to an a already existing user.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`microsoft.ad.user`

##### ADDITIONAL INFORMATION
How to reproduce the error this PR fixes:
- Install Windows standalone server
- Add multiple accounts there
- Promote the server to a domain controller using `microsoft.ad.domain` module
- Use the `microsoft.ad.user` module to reconfigure any of the accounts created before DC promotion that are now domain accounts. Make sure the use the `path` parameter

The module will fail but will still move the user to the `path` defined. On second run of the module everything works.