### PR TITLE
Fix post action ADObject on move

### DIFF
--- a/changelogs/fragments/user-post-action-moved.yml
+++ b/changelogs/fragments/user-post-action-moved.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    user - Ensure any post actions like editing the user's groups are performed on the correct distinguished name. This
+    fixes the error when changing the user's groups when the user was moved in the same module invocation.

--- a/plugins/module_utils/_ADObject.psm1
+++ b/plugins/module_utils/_ADObject.psm1
@@ -1507,6 +1507,7 @@ Function Invoke-AnsibleADObject {
 
             # Won't be set in check mode
             if ($finalADObject) {
+                $adObject = $finalADObject
                 $objectDN = $finalADObject.DistinguishedName
             }
             else {

--- a/tests/integration/targets/user/tasks/tests.yml
+++ b/tests/integration/targets/user/tasks/tests.yml
@@ -123,6 +123,9 @@
     name: MyUser2
     identity: '{{ object_sid }}'  # ID by SID
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
+    groups:
+      add:
+      - Domain Admins
   register: move_user_check
   check_mode: true
 
@@ -131,6 +134,7 @@
     identity: '{{ object_identity }}'
     properties:
     - sAMAccountName
+    - memberOf
   register: move_user_check_actual
 
 - name: assert move user - check
@@ -141,12 +145,16 @@
     - move_user_check_actual.objects[0].DistinguishedName == 'CN=MyUser2,CN=Users,' ~ setup_domain_info.output[0].defaultNamingContext
     - move_user_check_actual.objects[0].Name == 'MyUser2'
     - move_user_check_actual.objects[0].sAMAccountName == 'MyUser'
+    - move_user_check_actual.objects[0].memberOf == None
 
 - name: move user
   user:
     name: MyUser2
     identity: '{{ object_sid }}'  # ID by SID
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
+    groups:
+      add:
+      - Domain Admins
   register: move_user
 
 - name: get result of move user
@@ -154,6 +162,7 @@
     identity: '{{ object_identity }}'
     properties:
     - sAMAccountName
+    - memberOf
   register: move_user_actual
 
 - name: assert move user
@@ -164,12 +173,16 @@
     - move_user_actual.objects[0].DistinguishedName == 'CN=MyUser2,' ~ setup_domain_info.output[0].defaultNamingContext
     - move_user_actual.objects[0].Name == 'MyUser2'
     - move_user_actual.objects[0].sAMAccountName == 'MyUser'
+    - move_user_actual.objects[0].memberOf == ["CN=Domain Admins,CN=Users," ~ setup_domain_info.output[0].defaultNamingContext]
 
 - name: move user - idempotent
   user:
     name: MyUser2
     identity: '{{ object_sid }}'  # ID by SID
     path: '{{ setup_domain_info.output[0].defaultNamingContext }}'
+    groups:
+      add:
+      - Domain Admins
   register: move_user_again
 
 - name: assert move user - idempotent


### PR DESCRIPTION
##### SUMMARY
Use the proper ADObject when calling the module's PostAction to ensure any actions are done on the final object that may have been moved.

Alternative to https://github.com/ansible-collections/microsoft.ad/pull/246

##### ISSUE TYPE
- Bugfix Pull Request