### PR TITLE
Prepare for v1.12.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,25 @@ Ansible Microsoft Active Directory Release Notes
 
 .. contents:: Topics
 
+v1.12.0
+=======
+
+Release Summary
+---------------
+
+Release summary for v1.12.0, this is identical to v1.11.1 except with proper changelog entries for the new modules accidentally marked in the v1.11.1 release.
+
+Bugfixes
+--------
+
+- domain - Ensure that the `microsoft.ad.domain` module errors when a forest already exists. This prevents the module from attempting to create a new forest if an existing forest is detected and prints an error message indicating that.
+
+New Modules
+-----------
+
+- gpo - Manage Group Policy Object links
+- pso - Manage Active Directory Password Settings Objects
+
 v1.11.1
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -131,6 +131,26 @@ releases:
     - release-summary.yml
     - user-post-action-moved.yml
     release_date: '2026-07-14'
+  1.12.0:
+    changes:
+      bugfixes:
+      - domain - Ensure that the `microsoft.ad.domain` module errors when a forest
+        already exists. This prevents the module from attempting to create a new forest
+        if an existing forest is detected and prints an error message indicating that.
+      release_summary: Release summary for v1.12.0, this is identical to v1.11.1 except
+        with proper changelog entries for the new modules accidentally marked in the
+        v1.11.1 release.
+    fragments:
+    - domain-print-error-on-existing.yml
+    - release-summary.yml
+    modules:
+    - description: Manage Group Policy Object links
+      name: gpo
+      namespace: ''
+    - description: Manage Active Directory Password Settings Objects
+      name: pso
+      namespace: ''
+    release_date: '2026-07-14'
   1.2.0:
     changes:
       bugfixes:

--- a/changelogs/fragments/domain-print-error-on-existing.yml
+++ b/changelogs/fragments/domain-print-error-on-existing.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - >-
-    domain - Ensure that the `microsoft.ad.domain` module errors when a forest already exists.
-    This prevents the module from attempting to create a new forest if an existing forest is detected and prints an error message indicating that.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: microsoft
 name: ad
-version: 1.11.1
+version: 1.12.0
 readme: README.md
 authors:
   - Jordan Borean @jborean93


### PR DESCRIPTION
##### SUMMARY
Preparation for the `v1.12.0` release. Unfortunately the changelog generation for the `v1.11.1` was not fully updated so didn't cover the new modules that were added. This release is identical to the `v1.11.1` release but with the proper version and changelog entries set.

##### ISSUE TYPE
- Feature Pull Request