### PR TITLE
fs_trust - Refactor SAML endpoint handling and update logic

### DIFF
--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -74,6 +74,8 @@ microsoft.ad.computer:
         sid: ($data.sid // null)
       },
       facts: {
+        infra_type: "private_cloud",
+        infra_bucket: "compute",
         device_type: "virtual_machine",
         platform: "microsoft_ad",
         distinguished_name: $data.distinguished_name

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -152,8 +152,8 @@ if ($state -eq 'present') {
                     # proxy boundary. Create them inside a WinPS session.
                     $addTrustWithEndpoints = {
                         param([hashtable]$Params, [string[]]$EndpointUris)
-                        $eps = foreach ($u in $EndpointUris) {
-                            New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $u
+                        $eps = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+                            New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
                         }
                         $Params['SamlEndpoint'] = @($eps)
                         Add-AdfsRelyingPartyTrust @Params
@@ -170,8 +170,8 @@ if ($state -eq 'present') {
                 else {
                     if ($module.Params.saml_endpoint) {
                         $endpoints = @()
-                        foreach ($ep in $module.Params.saml_endpoint) {
-                            $endpoints += New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $ep
+                        for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
+                            $endpoints += New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $module.Params.saml_endpoint[$i] -Index $i -IsDefault:($i -eq 0)
                         }
                         $addParams.SamlEndpoint = $endpoints
                     }
@@ -213,6 +213,67 @@ if ($state -eq 'present') {
                 }
                 catch {
                     $module.FailJson("Failed to update relying party trust '$name': $_", $_)
+                }
+            }
+        }
+
+        # Update SAML endpoints if different from what's currently configured.
+        # Set-AdfsRelyingPartyTrust -SamlEndpoint replaces the entire endpoint
+        # collection, so saml_endpoint in the playbook must always contain the
+        # full desired set, not just the endpoint(s) being added.
+        if ($module.Params.saml_endpoint) {
+            $currentUris = @($existing.SamlEndpoints | ForEach-Object { $_.Location.ToString() })
+            $desiredUris = @($module.Params.saml_endpoint)
+
+            $currentSorted = @($currentUris | Sort-Object)
+            $desiredSorted = @($desiredUris | Sort-Object)
+
+            $samlEndpointChanged = $currentSorted.Count -ne $desiredSorted.Count
+            if (-not $samlEndpointChanged) {
+                for ($i = 0; $i -lt $currentSorted.Count; $i++) {
+                    if ($currentSorted[$i] -ne $desiredSorted[$i]) {
+                        $samlEndpointChanged = $true
+                        break
+                    }
+                }
+            }
+
+            if ($samlEndpointChanged) {
+                $module.Result.changed = $true
+
+                if (-not $module.CheckMode) {
+                    try {
+                        $cmd = Get-Command Add-AdfsRelyingPartyTrust
+                        if ($cmd.Module.PrivateData.ImplicitRemoting) {
+                            # Same cross-proxy issue as on create: build the
+                            # SamlEndpoint objects inside a WinPS session.
+                            $setTrustEndpoints = {
+                                param([string]$Name, [string[]]$EndpointUris)
+                                $eps = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+                                    New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
+                                }
+                                Set-AdfsRelyingPartyTrust -TargetName $Name -SamlEndpoint @($eps)
+                            }
+                            [string[]]$samlUris = @($module.Params.saml_endpoint)
+                            $winPS = New-PSSession -UseWindowsPowerShell
+                            try {
+                                Invoke-Command -Session $winPS -ScriptBlock $setTrustEndpoints -ArgumentList $name, $samlUris
+                            }
+                            finally {
+                                $winPS | Remove-PSSession
+                            }
+                        }
+                        else {
+                            $endpoints = @()
+                            for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
+                                $endpoints += New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $module.Params.saml_endpoint[$i] -Index $i -IsDefault:($i -eq 0)
+                            }
+                            Set-AdfsRelyingPartyTrust -TargetName $name -SamlEndpoint $endpoints
+                        }
+                    }
+                    catch {
+                        $module.FailJson("Failed to update SAML endpoints for relying party trust '$name': $_", $_)
+                    }
                 }
             }
         }

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -232,13 +232,11 @@ if ($state -eq 'present') {
             $currentUris = @($existing.SamlEndpoints | ForEach-Object { $_.Location.ToString() })
             $desiredUris = @($module.Params.saml_endpoint)
 
-            $currentSorted = @($currentUris | Sort-Object)
-            $desiredSorted = @($desiredUris | Sort-Object)
-
-            $samlEndpointChanged = $currentSorted.Count -ne $desiredSorted.Count
+            # Compare in original order determines which endpoint gets Index 0 / IsDefault
+            $samlEndpointChanged = $currentUris.Count -ne $desiredUris.Count
             if (-not $samlEndpointChanged) {
-                for ($i = 0; $i -lt $currentSorted.Count; $i++) {
-                    if ($currentSorted[$i] -ne $desiredSorted[$i]) {
+                for ($i = 0; $i -lt $currentUris.Count; $i++) {
+                    if ($currentUris[$i] -ne $desiredUris[$i]) {
                         $samlEndpointChanged = $true
                         break
                     }

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -171,7 +171,14 @@ if ($state -eq 'present') {
                     if ($module.Params.saml_endpoint) {
                         $endpoints = @()
                         for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
-                            $endpoints += New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $module.Params.saml_endpoint[$i] -Index $i -IsDefault:($i -eq 0)
+                            $endpointParams = @{
+                                Binding   = 'POST'
+                                Protocol  = 'SAMLAssertionConsumer'
+                                Uri       = $module.Params.saml_endpoint[$i]
+                                Index     = $i
+                                IsDefault = ($i -eq 0)
+                            }
+                            $endpoints += New-AdfsSamlEndpoint @endpointParams
                         }
                         $addParams.SamlEndpoint = $endpoints
                     }
@@ -266,7 +273,14 @@ if ($state -eq 'present') {
                         else {
                             $endpoints = @()
                             for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
-                                $endpoints += New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $module.Params.saml_endpoint[$i] -Index $i -IsDefault:($i -eq 0)
+                                $endpointParams = @{
+                                    Binding   = 'POST'
+                                    Protocol  = 'SAMLAssertionConsumer'
+                                    Uri       = $module.Params.saml_endpoint[$i]
+                                    Index     = $i
+                                    IsDefault = ($i -eq 0)
+                                }
+                                $endpoints += New-AdfsSamlEndpoint @endpointParams
                             }
                             Set-AdfsRelyingPartyTrust -TargetName $name -SamlEndpoint $endpoints
                         }

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -172,10 +172,10 @@ if ($state -eq 'present') {
                         $endpoints = @()
                         for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
                             $endpointParams = @{
-                                Binding   = 'POST'
-                                Protocol  = 'SAMLAssertionConsumer'
-                                Uri       = $module.Params.saml_endpoint[$i]
-                                Index     = $i
+                                Binding = 'POST'
+                                Protocol = 'SAMLAssertionConsumer'
+                                Uri = $module.Params.saml_endpoint[$i]
+                                Index = $i
                                 IsDefault = ($i -eq 0)
                             }
                             $endpoints += New-AdfsSamlEndpoint @endpointParams
@@ -274,10 +274,10 @@ if ($state -eq 'present') {
                             $endpoints = @()
                             for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
                                 $endpointParams = @{
-                                    Binding   = 'POST'
-                                    Protocol  = 'SAMLAssertionConsumer'
-                                    Uri       = $module.Params.saml_endpoint[$i]
-                                    Index     = $i
+                                    Binding = 'POST'
+                                    Protocol = 'SAMLAssertionConsumer'
+                                    Uri = $module.Params.saml_endpoint[$i]
+                                    Index = $i
                                     IsDefault = ($i -eq 0)
                                 }
                                 $endpoints += New-AdfsSamlEndpoint @endpointParams

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -88,7 +88,7 @@ $name = $module.Params.name
 $state = $module.Params.state
 
 $signatureAlgorithmMap = @{
-    'rsa_sha1'   = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+    'rsa_sha1' = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
     'rsa_sha256' = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
 }
 
@@ -180,7 +180,7 @@ function Test-AdfsSamlEndpointsChanged {
 }
 
 # Build the desired SAML endpoint collection.
-function New-DesiredAdfsSamlEndpoints {
+function New-DesiredAdfsSamlEndpoint {
     param(
         [Parameter(Mandatory)]
         [string[]]$EndpointUris
@@ -258,8 +258,7 @@ function Set-AdfsModuleResult {
         $State.SignatureAlgorithm -and
         $signatureAlgorithmReverseMap.ContainsKey($State.SignatureAlgorithm)
     ) {
-        $module.Result.signature_algorithm =
-            $signatureAlgorithmReverseMap[$State.SignatureAlgorithm]
+        $module.Result.signature_algorithm = $signatureAlgorithmReverseMap[$State.SignatureAlgorithm]
     }
     else {
         $module.Result.signature_algorithm = $State.SignatureAlgorithm
@@ -498,8 +497,7 @@ if ($state -eq 'present') {
         }
 
         if ($module.Params.saml_endpoint) {
-            $desiredState.SamlEndpoints =
-                New-DesiredAdfsSamlEndpoints -EndpointUris @($module.Params.saml_endpoint)
+            $desiredState.SamlEndpoints = New-DesiredAdfsSamlEndpoint -EndpointUris @($module.Params.saml_endpoint)
         }
 
         $module.Result.changed = $true
@@ -564,7 +562,7 @@ if ($state -eq 'present') {
         # SAML endpoints
 
         if ($module.Params.saml_endpoint) {
-            $desiredSamlEndpoints = New-DesiredAdfsSamlEndpoints -EndpointUris @($module.Params.saml_endpoint)
+            $desiredSamlEndpoints = New-DesiredAdfsSamlEndpoint -EndpointUris @($module.Params.saml_endpoint)
 
             $currentSamlEndpoints = @($existing.SamlEndpoints)
 

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -143,6 +143,11 @@ function Invoke-AdfsTrustSamlEndpoint {
     if ($useRemoting) {
         $scriptBlock = {
             param([string]$Operation, [string]$Name, [string[]]$EndpointUris, [hashtable]$AddParams)
+            # $eps = [System.Collections.Generic.List[object]]::new()
+            # for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+            #     $eps.Add((New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)))
+            # }
+
             $eps = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
                 New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
             }
@@ -164,6 +169,11 @@ function Invoke-AdfsTrustSamlEndpoint {
         }
     }
     else {
+        # $endpoints = [System.Collections.Generic.List[object]]::new()
+        # for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+        #     $endpoints.Add((New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)))
+        # }
+
         $endpoints = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
             New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
         }
@@ -194,6 +204,10 @@ if ($state -eq 'present') {
         }
 
         if ($module.Params.metadata_url) {
+            # No separate reachability pre-check here: Add-AdfsRelyingPartyTrust
+            # will itself fail with a clear error if the URL can't be reached,
+            # so a second, possibly differently-authenticated request is just
+            # an extra point of failure without adding real safety.
             $addParams.MetadataUrl = [Uri]$module.Params.metadata_url
         }
         elseif ($module.Params.metadata_file) {
@@ -281,14 +295,43 @@ if ($state -eq 'present') {
         # collection, so saml_endpoint in the playbook must always contain the
         # full desired set, not just the endpoint(s) being added.
         if ($module.Params.saml_endpoint) {
-            $desiredEndpoints = for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
-                [PSCustomObject]@{
-                    Uri = $module.Params.saml_endpoint[$i]
-                    Binding = 'POST'
-                    Protocol = 'SAMLAssertionConsumer'
-                    IsDefault = ($i -eq 0)
+            # Build both lists with .Add() rather than capturing loop/pipeline
+            # output into a variable. Capturing a for/foreach/pipeline result
+            # directly unwraps a single-item result into a bare object
+            # instead of a 1-element array, which broke .Count comparisons
+            # (and therefore idempotency) whenever exactly one SAML endpoint
+            # was configured.
+            # $desiredEndpoints = [System.Collections.Generic.List[object]]::new()
+            # for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
+            #     $desiredEndpoints.Add([PSCustomObject]@{
+            #         Uri = $module.Params.saml_endpoint[$i]
+            #         Binding = 'POST'
+            #         Protocol = 'SAMLAssertionConsumer'
+            #         IsDefault = ($i -eq 0)
+            #    })
+            # }
+
+            # $currentEndpoints = [System.Collections.Generic.List[object]]::new()
+            # ForEach ($endpoint in @($existing.SamlEndpoints)) {
+            #     $currentEndpoints.Add([PSCustomObject]@{
+            #         Uri = $endpoint.Location.ToString()
+            #         Binding = $endpoint.Binding.ToString()
+            #         Protocol = $endpoint.Protocol.ToString()
+            #         IsDefault = $endpoint.IsDefault
+            #     })
+            # }
+
+            $desiredEndpoints = @(
+                ForEach ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
+                    [PSCustomObject]@{
+                        Uri = $module.Params.saml_endpoint[$i]
+                        Binding = 'POST'
+                        Protocol = 'SAMLAssertionConsumer'
+                        IsDefault = ($i -eq 0)
+                    }
                 }
-            }
+            )
+
             $currentEndpoints = @(
                 ForEach ($ep in $existing.SamlEndpoints) {
                     [PSCustomObject]@{

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -130,21 +130,10 @@ function Test-AdfsValueChanged {
     $currentArray = @($Current | Where-Object { $null -ne $_ } | ForEach-Object { [string]$_ })
     $desiredArray = @($Desired | Where-Object { $null -ne $_ } | ForEach-Object { [string]$_ })
 
-    if ($currentArray.Count -ne $desiredArray.Count) {
-        return $true
-    }
+    $currentSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$currentArray)
+    $desiredSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$desiredArray)
 
-    if ($currentArray.Count -eq 0) {
-        return $false
-    }
-
-    for ($i = 0; $i -lt $currentArray.Count; $i++) {
-        if ($currentArray[$i] -ne $desiredArray[$i]) {
-            return $true
-        }
-    }
-
-    return $false
+    return -not $currentSet.SetEquals($desiredSet)
 }
 
 # Compare SAML endpoints in their original order.
@@ -415,7 +404,7 @@ try {
     $existing = Get-AdfsRelyingPartyTrustDetail -Name $name
 }
 catch {
-    $module.FailJson("Failed to retrieve relying party trust '$name': $($_.Exception.Message)", $_)
+    $module.FailJson("Failed to retrieve relying party trust '$name': $_", $_)
 }
 
 # $desiredState is the single representation of the state the module wants.
@@ -512,14 +501,14 @@ if ($state -eq 'present') {
                 }
             }
             catch {
-                $module.FailJson("Failed to create relying party trust '$name': $($_.Exception.Message)", $_)
+                $module.FailJson("Failed to create relying party trust '$name': $_", $_)
             }
 
             try {
                 $existing = Get-AdfsRelyingPartyTrustDetail -Name $name
             }
             catch {
-                $module.FailJson("Failed to retrieve newly created trust '$name': $($_.Exception.Message)", $_)
+                $module.FailJson("Failed to retrieve newly created trust '$name': $_", $_)
             }
 
             # Actual ADFS state is authoritative after creation.
@@ -621,10 +610,7 @@ if ($state -eq 'present') {
                 }
             }
             catch {
-                $module.FailJson(
-                    "Failed to update relying party trust '$name': $($_.Exception.Message)",
-                    $_
-                )
+                $module.FailJson("Failed to update relying party trust '$name': $_", $_)
             }
 
             # Re-read the actual state after applying the changes.
@@ -632,10 +618,7 @@ if ($state -eq 'present') {
                 $existing = Get-AdfsRelyingPartyTrustDetail -Name $name
             }
             catch {
-                $module.FailJson(
-                    "Failed to retrieve updated trust '$name': $($_.Exception.Message)",
-                    $_
-                )
+                $module.FailJson("Failed to retrieve updated trust '$name': $_", $_)
             }
 
             # Actual ADFS state is authoritative after a real update.
@@ -663,7 +646,7 @@ else {
                 Remove-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false -ErrorAction Stop
             }
             catch {
-                $module.FailJson("Failed to remove relying party trust '$name': $($_.Exception.Message)", $_)
+                $module.FailJson("Failed to remove relying party trust '$name': $_", $_)
             }
         }
     }

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -114,15 +114,28 @@ $propertyMap = @(
 )
 
 # Generic "is this different" check used for both scalars and arrays (e.g.
-# Identifier). Compare-Object handles both cleanly when each side is
-# wrapped in @(); plain -ne on two arrays does an unintended element-wise
-# comparison rather than a whole-collection comparison.
+# Identifier). Treats both sides as unordered sets of values - this matches
+# ADFS semantics for multi-valued properties like Identifier, and is a no-op
+# simplification for scalars. Avoids Compare-Object entirely: passing it a
+# genuinely empty array as -ReferenceObject/-DifferenceObject throws
+# "Cannot bind argument to parameter 'ReferenceObject' because it is null"
+# due to a PowerShell parameter-binding quirk, not because the value is
+# actually null.
 function Test-AdfsValueChanged {
     param($Current, $Desired)
-    # Handle null/empty inputs for Compare-Object
-    $currentArray = if ($null -eq $Current) { @() } else { @($Current) }
-    $desiredArray = if ($null -eq $Desired) { @() } else { @($Desired) }
-    return [bool](Compare-Object -ReferenceObject $currentArray -DifferenceObject $desiredArray)
+
+    $currentArray = @($Current | Where-Object { $null -ne $_ } | ForEach-Object { [string]$_ })
+    $desiredArray = @($Desired | Where-Object { $null -ne $_ } | ForEach-Object { [string]$_ })
+
+    if ($currentArray.Count -ne $desiredArray.Count) {
+        return $true
+    }
+    if ($currentArray.Count -eq 0) {
+        return $false
+    }
+
+    $currentSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$currentArray)
+    return -not $currentSet.SetEquals([string[]]$desiredArray)
 }
 
 # Builds the desired SAML endpoint collection and applies it via either

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -70,6 +70,8 @@ $spec = @{
 }
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+
 $module.Result.changed = $false
 $module.Result.identifier = @()
 $module.Result.enabled = $null
@@ -90,6 +92,7 @@ $signatureAlgorithmMap = @{
     'rsa_sha1' = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
     'rsa_sha256' = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
 }
+
 # Reverse map so we can report signature_algorithm back in the friendly
 # short form rather than the raw XML-DSig URI.
 $signatureAlgorithmReverseMap = @{}
@@ -130,12 +133,95 @@ function Test-AdfsValueChanged {
     if ($currentArray.Count -ne $desiredArray.Count) {
         return $true
     }
+
     if ($currentArray.Count -eq 0) {
         return $false
     }
 
     $currentSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$currentArray)
     return -not $currentSet.SetEquals([string[]]$desiredArray)
+}
+
+function New-DesiredAdfsSamlEndpoints {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$EndpointUris
+    )
+
+    @(
+        for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+            [PSCustomObject]@{
+                Uri = $EndpointUris[$i]
+                Binding = 'POST'
+                Protocol = 'SAMLAssertionConsumer'
+                IsDefault = ($i -eq 0)
+            }
+        }
+    )
+}
+
+function New-AdfsDesiredState {
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$Current
+    )
+
+    [PSCustomObject]@{
+        Identifier = @($Current.Identifier)
+        Enabled = $Current.Enabled
+        MonitoringEnabled = $Current.MonitoringEnabled
+        AutoUpdateEnabled = $Current.AutoUpdateEnabled
+        TokenLifetime = $Current.TokenLifetime
+        Notes = $Current.Notes
+        AccessControlPolicyName = $Current.AccessControlPolicyName
+        SignatureAlgorithm = $Current.SignatureAlgorithm
+        EncryptClaims = $Current.EncryptClaims
+        WSFedEndpoint = $Current.WSFedEndpoint
+        SamlEndpoints = @(
+            $Current.SamlEndpoints | ForEach-Object {
+                [PSCustomObject]@{
+                    Uri = $_.Uri
+                    Binding = $_.Binding
+                    Protocol = $_.Protocol
+                    IsDefault = $_.IsDefault
+                }
+            }
+        )
+    }
+}
+
+function Set-AdfsModuleResult {
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$State
+    )
+
+    $module.Result.identifier = @($State.Identifier)
+    $module.Result.enabled = $State.Enabled
+    $module.Result.monitoring_enabled = $State.MonitoringEnabled
+    $module.Result.auto_update_enabled = $State.AutoUpdateEnabled
+    $module.Result.token_lifetime = $State.TokenLifetime
+    $module.Result.notes = $State.Notes
+    $module.Result.access_control_policy_name = $State.AccessControlPolicyName
+    $module.Result.encrypt_claims = $State.EncryptClaims
+    $module.Result.saml_endpoints = @(
+        $State.SamlEndpoints | ForEach-Object {
+            $_.Uri
+        }
+    )
+
+    if (
+        $State.SignatureAlgorithm -and
+        $signatureAlgorithmReverseMap.ContainsKey($State.SignatureAlgorithm)
+    ) {
+        $module.Result.signature_algorithm =
+            $signatureAlgorithmReverseMap[$State.SignatureAlgorithm]
+    }
+    else {
+        $module.Result.signature_algorithm = $State.SignatureAlgorithm
+    }
+
+    $module.Result.wsfed_endpoint = $State.WSFedEndpoint
 }
 
 # Builds the desired SAML endpoint collection and applies it via either
@@ -158,11 +244,20 @@ function Invoke-AdfsTrustSamlEndpoint {
 
     if ($useRemoting) {
         $scriptBlock = {
-            param([string]$Operation, [string]$Name, [string[]]$EndpointUris, [hashtable]$AddParams)
+            param(
+                [string]$Operation,
+                [string]$Name,
+                [string[]]$EndpointUris,
+                [hashtable]$AddParams
+            )
 
-            $eps = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
-                New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
-            }
+            $eps = @(
+                for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+                    New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
+
+                }
+            )
+
             if ($Operation -eq 'Add') {
                 $AddParams['SamlEndpoint'] = @($eps)
                 Add-AdfsRelyingPartyTrust @AddParams
@@ -173,6 +268,7 @@ function Invoke-AdfsTrustSamlEndpoint {
         }
 
         $winPS = New-PSSession -UseWindowsPowerShell -ErrorAction Stop
+
         try {
             Invoke-Command -Session $winPS -ScriptBlock $scriptBlock -ArgumentList $Operation, $Name, $EndpointUris, $AddParams -ErrorAction Stop
         }
@@ -181,9 +277,11 @@ function Invoke-AdfsTrustSamlEndpoint {
         }
     }
     else {
-        $endpoints = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
-            New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
-        }
+        $endpoints = @(
+            for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+                New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
+            }
+        )
 
         if ($Operation -eq 'Add') {
             $AddParams['SamlEndpoint'] = @($endpoints)
@@ -221,36 +319,45 @@ function Get-AdfsRelyingPartyTrustDetail {
         param([string]$Name)
 
         $rp = Get-AdfsRelyingPartyTrust -Name $Name -ErrorAction Stop
+
         if (-not $rp) {
             return $null
         }
 
-        $samlEndpoints = @($rp.SamlEndpoints | ForEach-Object {
-            [PSCustomObject]@{
-                Uri       = $_.Location.ToString()
-                Binding   = $_.Binding.ToString()
-                Protocol  = $_.Protocol.ToString()
-                IsDefault = $_.IsDefault
+        $samlEndpoints = @(
+            $rp.SamlEndpoints | ForEach-Object {
+                [PSCustomObject]@{
+                    Uri = $_.Location.ToString()
+                    Binding = $_.Binding.ToString()
+                    Protocol = $_.Protocol.ToString()
+                    IsDefault = $_.IsDefault
+                }
             }
-        })
+        )
 
         [PSCustomObject]@{
-            Identifier               = @($rp.Identifier)
-            WSFedEndpoint            = if ($rp.WSFedEndpoint) { $rp.WSFedEndpoint.ToString() } else { $null }
-            Enabled                  = $rp.Enabled
-            MonitoringEnabled        = $rp.MonitoringEnabled
-            AutoUpdateEnabled        = $rp.AutoUpdateEnabled
-            TokenLifetime            = $rp.TokenLifetime
-            Notes                    = $rp.Notes
-            AccessControlPolicyName  = $rp.AccessControlPolicyName
-            SignatureAlgorithm       = $rp.SignatureAlgorithm
-            EncryptClaims            = $rp.EncryptClaims
-            SamlEndpoints            = $samlEndpoints
+            Identifier = @($rp.Identifier)
+            WSFedEndpoint = if ($rp.WSFedEndpoint) {
+                $rp.WSFedEndpoint.ToString()
+            }
+            else {
+                $null
+            }
+            Enabled = $rp.Enabled
+            MonitoringEnabled = $rp.MonitoringEnabled
+            AutoUpdateEnabled = $rp.AutoUpdateEnabled
+            TokenLifetime = $rp.TokenLifetime
+            Notes = $rp.Notes
+            AccessControlPolicyName = $rp.AccessControlPolicyName
+            SignatureAlgorithm = $rp.SignatureAlgorithm
+            EncryptClaims = $rp.EncryptClaims
+            SamlEndpoints = $samlEndpoints
         }
     }
 
     if ($useRemoting) {
         $winPS = New-PSSession -UseWindowsPowerShell -ErrorAction Stop
+
         try {
             return Invoke-Command -Session $winPS -ScriptBlock $scriptBlock -ArgumentList $Name -ErrorAction Stop
         }
@@ -270,9 +377,19 @@ catch {
     $module.FailJson("Failed to retrieve relying party trust '$name': $($_.Exception.Message)", $_)
 }
 
+# $desiredState represents the state the module wants ADFS to have.
+# In check mode this is returned directly.
+# In normal mode it is replaced with the actual state after changes.
+$desiredState = $null
+
+if ($existing) {
+    $desiredState = New-AdfsDesiredState -Current $existing
+}
+
 if ($state -eq 'present') {
     if (-not $existing) {
         # CREATE
+
         $addParams = @{
             Name = $name
             Confirm = $false
@@ -289,10 +406,12 @@ if ($state -eq 'present') {
             if (-not (Test-Path -LiteralPath $module.Params.metadata_file)) {
                 $module.FailJson("Metadata file not found: '$($module.Params.metadata_file)'")
             }
+
             $addParams.MetadataFile = $module.Params.metadata_file
         }
         else {
             $addParams.Identifier = $module.Params.identifier
+
             if ($module.Params.wsfed_endpoint) {
                 $addParams.WSFedEndpoint = [Uri]$module.Params.wsfed_endpoint
             }
@@ -305,13 +424,41 @@ if ($state -eq 'present') {
         ForEach ($prop in $propertyMap) {
             # Identifier/WSFedEndpoint are already handled above for the
             # non-metadata creation path; avoid clobbering/duplicating them.
-            if ($prop.Param -in @('identifier', 'wsfed_endpoint')) { continue }
+            if ($prop.Param -in @('identifier', 'wsfed_endpoint')) {
+                continue
+            }
 
             $val = $module.Params[$prop.Param]
-            if ($null -ne $val) {
-                if ($prop.Cast) { $val = & $prop.Cast $val }
-                $addParams[$prop.Cmdlet] = $val
+
+            if ($null -eq $val) {
+                continue
             }
+
+            if ($prop.Cast) {
+                $val = & $prop.Cast $val
+            }
+
+            $addParams[$prop.Cmdlet] = $val
+        }
+
+        # Build the desired state for the object that would be created.
+        $desiredState = [PSCustomObject]@{
+            Identifier = @($module.Params.identifier)
+            Enabled = $module.Params.enabled
+            MonitoringEnabled = $module.Params.monitoring_enabled
+            AutoUpdateEnabled = $module.Params.auto_update_enabled
+            TokenLifetime = $module.Params.token_lifetime
+            Notes = $module.Params.notes
+            AccessControlPolicyName = $module.Params.access_control_policy_name
+            SignatureAlgorithm = $module.Params.signature_algorithm
+            EncryptClaims = $module.Params.encrypt_claims
+            WSFedEndpoint = $module.Params.wsfed_endpoint
+            SamlEndpoints = @()
+        }
+
+        if ($module.Params.saml_endpoint) {
+            $desiredState.SamlEndpoints =
+                New-DesiredAdfsSamlEndpoints -EndpointUris @($module.Params.saml_endpoint)
         }
 
         $module.Result.changed = $true
@@ -335,64 +482,67 @@ if ($state -eq 'present') {
             catch {
                 $module.FailJson("Failed to retrieve newly created trust '$name': $($_.Exception.Message)", $_)
             }
+
+            # Actual state is authoritative after creation.
+            $desiredState = New-AdfsDesiredState -Current $existing
         }
     }
     else {
         # UPDATE
-        $updateParams = @{}
+
+        $updateParams = @()
 
         ForEach ($prop in $propertyMap) {
             $desired = $module.Params[$prop.Param]
-            if ($null -eq $desired) { continue }
 
-            if ($prop.Cast) { $desired = & $prop.Cast $desired }
+            if ($null -eq $desired) {
+                continue
+            }
+
+            $desiredAdfsValue = $desired
+
+            if ($prop.Cast) {
+                $desiredAdfsValue = & $prop.Cast $desiredAdfsValue
+            }
+
             $current = $existing.($prop.Cmdlet)
 
             if (Test-AdfsValueChanged -Current $current -Desired $desired) {
-                $updateParams[$prop.Cmdlet] = $desired
+                $updateParams += @{
+                    Cmdlet = $prop.Cmdlet
+                    Value  = $desiredAdfsValue
+                }
+
+                # Project the requested value into the desired state.
+                $desiredState.($prop.Cmdlet) = $desiredAdfsValue
             }
         }
 
-        if ($updateParams.Count -gt 0) {
-            $module.Result.changed = $true
-            if (-not $module.CheckMode) {
-                try {
-                    Set-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false @updateParams -ErrorAction Stop
-                }
-                catch {
-                    $module.FailJson("Failed to update relying party trust '$name': $($_.Exception.Message)", $_)
-                }
-            }
-        }
+        # SAML endpoint desired state.
+        $samlEndpointChanged = $false
 
-        # Update SAML endpoints if different from what's currently configured.
-        # Set-AdfsRelyingPartyTrust -SamlEndpoint replaces the entire endpoint
-        # collection, so saml_endpoint in the playbook must always contain the
-        # full desired set, not just the endpoint(s) being added.
         if ($module.Params.saml_endpoint) {
-            $desiredEndpoints = @(
-                for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
-                    [PSCustomObject]@{
-                        Uri = $module.Params.saml_endpoint[$i]
-                        Binding = 'POST'
-                        Protocol = 'SAMLAssertionConsumer'
-                        IsDefault = ($i -eq 0)
-                    }
-                }
-            )
+            $desiredSamlEndpoints = New-DesiredAdfsSamlEndpoints -EndpointUris @($module.Params.saml_endpoint)
 
-            $currentEndpoints = @($existing.SamlEndpoints)
+            $currentSamlEndpoints = @($existing.SamlEndpoints)
 
             # Compare in original order: order determines which endpoint gets
             # Index 0 / IsDefault. Compare Uri, Binding, Protocol, and
             # IsDefault so a change to any of those is detected, not just a
             # changed Location.
-            $samlEndpointChanged = $currentEndpoints.Count -ne $desiredEndpoints.Count
+            $samlEndpointChanged = $currentSamlEndpoints.Count -ne $desiredSamlEndpoints.Count
+
             if (-not $samlEndpointChanged) {
-                for ($i = 0; $i -lt $currentEndpoints.Count; $i++) {
-                    $c = $currentEndpoints[$i]
-                    $d = $desiredEndpoints[$i]
-                    if ($c.Uri -ne $d.Uri -or $c.Binding -ne $d.Binding -or $c.Protocol -ne $d.Protocol -or $c.IsDefault -ne $d.IsDefault) {
+                for ($i = 0; $i -lt $currentSamlEndpoints.Count; $i++) {
+                    $currentEndpoint = $currentSamlEndpoints[$i]
+                    $desiredEndpoint = $desiredSamlEndpoints[$i]
+
+                    if (
+                        $currentEndpoint.Uri -ne $desiredEndpoint.Uri -or
+                        $currentEndpoint.Binding -ne $desiredEndpoint.Binding -or
+                        $currentEndpoint.Protocol -ne $desiredEndpoint.Protocol -or
+                        $currentEndpoint.IsDefault -ne $desiredEndpoint.IsDefault
+                    ) {
                         $samlEndpointChanged = $true
                         break
                     }
@@ -400,23 +550,48 @@ if ($state -eq 'present') {
             }
 
             if ($samlEndpointChanged) {
-                $module.Result.changed = $true
-
-                if (-not $module.CheckMode) {
-                    try {
-                        Invoke-AdfsTrustSamlEndpoint -Operation Set -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $null
-                    }
-                    catch {
-                        $module.FailJson("Failed to update SAML endpoints for relying party trust '$name': $($_.Exception.Message)", $_)
-                    }
-                }
+                $desiredState.SamlEndpoints = $desiredSamlEndpoints
             }
         }
 
-        if ($null -ne $module.Params.enabled -and $module.Params.enabled -ne $existing.Enabled) {
+        # Enabled desired state.
+        $enabledChanged = (
+            $null -ne $module.Params.enabled -and
+            $module.Params.enabled -ne $existing.Enabled
+        )
+
+        if ($enabledChanged) {
+            $desiredState.Enabled = $module.Params.enabled
+        }
+
+        if (
+            $updateParams.Count -gt 0 -or
+            $samlEndpointChanged -or
+            $enabledChanged
+        ) {
             $module.Result.changed = $true
-            if (-not $module.CheckMode) {
-                try {
+        }
+
+        if (-not $module.CheckMode -and $module.Result.changed) {
+            try {
+                # Apply normal property updates.
+                if ($updateParams.Count -gt 0) {
+                    $setParams = @{}
+
+                    foreach ($update in $updateParams) {
+                        $setParams[$update.Cmdlet] = $update.Value
+                    }
+
+                    Set-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false @setParams -ErrorAction Stop
+                }
+
+                # Apply SAML endpoint changes.
+                if ($samlEndpointChanged) {
+                    Invoke-AdfsTrustSamlEndpoint -Operation Set -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $null
+                }
+
+                # Apply enabled state.
+                if ($enabledChanged) {
                     if ($module.Params.enabled) {
                         Enable-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false -ErrorAction Stop
                     }
@@ -424,47 +599,36 @@ if ($state -eq 'present') {
                         Disable-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false -ErrorAction Stop
                     }
                 }
-                catch {
-                    $module.FailJson("Failed to set enabled state for relying party trust '$name': $($_.Exception.Message)", $_)
-                }
             }
-        }
+            catch {
+                $module.FailJson(
+                    "Failed to update relying party trust '$name': $($_.Exception.Message)",
+                    $_
+                )
+            }
 
-        if ($module.Result.changed -and -not $module.CheckMode) {
             try {
                 $existing = Get-AdfsRelyingPartyTrustDetail -Name $name
             }
             catch {
-                $module.FailJson("Failed to retrieve updated trust '$name': $($_.Exception.Message)", $_)
+                $module.FailJson(
+                    "Failed to retrieve updated trust '$name': $($_.Exception.Message)",
+                    $_
+                )
             }
+
+            # Actual state is authoritative after a real update.
+            $desiredState = New-AdfsDesiredState -Current $existing
         }
     }
 
-    if ($existing) {
-        $module.Result.identifier = @($existing.Identifier)
-        $module.Result.enabled = $existing.Enabled
-        $module.Result.monitoring_enabled = $existing.MonitoringEnabled
-        $module.Result.auto_update_enabled = $existing.AutoUpdateEnabled
-        $module.Result.token_lifetime = $existing.TokenLifetime
-        $module.Result.notes = $existing.Notes
-        $module.Result.access_control_policy_name = $existing.AccessControlPolicyName
-        $module.Result.encrypt_claims = $existing.EncryptClaims
-        $module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_.Uri })
-
-        if ($existing.SignatureAlgorithm -and $signatureAlgorithmReverseMap.ContainsKey($existing.SignatureAlgorithm)) {
-            $module.Result.signature_algorithm = $signatureAlgorithmReverseMap[$existing.SignatureAlgorithm]
-        }
-        else {
-            $module.Result.signature_algorithm = $existing.SignatureAlgorithm
-        }
-
-        if ($existing.WSFedEndpoint) {
-            $module.Result.wsfed_endpoint = $existing.WSFedEndpoint
-        }
+    if ($desiredState) {
+        Set-AdfsModuleResult -State $desiredState
     }
 }
 else {
     # ABSENT
+
     if ($existing) {
         $module.Result.changed = $true
 

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -159,10 +159,6 @@ function Invoke-AdfsTrustSamlEndpoint {
     if ($useRemoting) {
         $scriptBlock = {
             param([string]$Operation, [string]$Name, [string[]]$EndpointUris, [hashtable]$AddParams)
-            # $eps = [System.Collections.Generic.List[object]]::new()
-            # for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
-            #     $eps.Add((New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)))
-            # }
 
             $eps = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
                 New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
@@ -185,11 +181,6 @@ function Invoke-AdfsTrustSamlEndpoint {
         }
     }
     else {
-        # $endpoints = [System.Collections.Generic.List[object]]::new()
-        # for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
-        #     $endpoints.Add((New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)))
-        # }
-
         $endpoints = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
             New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
         }
@@ -204,8 +195,76 @@ function Invoke-AdfsTrustSamlEndpoint {
     }
 }
 
+# Retrieves a relying party trust and flattens it into a plain PSCustomObject
+# before it can cross the WinCompat remoting boundary. Under implicit
+# remoting (PowerShell 7+ consuming the ADFS module via WinPS Compatibility),
+# nested complex properties - most notably SamlEndpoints - do not survive
+# CliXml round-tripping intact: PowerShell's remoting serializer falls back
+# to capturing only ToString() once a type exceeds its default serialization
+# depth, silently turning e.g. each SamlEndpoint object into the bare string
+# "Microsoft.IdentityServer.Management.Resources.SamlEndpoint" with none of
+# its real properties (Location, Binding, Protocol, IsDefault) intact. Doing
+# the property extraction *inside* the native Windows PowerShell session -
+# before anything crosses the proxy - avoids this entirely, mirroring how
+# Invoke-AdfsTrustSamlEndpoint already does writes inside the same session
+# boundary.
+function Get-AdfsRelyingPartyTrustDetail {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    $cmd = Get-Command Get-AdfsRelyingPartyTrust -ErrorAction Stop
+    $useRemoting = [bool]($cmd.Module.PrivateData.ImplicitRemoting)
+
+    $scriptBlock = {
+        param([string]$Name)
+
+        $rp = Get-AdfsRelyingPartyTrust -Name $Name -ErrorAction Stop
+        if (-not $rp) {
+            return $null
+        }
+
+        $samlEndpoints = @($rp.SamlEndpoints | ForEach-Object {
+            [PSCustomObject]@{
+                Uri       = $_.Location.ToString()
+                Binding   = $_.Binding.ToString()
+                Protocol  = $_.Protocol.ToString()
+                IsDefault = $_.IsDefault
+            }
+        })
+
+        [PSCustomObject]@{
+            Identifier               = @($rp.Identifier)
+            WSFedEndpoint            = if ($rp.WSFedEndpoint) { $rp.WSFedEndpoint.ToString() } else { $null }
+            Enabled                  = $rp.Enabled
+            MonitoringEnabled        = $rp.MonitoringEnabled
+            AutoUpdateEnabled        = $rp.AutoUpdateEnabled
+            TokenLifetime            = $rp.TokenLifetime
+            Notes                    = $rp.Notes
+            AccessControlPolicyName  = $rp.AccessControlPolicyName
+            SignatureAlgorithm       = $rp.SignatureAlgorithm
+            EncryptClaims            = $rp.EncryptClaims
+            SamlEndpoints            = $samlEndpoints
+        }
+    }
+
+    if ($useRemoting) {
+        $winPS = New-PSSession -UseWindowsPowerShell -ErrorAction Stop
+        try {
+            return Invoke-Command -Session $winPS -ScriptBlock $scriptBlock -ArgumentList $Name -ErrorAction Stop
+        }
+        finally {
+            $winPS | Remove-PSSession -ErrorAction SilentlyContinue
+        }
+    }
+    else {
+        return & $scriptBlock $Name
+    }
+}
+
 try {
-    $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction Stop
+    $existing = Get-AdfsRelyingPartyTrustDetail -Name $name
 }
 catch {
     $module.FailJson("Failed to retrieve relying party trust '$name': $($_.Exception.Message)", $_)
@@ -271,7 +330,7 @@ if ($state -eq 'present') {
             }
 
             try {
-                $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction Stop
+                $existing = Get-AdfsRelyingPartyTrustDetail -Name $name
             }
             catch {
                 $module.FailJson("Failed to retrieve newly created trust '$name': $($_.Exception.Message)", $_)
@@ -311,32 +370,6 @@ if ($state -eq 'present') {
         # collection, so saml_endpoint in the playbook must always contain the
         # full desired set, not just the endpoint(s) being added.
         if ($module.Params.saml_endpoint) {
-            # Build both lists with .Add() rather than capturing loop/pipeline
-            # output into a variable. Capturing a for/foreach/pipeline result
-            # directly unwraps a single-item result into a bare object
-            # instead of a 1-element array, which broke .Count comparisons
-            # (and therefore idempotency) whenever exactly one SAML endpoint
-            # was configured.
-            # $desiredEndpoints = [System.Collections.Generic.List[object]]::new()
-            # for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
-            #     $desiredEndpoints.Add([PSCustomObject]@{
-            #         Uri = $module.Params.saml_endpoint[$i]
-            #         Binding = 'POST'
-            #         Protocol = 'SAMLAssertionConsumer'
-            #         IsDefault = ($i -eq 0)
-            #    })
-            # }
-
-            # $currentEndpoints = [System.Collections.Generic.List[object]]::new()
-            # ForEach ($endpoint in @($existing.SamlEndpoints)) {
-            #     $currentEndpoints.Add([PSCustomObject]@{
-            #         Uri = $endpoint.Location.ToString()
-            #         Binding = $endpoint.Binding.ToString()
-            #         Protocol = $endpoint.Protocol.ToString()
-            #         IsDefault = $endpoint.IsDefault
-            #     })
-            # }
-
             $desiredEndpoints = @(
                 for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
                     [PSCustomObject]@{
@@ -348,16 +381,7 @@ if ($state -eq 'present') {
                 }
             )
 
-            $currentEndpoints = @(
-                ForEach ($ep in $existing.SamlEndpoints) {
-                    [PSCustomObject]@{
-                        Uri = $ep.Location
-                        Binding = $ep.Binding.ToString()
-                        Protocol = $ep.Protocol.ToString()
-                        IsDefault = $ep.IsDefault
-                    }
-                }
-            )
+            $currentEndpoints = @($existing.SamlEndpoints)
 
             # Compare in original order: order determines which endpoint gets
             # Index 0 / IsDefault. Compare Uri, Binding, Protocol, and
@@ -408,7 +432,7 @@ if ($state -eq 'present') {
 
         if ($module.Result.changed -and -not $module.CheckMode) {
             try {
-                $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction Stop
+                $existing = Get-AdfsRelyingPartyTrustDetail -Name $name
             }
             catch {
                 $module.FailJson("Failed to retrieve updated trust '$name': $($_.Exception.Message)", $_)
@@ -425,7 +449,7 @@ if ($state -eq 'present') {
         $module.Result.notes = $existing.Notes
         $module.Result.access_control_policy_name = $existing.AccessControlPolicyName
         $module.Result.encrypt_claims = $existing.EncryptClaims
-        $module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_ })
+        $module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_.Uri })
 
         if ($existing.SignatureAlgorithm -and $signatureAlgorithmReverseMap.ContainsKey($existing.SignatureAlgorithm)) {
             $module.Result.signature_algorithm = $signatureAlgorithmReverseMap[$existing.SignatureAlgorithm]
@@ -435,7 +459,7 @@ if ($state -eq 'present') {
         }
 
         if ($existing.WSFedEndpoint) {
-            $module.Result.wsfed_endpoint = $existing.WSFedEndpoint.ToString()
+            $module.Result.wsfed_endpoint = $existing.WSFedEndpoint
         }
     }
 }

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -425,7 +425,8 @@ if ($state -eq 'present') {
         $module.Result.notes = $existing.Notes
         $module.Result.access_control_policy_name = $existing.AccessControlPolicyName
         $module.Result.encrypt_claims = $existing.EncryptClaims
-        $module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_.Location.OriginalString })
+        #$module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_.Location.OriginalString })
+        $module.Result.saml_endpoints = @($existing.SamlEndpoints)
 
         if ($existing.SignatureAlgorithm -and $signatureAlgorithmReverseMap.ContainsKey($existing.SignatureAlgorithm)) {
             $module.Result.signature_algorithm = $signatureAlgorithmReverseMap[$existing.SignatureAlgorithm]

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -119,7 +119,10 @@ $propertyMap = @(
 # comparison rather than a whole-collection comparison.
 function Test-AdfsValueChanged {
     param($Current, $Desired)
-    return [bool](Compare-Object -ReferenceObject @($Current) -DifferenceObject @($Desired))
+    # Handle null/empty inputs for Compare-Object
+    $currentArray = if ($null -eq $Current) { @() } else { @($Current) }
+    $desiredArray = if ($null -eq $Desired) { @() } else { @($Desired) }
+    return [bool](Compare-Object -ReferenceObject $currentArray -DifferenceObject $desiredArray)
 }
 
 # Builds the desired SAML endpoint collection and applies it via either

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -44,7 +44,6 @@ $spec = @{
         }
         token_lifetime = @{
             type = 'int'
-            no_log = $false
         }
         notes = @{
             type = 'str'
@@ -74,6 +73,15 @@ $module.Result.changed = $false
 $module.Result.identifier = @()
 $module.Result.enabled = $null
 $module.Result.monitoring_enabled = $null
+$module.Result.auto_update_enabled = $null
+$module.Result.token_lifetime = $null
+$module.Result.notes = $null
+$module.Result.access_control_policy_name = $null
+$module.Result.signature_algorithm = $null
+$module.Result.encrypt_claims = $null
+$module.Result.wsfed_endpoint = $null
+$module.Result.saml_endpoints = @()
+
 $name = $module.Params.name
 $state = $module.Params.state
 
@@ -81,8 +89,20 @@ $signatureAlgorithmMap = @{
     'rsa_sha1' = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
     'rsa_sha256' = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
 }
+# Reverse map so we can report signature_algorithm back in the friendly
+# short form rather than the raw XML-DSig URI.
+$signatureAlgorithmReverseMap = @{}
+foreach ($kvp in $signatureAlgorithmMap.GetEnumerator()) {
+    $signatureAlgorithmReverseMap[$kvp.Value] = $kvp.Name
+}
 
+# Properties that can be set both at creation time (via Add-AdfsRelyingPartyTrust)
+# and updated afterwards (via Set-AdfsRelyingPartyTrust). Identifier and
+# WSFedEndpoint are included here too so drift on those is detected/corrected
+# on update, not just applied at creation.
 $propertyMap = @(
+    @{ Param = 'identifier'; Cmdlet = 'Identifier' }
+    @{ Param = 'wsfed_endpoint'; Cmdlet = 'WSFedEndpoint'; Cast = { param($v) [Uri]$v } }
     @{ Param = 'monitoring_enabled'; Cmdlet = 'MonitoringEnabled' }
     @{ Param = 'auto_update_enabled'; Cmdlet = 'AutoUpdateEnabled' }
     @{ Param = 'token_lifetime'; Cmdlet = 'TokenLifetime' }
@@ -92,11 +112,76 @@ $propertyMap = @(
     @{ Param = 'encrypt_claims'; Cmdlet = 'EncryptClaims' }
 )
 
+# Generic "is this different" check used for both scalars and arrays (e.g.
+# Identifier). Compare-Object handles both cleanly when each side is
+# wrapped in @(); plain -ne on two arrays does an unintended element-wise
+# comparison rather than a whole-collection comparison.
+function Test-AdfsValueChanged {
+    param($Current, $Desired)
+    return [bool](Compare-Object -ReferenceObject @($Current) -DifferenceObject @($Desired))
+}
+
+# Builds the desired SAML endpoint collection and applies it via either
+# Add-AdfsRelyingPartyTrust (creation) or Set-AdfsRelyingPartyTrust (update).
+# When the ADFS module is loaded via implicit remoting, New-AdfsSamlEndpoint
+# objects can't cross the proxy boundary, so in that case the endpoint
+# creation AND the Add/Set call must happen together inside the same
+# Windows PowerShell session.
+function Set-AdfsTrustSamlEndpoints {
+    param(
+        [ValidateSet('Add', 'Set')]
+        [string]$Operation,
+        [string]$Name,
+        [string[]]$EndpointUris,
+        [hashtable]$AddParams
+    )
+
+    $cmd = Get-Command Add-AdfsRelyingPartyTrust -ErrorAction Stop
+    $useRemoting = [bool]($cmd.Module.PrivateData.ImplicitRemoting)
+
+    if ($useRemoting) {
+        $scriptBlock = {
+            param([string]$Operation, [string]$Name, [string[]]$EndpointUris, [hashtable]$AddParams)
+            $eps = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+                New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
+            }
+            if ($Operation -eq 'Add') {
+                $AddParams['SamlEndpoint'] = @($eps)
+                Add-AdfsRelyingPartyTrust @AddParams
+            }
+            else {
+                Set-AdfsRelyingPartyTrust -TargetName $Name -SamlEndpoint @($eps) -Confirm:$false
+            }
+        }
+
+        $winPS = New-PSSession -UseWindowsPowerShell -ErrorAction Stop
+        try {
+            Invoke-Command -Session $winPS -ScriptBlock $scriptBlock -ArgumentList $Operation, $Name, $EndpointUris, $AddParams -ErrorAction Stop
+        }
+        finally {
+            $winPS | Remove-PSSession -ErrorAction SilentlyContinue
+        }
+    }
+    else {
+        $endpoints = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
+            New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
+        }
+
+        if ($Operation -eq 'Add') {
+            $AddParams['SamlEndpoint'] = @($endpoints)
+            Add-AdfsRelyingPartyTrust @AddParams -ErrorAction Stop
+        }
+        else {
+            Set-AdfsRelyingPartyTrust -TargetName $Name -SamlEndpoint @($endpoints) -Confirm:$false -ErrorAction Stop
+        }
+    }
+}
+
 try {
     $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction Stop
 }
 catch {
-    $module.FailJson("Failed to retrieve relying party trust '$name': $_", $_)
+    $module.FailJson("Failed to retrieve relying party trust '$name': $($_.Exception.Message)", $_)
 }
 
 if ($state -eq 'present') {
@@ -108,12 +193,6 @@ if ($state -eq 'present') {
         }
 
         if ($module.Params.metadata_url) {
-            try {
-                $null = Invoke-WebRequest -Uri $module.Params.metadata_url -UseBasicParsing -ErrorAction Stop
-            }
-            catch {
-                $module.FailJson("Cannot reach metadata URL '$($module.Params.metadata_url)': $_", $_)
-            }
             $addParams.MetadataUrl = [Uri]$module.Params.metadata_url
         }
         elseif ($module.Params.metadata_file) {
@@ -134,6 +213,10 @@ if ($state -eq 'present') {
         }
 
         foreach ($prop in $propertyMap) {
+            # Identifier/WSFedEndpoint are already handled above for the
+            # non-metadata creation path; avoid clobbering/duplicating them.
+            if ($prop.Param -in @('identifier', 'wsfed_endpoint')) { continue }
+
             $val = $module.Params[$prop.Param]
             if ($null -ne $val) {
                 if ($prop.Cast) { $val = & $prop.Cast $val }
@@ -145,55 +228,22 @@ if ($state -eq 'present') {
 
         if (-not $module.CheckMode) {
             try {
-                $cmd = Get-Command Add-AdfsRelyingPartyTrust
-                if ($module.Params.saml_endpoint -and $cmd.Module.PrivateData.ImplicitRemoting) {
-                    # The ADFS module is loaded via implicit remoting and
-                    # SamlEndpoint objects get deserialized crossing the
-                    # proxy boundary. Create them inside a WinPS session.
-                    $addTrustWithEndpoints = {
-                        param([hashtable]$Params, [string[]]$EndpointUris)
-                        $eps = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
-                            New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
-                        }
-                        $Params['SamlEndpoint'] = @($eps)
-                        Add-AdfsRelyingPartyTrust @Params
-                    }
-                    [string[]]$samlUris = @($module.Params.saml_endpoint)
-                    $winPS = New-PSSession -UseWindowsPowerShell
-                    try {
-                        Invoke-Command -Session $winPS -ScriptBlock $addTrustWithEndpoints -ArgumentList $addParams, $samlUris
-                    }
-                    finally {
-                        $winPS | Remove-PSSession
-                    }
+                if ($module.Params.saml_endpoint) {
+                    Set-AdfsTrustSamlEndpoints -Operation Add -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $addParams
                 }
                 else {
-                    if ($module.Params.saml_endpoint) {
-                        $endpoints = @()
-                        for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
-                            $endpointParams = @{
-                                Binding = 'POST'
-                                Protocol = 'SAMLAssertionConsumer'
-                                Uri = $module.Params.saml_endpoint[$i]
-                                Index = $i
-                                IsDefault = ($i -eq 0)
-                            }
-                            $endpoints += New-AdfsSamlEndpoint @endpointParams
-                        }
-                        $addParams.SamlEndpoint = $endpoints
-                    }
-                    Add-AdfsRelyingPartyTrust @addParams
+                    Add-AdfsRelyingPartyTrust @addParams -ErrorAction Stop
                 }
             }
             catch {
-                $module.FailJson("Failed to create relying party trust '$name': $_", $_)
+                $module.FailJson("Failed to create relying party trust '$name': $($_.Exception.Message)", $_)
             }
 
             try {
-                $existing = Get-AdfsRelyingPartyTrust -Name $name
+                $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction Stop
             }
             catch {
-                $module.FailJson("Failed to retrieve newly created trust '$name': $_", $_)
+                $module.FailJson("Failed to retrieve newly created trust '$name': $($_.Exception.Message)", $_)
             }
         }
     }
@@ -207,7 +257,8 @@ if ($state -eq 'present') {
 
             if ($prop.Cast) { $desired = & $prop.Cast $desired }
             $current = $existing.($prop.Cmdlet)
-            if ($desired -ne $current) {
+
+            if (Test-AdfsValueChanged -Current $current -Desired $desired) {
                 $updateParams[$prop.Cmdlet] = $desired
             }
         }
@@ -216,10 +267,10 @@ if ($state -eq 'present') {
             $module.Result.changed = $true
             if (-not $module.CheckMode) {
                 try {
-                    Set-AdfsRelyingPartyTrust -TargetName $name @updateParams
+                    Set-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false @updateParams -ErrorAction Stop
                 }
                 catch {
-                    $module.FailJson("Failed to update relying party trust '$name': $_", $_)
+                    $module.FailJson("Failed to update relying party trust '$name': $($_.Exception.Message)", $_)
                 }
             }
         }
@@ -229,14 +280,33 @@ if ($state -eq 'present') {
         # collection, so saml_endpoint in the playbook must always contain the
         # full desired set, not just the endpoint(s) being added.
         if ($module.Params.saml_endpoint) {
-            $currentUris = @($existing.SamlEndpoints | ForEach-Object { $_.Location.ToString() })
-            $desiredUris = @($module.Params.saml_endpoint)
+            $desiredEndpoints = for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
+                [PSCustomObject]@{
+                    Uri = $module.Params.saml_endpoint[$i]
+                    Binding = 'POST'
+                    Protocol = 'SAMLAssertionConsumer'
+                    IsDefault = ($i -eq 0)
+                }
+            }
+            $currentEndpoints = @($existing.SamlEndpoints | ForEach-Object {
+                [PSCustomObject]@{
+                    Uri = $_.Location.ToString()
+                    Binding = $_.Binding.ToString()
+                    Protocol = $_.Protocol.ToString()
+                    IsDefault = $_.IsDefault
+                }
+            })
 
-            # Compare in original order determines which endpoint gets Index 0 / IsDefault
-            $samlEndpointChanged = $currentUris.Count -ne $desiredUris.Count
+            # Compare in original order: order determines which endpoint gets
+            # Index 0 / IsDefault. Compare Uri, Binding, Protocol, and
+            # IsDefault so a change to any of those is detected, not just a
+            # changed Location.
+            $samlEndpointChanged = $currentEndpoints.Count -ne $desiredEndpoints.Count
             if (-not $samlEndpointChanged) {
-                for ($i = 0; $i -lt $currentUris.Count; $i++) {
-                    if ($currentUris[$i] -ne $desiredUris[$i]) {
+                for ($i = 0; $i -lt $currentEndpoints.Count; $i++) {
+                    $c = $currentEndpoints[$i]
+                    $d = $desiredEndpoints[$i]
+                    if ($c.Uri -ne $d.Uri -or $c.Binding -ne $d.Binding -or $c.Protocol -ne $d.Protocol -or $c.IsDefault -ne $d.IsDefault) {
                         $samlEndpointChanged = $true
                         break
                     }
@@ -248,43 +318,10 @@ if ($state -eq 'present') {
 
                 if (-not $module.CheckMode) {
                     try {
-                        $cmd = Get-Command Add-AdfsRelyingPartyTrust
-                        if ($cmd.Module.PrivateData.ImplicitRemoting) {
-                            # Same cross-proxy issue as on create: build the
-                            # SamlEndpoint objects inside a WinPS session.
-                            $setTrustEndpoints = {
-                                param([string]$Name, [string[]]$EndpointUris)
-                                $eps = for ($i = 0; $i -lt $EndpointUris.Count; $i++) {
-                                    New-AdfsSamlEndpoint -Binding POST -Protocol SAMLAssertionConsumer -Uri $EndpointUris[$i] -Index $i -IsDefault:($i -eq 0)
-                                }
-                                Set-AdfsRelyingPartyTrust -TargetName $Name -SamlEndpoint @($eps)
-                            }
-                            [string[]]$samlUris = @($module.Params.saml_endpoint)
-                            $winPS = New-PSSession -UseWindowsPowerShell
-                            try {
-                                Invoke-Command -Session $winPS -ScriptBlock $setTrustEndpoints -ArgumentList $name, $samlUris
-                            }
-                            finally {
-                                $winPS | Remove-PSSession
-                            }
-                        }
-                        else {
-                            $endpoints = @()
-                            for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
-                                $endpointParams = @{
-                                    Binding = 'POST'
-                                    Protocol = 'SAMLAssertionConsumer'
-                                    Uri = $module.Params.saml_endpoint[$i]
-                                    Index = $i
-                                    IsDefault = ($i -eq 0)
-                                }
-                                $endpoints += New-AdfsSamlEndpoint @endpointParams
-                            }
-                            Set-AdfsRelyingPartyTrust -TargetName $name -SamlEndpoint $endpoints
-                        }
+                        Set-AdfsTrustSamlEndpoints -Operation Set -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $null
                     }
                     catch {
-                        $module.FailJson("Failed to update SAML endpoints for relying party trust '$name': $_", $_)
+                        $module.FailJson("Failed to update SAML endpoints for relying party trust '$name': $($_.Exception.Message)", $_)
                     }
                 }
             }
@@ -295,24 +332,24 @@ if ($state -eq 'present') {
             if (-not $module.CheckMode) {
                 try {
                     if ($module.Params.enabled) {
-                        Enable-AdfsRelyingPartyTrust -TargetName $name
+                        Enable-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false -ErrorAction Stop
                     }
                     else {
-                        Disable-AdfsRelyingPartyTrust -TargetName $name
+                        Disable-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false -ErrorAction Stop
                     }
                 }
                 catch {
-                    $module.FailJson("Failed to set enabled state for relying party trust '$name': $_", $_)
+                    $module.FailJson("Failed to set enabled state for relying party trust '$name': $($_.Exception.Message)", $_)
                 }
             }
         }
 
         if ($module.Result.changed -and -not $module.CheckMode) {
             try {
-                $existing = Get-AdfsRelyingPartyTrust -Name $name
+                $existing = Get-AdfsRelyingPartyTrust -Name $name -ErrorAction Stop
             }
             catch {
-                $module.FailJson("Failed to retrieve updated trust '$name': $_", $_)
+                $module.FailJson("Failed to retrieve updated trust '$name': $($_.Exception.Message)", $_)
             }
         }
     }
@@ -321,6 +358,23 @@ if ($state -eq 'present') {
         $module.Result.identifier = @($existing.Identifier)
         $module.Result.enabled = $existing.Enabled
         $module.Result.monitoring_enabled = $existing.MonitoringEnabled
+        $module.Result.auto_update_enabled = $existing.AutoUpdateEnabled
+        $module.Result.token_lifetime = $existing.TokenLifetime
+        $module.Result.notes = $existing.Notes
+        $module.Result.access_control_policy_name = $existing.AccessControlPolicyName
+        $module.Result.encrypt_claims = $existing.EncryptClaims
+        $module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_.Location.ToString() })
+
+        if ($existing.SignatureAlgorithm -and $signatureAlgorithmReverseMap.ContainsKey($existing.SignatureAlgorithm)) {
+            $module.Result.signature_algorithm = $signatureAlgorithmReverseMap[$existing.SignatureAlgorithm]
+        }
+        else {
+            $module.Result.signature_algorithm = $existing.SignatureAlgorithm
+        }
+
+        if ($existing.WSFedEndpoint) {
+            $module.Result.wsfed_endpoint = $existing.WSFedEndpoint.ToString()
+        }
     }
 }
 else {
@@ -330,10 +384,10 @@ else {
 
         if (-not $module.CheckMode) {
             try {
-                Remove-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false
+                Remove-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false -ErrorAction Stop
             }
             catch {
-                $module.FailJson("Failed to remove relying party trust '$name': $_", $_)
+                $module.FailJson("Failed to remove relying party trust '$name': $($_.Exception.Message)", $_)
             }
         }
     }

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -44,6 +44,7 @@ $spec = @{
         }
         token_lifetime = @{
             type = 'int'
+            no_log = $false  # Needed for linter: no-log-needed: Argument 'token_lifetime' in argument_spec could be a secret, though doesn't have `no_log` set
         }
         notes = @{
             type = 'str'
@@ -288,14 +289,16 @@ if ($state -eq 'present') {
                     IsDefault = ($i -eq 0)
                 }
             }
-            $currentEndpoints = @(ForEach ($ep in $existing.SamlEndpoints) {
-                [PSCustomObject]@{
-                    Uri = $ep.Location.ToString()
-                    Binding = $ep.Binding.ToString()
-                    Protocol = $ep.Protocol.ToString()
-                    IsDefault = $ep.IsDefault
+            $currentEndpoints = @(
+                ForEach ($ep in $existing.SamlEndpoints) {
+                    [PSCustomObject]@{
+                        Uri = $ep.Location.ToString()
+                        Binding = $ep.Binding.ToString()
+                        Protocol = $ep.Protocol.ToString()
+                        IsDefault = $ep.IsDefault
+                    }
                 }
-            })
+            )
 
             # Compare in original order: order determines which endpoint gets
             # Index 0 / IsDefault. Compare Uri, Binding, Protocol, and

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -92,7 +92,7 @@ $signatureAlgorithmMap = @{
 # Reverse map so we can report signature_algorithm back in the friendly
 # short form rather than the raw XML-DSig URI.
 $signatureAlgorithmReverseMap = @{}
-foreach ($kvp in $signatureAlgorithmMap.GetEnumerator()) {
+ForEach ($kvp in $signatureAlgorithmMap.GetEnumerator()) {
     $signatureAlgorithmReverseMap[$kvp.Value] = $kvp.Name
 }
 
@@ -127,7 +127,7 @@ function Test-AdfsValueChanged {
 # objects can't cross the proxy boundary, so in that case the endpoint
 # creation AND the Add/Set call must happen together inside the same
 # Windows PowerShell session.
-function Set-AdfsTrustSamlEndpoints {
+function Invoke-AdfsTrustSamlEndpoint {
     param(
         [ValidateSet('Add', 'Set')]
         [string]$Operation,
@@ -212,7 +212,7 @@ if ($state -eq 'present') {
             $addParams.Enabled = $module.Params.enabled
         }
 
-        foreach ($prop in $propertyMap) {
+        ForEach ($prop in $propertyMap) {
             # Identifier/WSFedEndpoint are already handled above for the
             # non-metadata creation path; avoid clobbering/duplicating them.
             if ($prop.Param -in @('identifier', 'wsfed_endpoint')) { continue }
@@ -229,7 +229,7 @@ if ($state -eq 'present') {
         if (-not $module.CheckMode) {
             try {
                 if ($module.Params.saml_endpoint) {
-                    Set-AdfsTrustSamlEndpoints -Operation Add -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $addParams
+                    Invoke-AdfsTrustSamlEndpoint -Operation Add -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $addParams
                 }
                 else {
                     Add-AdfsRelyingPartyTrust @addParams -ErrorAction Stop
@@ -251,7 +251,7 @@ if ($state -eq 'present') {
         # UPDATE
         $updateParams = @{}
 
-        foreach ($prop in $propertyMap) {
+        ForEach ($prop in $propertyMap) {
             $desired = $module.Params[$prop.Param]
             if ($null -eq $desired) { continue }
 
@@ -288,12 +288,12 @@ if ($state -eq 'present') {
                     IsDefault = ($i -eq 0)
                 }
             }
-            $currentEndpoints = @($existing.SamlEndpoints | ForEach-Object {
+            $currentEndpoints = @(ForEach ($ep in $existing.SamlEndpoints) {
                 [PSCustomObject]@{
-                    Uri = $_.Location.ToString()
-                    Binding = $_.Binding.ToString()
-                    Protocol = $_.Protocol.ToString()
-                    IsDefault = $_.IsDefault
+                    Uri = $ep.Location.ToString()
+                    Binding = $ep.Binding.ToString()
+                    Protocol = $ep.Protocol.ToString()
+                    IsDefault = $ep.IsDefault
                 }
             })
 
@@ -318,7 +318,7 @@ if ($state -eq 'present') {
 
                 if (-not $module.CheckMode) {
                     try {
-                        Set-AdfsTrustSamlEndpoints -Operation Set -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $null
+                        Invoke-AdfsTrustSamlEndpoint -Operation Set -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $null
                     }
                     catch {
                         $module.FailJson("Failed to update SAML endpoints for relying party trust '$name': $($_.Exception.Message)", $_)

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -322,7 +322,7 @@ if ($state -eq 'present') {
             # }
 
             $desiredEndpoints = @(
-                ForEach ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
+                for ($i = 0; $i -lt $module.Params.saml_endpoint.Count; $i++) {
                     [PSCustomObject]@{
                         Uri = $module.Params.saml_endpoint[$i]
                         Binding = 'POST'

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -351,7 +351,7 @@ if ($state -eq 'present') {
             $currentEndpoints = @(
                 ForEach ($ep in $existing.SamlEndpoints) {
                     [PSCustomObject]@{
-                        Uri = $ep.Location.OriginalString
+                        Uri = $ep.Location
                         Binding = $ep.Binding.ToString()
                         Protocol = $ep.Protocol.ToString()
                         IsDefault = $ep.IsDefault
@@ -425,8 +425,7 @@ if ($state -eq 'present') {
         $module.Result.notes = $existing.Notes
         $module.Result.access_control_policy_name = $existing.AccessControlPolicyName
         $module.Result.encrypt_claims = $existing.EncryptClaims
-        #$module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_.Location.OriginalString })
-        $module.Result.saml_endpoints = @($existing.SamlEndpoints)
+        $module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_ })
 
         if ($existing.SignatureAlgorithm -and $signatureAlgorithmReverseMap.ContainsKey($existing.SignatureAlgorithm)) {
             $module.Result.signature_algorithm = $signatureAlgorithmReverseMap[$existing.SignatureAlgorithm]

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -351,7 +351,7 @@ if ($state -eq 'present') {
             $currentEndpoints = @(
                 ForEach ($ep in $existing.SamlEndpoints) {
                     [PSCustomObject]@{
-                        Uri = $ep.Location.ToString()
+                        Uri = $ep.Location.OriginalString
                         Binding = $ep.Binding.ToString()
                         Protocol = $ep.Protocol.ToString()
                         IsDefault = $ep.IsDefault
@@ -425,7 +425,7 @@ if ($state -eq 'present') {
         $module.Result.notes = $existing.Notes
         $module.Result.access_control_policy_name = $existing.AccessControlPolicyName
         $module.Result.encrypt_claims = $existing.EncryptClaims
-        $module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_.Location.ToString() })
+        $module.Result.saml_endpoints = @($existing.SamlEndpoints | ForEach-Object { $_.Location.OriginalString })
 
         if ($existing.SignatureAlgorithm -and $signatureAlgorithmReverseMap.ContainsKey($existing.SignatureAlgorithm)) {
             $module.Result.signature_algorithm = $signatureAlgorithmReverseMap[$existing.SignatureAlgorithm]

--- a/plugins/modules/fs_trust.ps1
+++ b/plugins/modules/fs_trust.ps1
@@ -71,7 +71,6 @@ $spec = @{
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 
-
 $module.Result.changed = $false
 $module.Result.identifier = @()
 $module.Result.enabled = $null
@@ -89,13 +88,14 @@ $name = $module.Params.name
 $state = $module.Params.state
 
 $signatureAlgorithmMap = @{
-    'rsa_sha1' = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+    'rsa_sha1'   = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
     'rsa_sha256' = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
 }
 
 # Reverse map so we can report signature_algorithm back in the friendly
 # short form rather than the raw XML-DSig URI.
 $signatureAlgorithmReverseMap = @{}
+
 ForEach ($kvp in $signatureAlgorithmMap.GetEnumerator()) {
     $signatureAlgorithmReverseMap[$kvp.Value] = $kvp.Name
 }
@@ -138,10 +138,48 @@ function Test-AdfsValueChanged {
         return $false
     }
 
-    $currentSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$currentArray)
-    return -not $currentSet.SetEquals([string[]]$desiredArray)
+    for ($i = 0; $i -lt $currentArray.Count; $i++) {
+        if ($currentArray[$i] -ne $desiredArray[$i]) {
+            return $true
+        }
+    }
+
+    return $false
 }
 
+# Compare SAML endpoints in their original order.
+# Endpoint order matters because Index 0 is the default endpoint.
+function Test-AdfsSamlEndpointsChanged {
+    param(
+        [Parameter(Mandatory)]
+        [array]$Current,
+
+        [Parameter(Mandatory)]
+        [array]$Desired
+    )
+
+    if ($Current.Count -ne $Desired.Count) {
+        return $true
+    }
+
+    for ($i = 0; $i -lt $Current.Count; $i++) {
+        $currentEndpoint = $Current[$i]
+        $desiredEndpoint = $Desired[$i]
+
+        if (
+            ([string]$currentEndpoint.Uri) -ne ([string]$desiredEndpoint.Uri) -or
+            ([string]$currentEndpoint.Binding) -ne ([string]$desiredEndpoint.Binding) -or
+            ([string]$currentEndpoint.Protocol) -ne ([string]$desiredEndpoint.Protocol) -or
+            ([bool]$currentEndpoint.IsDefault) -ne ([bool]$desiredEndpoint.IsDefault)
+        ) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+# Build the desired SAML endpoint collection.
 function New-DesiredAdfsSamlEndpoints {
     param(
         [Parameter(Mandatory)]
@@ -160,6 +198,10 @@ function New-DesiredAdfsSamlEndpoints {
     )
 }
 
+# Create a desired-state object from the current ADFS state.
+#
+# The desired state is used as the projected result in check mode.
+# After a real update/create, it is replaced with the actual ADFS state.
 function New-AdfsDesiredState {
     param(
         [Parameter(Mandatory)]
@@ -190,6 +232,7 @@ function New-AdfsDesiredState {
     }
 }
 
+# Convert a desired/current state object into the Ansible module result.
 function Set-AdfsModuleResult {
     param(
         [Parameter(Mandatory)]
@@ -204,6 +247,7 @@ function Set-AdfsModuleResult {
     $module.Result.notes = $State.Notes
     $module.Result.access_control_policy_name = $State.AccessControlPolicyName
     $module.Result.encrypt_claims = $State.EncryptClaims
+
     $module.Result.saml_endpoints = @(
         $State.SamlEndpoints | ForEach-Object {
             $_.Uri
@@ -226,10 +270,10 @@ function Set-AdfsModuleResult {
 
 # Builds the desired SAML endpoint collection and applies it via either
 # Add-AdfsRelyingPartyTrust (creation) or Set-AdfsRelyingPartyTrust (update).
+#
 # When the ADFS module is loaded via implicit remoting, New-AdfsSamlEndpoint
-# objects can't cross the proxy boundary, so in that case the endpoint
-# creation AND the Add/Set call must happen together inside the same
-# Windows PowerShell session.
+# objects cannot cross the proxy boundary. In that case endpoint creation and
+# the Add/Set call must happen inside the same Windows PowerShell session.
 function Invoke-AdfsTrustSamlEndpoint {
     param(
         [ValidateSet('Add', 'Set')]
@@ -260,6 +304,7 @@ function Invoke-AdfsTrustSamlEndpoint {
 
             if ($Operation -eq 'Add') {
                 $AddParams['SamlEndpoint'] = @($eps)
+
                 Add-AdfsRelyingPartyTrust @AddParams
             }
             else {
@@ -285,6 +330,7 @@ function Invoke-AdfsTrustSamlEndpoint {
 
         if ($Operation -eq 'Add') {
             $AddParams['SamlEndpoint'] = @($endpoints)
+
             Add-AdfsRelyingPartyTrust @AddParams -ErrorAction Stop
         }
         else {
@@ -301,11 +347,7 @@ function Invoke-AdfsTrustSamlEndpoint {
 # to capturing only ToString() once a type exceeds its default serialization
 # depth, silently turning e.g. each SamlEndpoint object into the bare string
 # "Microsoft.IdentityServer.Management.Resources.SamlEndpoint" with none of
-# its real properties (Location, Binding, Protocol, IsDefault) intact. Doing
-# the property extraction *inside* the native Windows PowerShell session -
-# before anything crosses the proxy - avoids this entirely, mirroring how
-# Invoke-AdfsTrustSamlEndpoint already does writes inside the same session
-# boundary.
+# its real properties (Location, Binding, Protocol, IsDefault) intact.
 function Get-AdfsRelyingPartyTrustDetail {
     param(
         [Parameter(Mandatory)]
@@ -377,9 +419,13 @@ catch {
     $module.FailJson("Failed to retrieve relying party trust '$name': $($_.Exception.Message)", $_)
 }
 
-# $desiredState represents the state the module wants ADFS to have.
-# In check mode this is returned directly.
-# In normal mode it is replaced with the actual state after changes.
+# $desiredState is the single representation of the state the module wants.
+#
+# In check mode:
+#   current state -> projected desired state -> result
+#
+# In normal mode:
+#   current state -> projected desired state -> apply -> actual state -> result
 $desiredState = $null
 
 if ($existing) {
@@ -396,10 +442,6 @@ if ($state -eq 'present') {
         }
 
         if ($module.Params.metadata_url) {
-            # No separate reachability pre-check here: Add-AdfsRelyingPartyTrust
-            # will itself fail with a clear error if the URL can't be reached,
-            # so a second, possibly differently-authenticated request is just
-            # an extra point of failure without adding real safety.
             $addParams.MetadataUrl = [Uri]$module.Params.metadata_url
         }
         elseif ($module.Params.metadata_file) {
@@ -422,8 +464,7 @@ if ($state -eq 'present') {
         }
 
         ForEach ($prop in $propertyMap) {
-            # Identifier/WSFedEndpoint are already handled above for the
-            # non-metadata creation path; avoid clobbering/duplicating them.
+            # These are already handled above for creation.
             if ($prop.Param -in @('identifier', 'wsfed_endpoint')) {
                 continue
             }
@@ -441,7 +482,7 @@ if ($state -eq 'present') {
             $addParams[$prop.Cmdlet] = $val
         }
 
-        # Build the desired state for the object that would be created.
+        # Build the projected desired state.
         $desiredState = [PSCustomObject]@{
             Identifier = @($module.Params.identifier)
             Enabled = $module.Params.enabled
@@ -483,87 +524,70 @@ if ($state -eq 'present') {
                 $module.FailJson("Failed to retrieve newly created trust '$name': $($_.Exception.Message)", $_)
             }
 
-            # Actual state is authoritative after creation.
+            # Actual ADFS state is authoritative after creation.
             $desiredState = New-AdfsDesiredState -Current $existing
         }
     }
     else {
         # UPDATE
 
-        $updateParams = @()
+        # Always start from the current ADFS state.
+        $desiredState = New-AdfsDesiredState -Current $existing
 
+        $updateParams = @{}
+        $samlEndpointChanged = $false
+        $enabledChanged = $false
+
+        # Scalar properties
         ForEach ($prop in $propertyMap) {
-            $desired = $module.Params[$prop.Param]
+            $requested = $module.Params[$prop.Param]
 
-            if ($null -eq $desired) {
+            if ($null -eq $requested) {
                 continue
             }
 
-            $desiredAdfsValue = $desired
+            $desiredValue = $requested
 
             if ($prop.Cast) {
-                $desiredAdfsValue = & $prop.Cast $desiredAdfsValue
+                $desiredValue = & $prop.Cast $desiredValue
             }
 
-            $current = $existing.($prop.Cmdlet)
+            $currentValue = $existing.($prop.Cmdlet)
 
-            if (Test-AdfsValueChanged -Current $current -Desired $desired) {
-                $updateParams += @{
-                    Cmdlet = $prop.Cmdlet
-                    Value  = $desiredAdfsValue
-                }
+            if (Test-AdfsValueChanged -Current $currentValue -Desired $desiredValue) {
+                $updateParams[$prop.Cmdlet] = $desiredValue
 
-                # Project the requested value into the desired state.
-                $desiredState.($prop.Cmdlet) = $desiredAdfsValue
+                # Project the requested value into desired state.
+                $desiredState.($prop.Cmdlet) = $desiredValue
             }
         }
-
-        # SAML endpoint desired state.
-        $samlEndpointChanged = $false
+        # SAML endpoints
 
         if ($module.Params.saml_endpoint) {
             $desiredSamlEndpoints = New-DesiredAdfsSamlEndpoints -EndpointUris @($module.Params.saml_endpoint)
 
             $currentSamlEndpoints = @($existing.SamlEndpoints)
 
-            # Compare in original order: order determines which endpoint gets
-            # Index 0 / IsDefault. Compare Uri, Binding, Protocol, and
-            # IsDefault so a change to any of those is detected, not just a
-            # changed Location.
-            $samlEndpointChanged = $currentSamlEndpoints.Count -ne $desiredSamlEndpoints.Count
-
-            if (-not $samlEndpointChanged) {
-                for ($i = 0; $i -lt $currentSamlEndpoints.Count; $i++) {
-                    $currentEndpoint = $currentSamlEndpoints[$i]
-                    $desiredEndpoint = $desiredSamlEndpoints[$i]
-
-                    if (
-                        $currentEndpoint.Uri -ne $desiredEndpoint.Uri -or
-                        $currentEndpoint.Binding -ne $desiredEndpoint.Binding -or
-                        $currentEndpoint.Protocol -ne $desiredEndpoint.Protocol -or
-                        $currentEndpoint.IsDefault -ne $desiredEndpoint.IsDefault
-                    ) {
-                        $samlEndpointChanged = $true
-                        break
-                    }
-                }
-            }
+            $samlEndpointChanged = Test-AdfsSamlEndpointsChanged -Current $currentSamlEndpoints -Desired $desiredSamlEndpoints
 
             if ($samlEndpointChanged) {
+                # Project requested SAML endpoint state.
                 $desiredState.SamlEndpoints = $desiredSamlEndpoints
             }
         }
 
-        # Enabled desired state.
-        $enabledChanged = (
+        # Enabled state
+        if (
             $null -ne $module.Params.enabled -and
             $module.Params.enabled -ne $existing.Enabled
-        )
+        ) {
+            $enabledChanged = $true
 
-        if ($enabledChanged) {
+            # Project requested enabled state.
             $desiredState.Enabled = $module.Params.enabled
         }
 
+        # Determine whether anything changed.
         if (
             $updateParams.Count -gt 0 -or
             $samlEndpointChanged -or
@@ -572,20 +596,18 @@ if ($state -eq 'present') {
             $module.Result.changed = $true
         }
 
-        if (-not $module.CheckMode -and $module.Result.changed) {
+        # Apply changes unless check mode is active.
+        if (
+            -not $module.CheckMode -and
+            $module.Result.changed
+        ) {
             try {
-                # Apply normal property updates.
+                # Apply scalar properties.
                 if ($updateParams.Count -gt 0) {
-                    $setParams = @{}
-
-                    foreach ($update in $updateParams) {
-                        $setParams[$update.Cmdlet] = $update.Value
-                    }
-
-                    Set-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false @setParams -ErrorAction Stop
+                    Set-AdfsRelyingPartyTrust -TargetName $name -Confirm:$false @updateParams -ErrorAction Stop
                 }
 
-                # Apply SAML endpoint changes.
+                # Apply SAML endpoints.
                 if ($samlEndpointChanged) {
                     Invoke-AdfsTrustSamlEndpoint -Operation Set -Name $name -EndpointUris @($module.Params.saml_endpoint) -AddParams $null
                 }
@@ -607,6 +629,7 @@ if ($state -eq 'present') {
                 )
             }
 
+            # Re-read the actual state after applying the changes.
             try {
                 $existing = Get-AdfsRelyingPartyTrustDetail -Name $name
             }
@@ -617,11 +640,16 @@ if ($state -eq 'present') {
                 )
             }
 
-            # Actual state is authoritative after a real update.
+            # Actual ADFS state is authoritative after a real update.
             $desiredState = New-AdfsDesiredState -Current $existing
         }
     }
 
+    # Return either:
+    #
+    #   - projected desired state in check mode
+    #   - actual ADFS state after a real operation
+    #
     if ($desiredState) {
         Set-AdfsModuleResult -State $desiredState
     }

--- a/plugins/modules/fs_trust.yml
+++ b/plugins/modules/fs_trust.yml
@@ -50,6 +50,7 @@ DOCUMENTATION:
         - Only used when creating a trust with O(identifier) for
           manual setup.
         - Each URL is registered as a SAML POST binding endpoint.
+        - The first URL in the list will be marked as IsDefault.
       type: list
       elements: str
     wsfed_endpoint:

--- a/plugins/modules/fs_trust.yml
+++ b/plugins/modules/fs_trust.yml
@@ -47,10 +47,14 @@ DOCUMENTATION:
     saml_endpoint:
       description:
         - List of SAML Assertion Consumer Service endpoint URLs.
-        - Only used when creating a trust with O(identifier) for
-          manual setup.
         - Each URL is registered as a SAML POST binding endpoint.
-        - The first URL in the list will be marked as IsDefault.
+        - The first URL in the list will be marked as IsDefault,
+          and list order determines each endpoint's index.
+        - When trust already exists, this list replaces the entire set of
+          configured SAML endpoints. It must always contain the full
+          desired set, not just the endpoint(s) being added or changed.
+        - When creating a new trust, only used together with O(identifier)
+          for manual setup.
       type: list
       elements: str
     wsfed_endpoint:

--- a/plugins/modules/fs_trust.yml
+++ b/plugins/modules/fs_trust.yml
@@ -28,8 +28,6 @@ DOCUMENTATION:
       description:
         - URL pointing to the federation metadata document for the
           relying party.
-        - The module tests connectivity to this URL before creating
-          the trust.
         - Mutually exclusive with O(metadata_file) and O(identifier).
       type: str
     metadata_file:
@@ -41,6 +39,8 @@ DOCUMENTATION:
       description:
         - List of unique identifiers (URIs) for the relying party trust.
         - Used for manual trust setup without a metadata document.
+        - When the trust already exists, the configured identifiers are
+          updated to match this list.
         - Mutually exclusive with O(metadata_url) and O(metadata_file).
       type: list
       elements: str
@@ -50,9 +50,10 @@ DOCUMENTATION:
         - Each URL is registered as a SAML POST binding endpoint.
         - The first URL in the list will be marked as IsDefault,
           and list order determines each endpoint's index.
-        - When trust already exists, this list replaces the entire set of
-          configured SAML endpoints. It must always contain the full
-          desired set, not just the endpoint(s) being added or changed.
+        - When the trust already exists, this list replaces the entire
+          set of configured SAML endpoints. It must always contain the
+          full desired set, not just the endpoint(s) being added or
+          changed.
         - When creating a new trust, only used together with O(identifier)
           for manual setup.
       type: list
@@ -60,8 +61,9 @@ DOCUMENTATION:
     wsfed_endpoint:
       description:
         - WS-Federation passive endpoint URL for the relying party.
-        - Only used when creating a trust with O(identifier) for
-          manual setup.
+        - Used when creating a trust with O(identifier) for manual setup.
+        - When the trust already exists, the configured WS-Federation
+          endpoint is updated to match this value.
       type: str
     enabled:
       description:
@@ -114,6 +116,9 @@ DOCUMENTATION:
     - name: Add-AdfsRelyingPartyTrust
       description: Microsoft documentation for the underlying cmdlet.
       link: https://learn.microsoft.com/en-us/powershell/module/adfs/add-adfsrelyingpartytrust
+    - name: Set-AdfsRelyingPartyTrust
+      description: Microsoft documentation for the underlying cmdlet.
+      link: https://learn.microsoft.com/en-us/powershell/module/adfs/set-adfsrelyingpartytrust
   extends_documentation_fragment:
     - ansible.builtin.action_common_attributes
   attributes:
@@ -165,6 +170,21 @@ EXAMPLES: |
       metadata_url: https://app.example.com/federationmetadata/2007-06/federationmetadata.xml
       monitoring_enabled: true
 
+  - name: Update the identifiers and WS-Fed endpoint on an existing trust
+    microsoft.ad.fs_trust:
+      name: WsFedApp
+      identifier:
+        - https://wsfed.example.com/
+        - https://wsfed.example.com/alt
+      wsfed_endpoint: https://wsfed.example.com/auth2
+
+  - name: Replace the SAML endpoints on an existing trust
+    microsoft.ad.fs_trust:
+      name: CustomSaaS
+      saml_endpoint:
+        - https://app.example.com/saml/acs
+        - https://app.example.com/saml/acs2
+
   - name: Remove a relying party trust
     microsoft.ad.fs_trust:
       name: MyApp
@@ -187,3 +207,44 @@ RETURN:
     returned: success and state is present
     type: bool
     sample: true
+  auto_update_enabled:
+    description: Whether automatic metadata updates are enabled.
+    returned: success and state is present
+    type: bool
+    sample: true
+  token_lifetime:
+    description: Token validity duration in minutes.
+    returned: success and state is present
+    type: int
+    sample: 60
+  notes:
+    description: Freeform notes configured for the relying party trust.
+    returned: success and state is present
+    type: str
+    sample: Managed by Ansible
+  access_control_policy_name:
+    description: Name of the assigned access control policy.
+    returned: success and state is present
+    type: str
+    sample: Permit everyone
+  signature_algorithm:
+    description: Configured signature algorithm.
+    returned: success and state is present
+    type: str
+    sample: rsa_sha256
+  encrypt_claims:
+    description: Whether claims sent to the relying party are encrypted.
+    returned: success and state is present
+    type: bool
+    sample: false
+  wsfed_endpoint:
+    description: The configured WS-Federation passive endpoint URL, if any.
+    returned: success and state is present
+    type: str
+    sample: https://wsfed.example.com/auth
+  saml_endpoints:
+    description: The configured SAML Assertion Consumer Service endpoint URLs.
+    returned: success and state is present
+    type: list
+    elements: str
+    sample: ["https://app.example.com/saml/acs"]

--- a/tests/integration/targets/fs_trust/tasks/main.yml
+++ b/tests/integration/targets/fs_trust/tasks/main.yml
@@ -82,10 +82,12 @@
       register: _create_multi
 
     - name: Get SAML endpoints for TestTrustMultiAcs
-      ansible.windows.win_shell: |
-        (Get-AdfsRelyingPartyTrust -Name "TestTrustMultiAcs").SamlEndpoints |
-          Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
+      ansible.windows.win_shell:
+        cmd: |
+          (Get-AdfsRelyingPartyTrust -Name "TestTrustMultiAcs").SamlEndpoints |
+            Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
       register: _multi_endpoints
+      changed_when: false
 
     - name: Assert multi-endpoint create
       ansible.builtin.assert:
@@ -138,10 +140,12 @@
       register: _add_endpoint
 
     - name: Get SAML endpoints for TestTrust after add
-      ansible.windows.win_shell: |
-        (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
-          Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
+      ansible.windows.win_shell:
+        cmd: |
+          (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
+            Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
       register: _endpoints_after_add
+      changed_when: false
 
     - name: Assert endpoint was added
       ansible.builtin.assert:
@@ -190,10 +194,14 @@
       register: _remove_endpoint
 
     - name: Get SAML endpoints for TestTrust after removal
-      ansible.windows.win_shell: |
-        (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
-          Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
+      ansible.windows.win_shell:
+        cmd: |
+          @(
+            (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
+              Select-Object Index, IsDefault, Location
+          ) | ConvertTo-Json -Compress
       register: _endpoints_after_remove
+      changed_when: false
 
     - name: Assert endpoint was removed
       ansible.builtin.assert:
@@ -252,10 +260,12 @@
       register: _reorder
 
     - name: Get SAML endpoints for TestTrust after reorder
-      ansible.windows.win_shell: |
-        (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
-          Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
+      ansible.windows.win_shell:
+        cmd: |
+          (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
+            Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
       register: _endpoints_after_reorder
+      changed_when: false
 
     - name: Assert default endpoint flipped after reorder
       ansible.builtin.assert:

--- a/tests/integration/targets/fs_trust/tasks/main.yml
+++ b/tests/integration/targets/fs_trust/tasks/main.yml
@@ -6,6 +6,11 @@
         name: TestTrust
         state: absent
 
+    - name: Pre-cleanup - ensure TestTrustMultiAcs does not exist
+      microsoft.ad.fs_trust:
+        name: TestTrustMultiAcs
+        state: absent
+
     - name: Create trust from identifier - check mode
       microsoft.ad.fs_trust:
         name: TestTrust
@@ -17,10 +22,23 @@
       register: _create_check
       check_mode: true
 
-    - name: Assert check mode reports changed
+    - name: Create trust with multiple SAML endpoints - check mode
+      microsoft.ad.fs_trust:
+        name: TestTrustMultiAcs
+        identifier:
+          - https://test.example.com/saml-multi
+        saml_endpoint:
+          - https://test.example.com/saml-multi/acs-a
+          - https://test.example.com/saml-multi/acs-b
+        enabled: true
+      register: _create_multi_check
+      check_mode: true
+
+    - name: Assert both check mode reports changed
       ansible.builtin.assert:
         that:
           - _create_check is changed
+          - _create_multi_check is changed
 
     - name: Create trust from identifier
       microsoft.ad.fs_trust:
@@ -51,6 +69,214 @@
       ansible.builtin.assert:
         that:
           - _create_idem is not changed
+
+    - name: Create trust with multiple SAML endpoints
+      microsoft.ad.fs_trust:
+        name: TestTrustMultiAcs
+        identifier:
+          - https://test.example.com/saml-multi
+        saml_endpoint:
+          - https://test.example.com/saml-multi/acs-a
+          - https://test.example.com/saml-multi/acs-b
+        enabled: true
+      register: _create_multi
+
+    - name: Get SAML endpoints for TestTrustMultiAcs
+      ansible.windows.win_shell: |
+        (Get-AdfsRelyingPartyTrust -Name "TestTrustMultiAcs").SamlEndpoints |
+          Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
+      register: _multi_endpoints
+
+    - name: Assert multi-endpoint create
+      ansible.builtin.assert:
+        that:
+          - _create_multi is changed
+          - (_multi_endpoints.stdout | from_json) | length == 2
+          - (_multi_endpoints.stdout | from_json | selectattr('IsDefault') | list) | length == 1
+          - (_multi_endpoints.stdout | from_json | selectattr('IsDefault') | first).Location == 'https://test.example.com/saml-multi/acs-a'
+
+    - name: Create trust with multiple SAML endpoints again - idempotency
+      microsoft.ad.fs_trust:
+        name: TestTrustMultiAcs
+        identifier:
+          - https://test.example.com/saml-multi
+        saml_endpoint:
+          - https://test.example.com/saml-multi/acs-a
+          - https://test.example.com/saml-multi/acs-b
+        enabled: true
+      register: _create_multi_idem
+
+    - name: Assert no change on multi-endpoint idempotent create
+      ansible.builtin.assert:
+        that:
+          - _create_multi_idem is not changed
+
+    - name: Add a second SAML endpoint on update - check mode
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+          - https://test.example.com/saml/acs-second
+      register: _add_endpoint_check
+      check_mode: true
+
+    - name: Assert add-endpoint check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _add_endpoint_check is changed
+
+    - name: Add a second SAML endpoint on update
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+          - https://test.example.com/saml/acs-second
+      register: _add_endpoint
+
+    - name: Get SAML endpoints for TestTrust after add
+      ansible.windows.win_shell: |
+        (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
+          Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
+      register: _endpoints_after_add
+
+    - name: Assert endpoint was added
+      ansible.builtin.assert:
+        that:
+          - _add_endpoint is changed
+          - (_endpoints_after_add.stdout | from_json) | length == 2
+          - "'https://test.example.com/saml/acs-second' in (_endpoints_after_add.stdout | from_json | map(attribute='Location') | list)"
+
+    - name: Add a second SAML endpoint on update again - idempotency
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+          - https://test.example.com/saml/acs-second
+      register: _add_endpoint_idem
+
+    - name: Assert no change on idempotent add-endpoint run
+      ansible.builtin.assert:
+        that:
+          - _add_endpoint_idem is not changed
+
+    - name: Remove second SAML endpoint on update - check mode
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+      register: _remove_endpoint_check
+      check_mode: true
+
+    - name: Assert remove-endpoint check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _remove_endpoint_check is changed
+
+    - name: Remove second SAML endpoint on update
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+      register: _remove_endpoint
+
+    - name: Get SAML endpoints for TestTrust after removal
+      ansible.windows.win_shell: |
+        (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
+          Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
+      register: _endpoints_after_remove
+
+    - name: Assert endpoint was removed
+      ansible.builtin.assert:
+        that:
+          - _remove_endpoint is changed
+          - (_endpoints_after_remove.stdout | from_json) | length == 1
+          - "'https://test.example.com/saml/acs-second' not in (_endpoints_after_remove.stdout | from_json | map(attribute='Location') | list)"
+
+    - name: Remove second SAML endpoint on update again - idempotency
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+      register: _remove_endpoint_idem
+
+    - name: Assert no change on idempotent remove-endpoint run
+      ansible.builtin.assert:
+        that:
+          - _remove_endpoint_idem is not changed
+
+    - name: Re-add a second SAML endpoint for reorder testing
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+          - https://test.example.com/saml/acs-second
+
+    - name: Reorder SAML endpoints so acs-second becomes default - check mode
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs-second
+          - https://test.example.com/saml/acs
+      register: _reorder_check
+      check_mode: true
+
+    - name: Assert reorder check mode reports changed
+      ansible.builtin.assert:
+        that:
+          - _reorder_check is changed
+
+    - name: Reorder SAML endpoints so acs-second becomes default
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs-second
+          - https://test.example.com/saml/acs
+      register: _reorder
+
+    - name: Get SAML endpoints for TestTrust after reorder
+      ansible.windows.win_shell: |
+        (Get-AdfsRelyingPartyTrust -Name "TestTrust").SamlEndpoints |
+          Select-Object Index, IsDefault, Location | ConvertTo-Json -Compress
+      register: _endpoints_after_reorder
+
+    - name: Assert default endpoint flipped after reorder
+      ansible.builtin.assert:
+        that:
+          - _reorder is changed
+          - (_endpoints_after_reorder.stdout | from_json | selectattr('IsDefault') | first).Location == 'https://test.example.com/saml/acs-second'
+
+    - name: Reorder SAML endpoints again with same order - idempotency
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs-second
+          - https://test.example.com/saml/acs
+      register: _reorder_idem
+
+    - name: Assert no change on idempotent reorder run
+      ansible.builtin.assert:
+        that:
+          - _reorder_idem is not changed
 
     - name: Update trust - set notes - check mode
       microsoft.ad.fs_trust:
@@ -99,10 +325,18 @@
       register: _remove_check
       check_mode: true
 
+    - name: Remove multi trust - check mode
+      microsoft.ad.fs_trust:
+        name: TestTrustMultiAcs
+        state: absent
+      register: _remove_multi_check
+      check_mode: true
+
     - name: Assert removal check mode reports changed
       ansible.builtin.assert:
         that:
           - _remove_check is changed
+          - _remove_multi_check is changed
 
     - name: Remove trust
       microsoft.ad.fs_trust:
@@ -110,10 +344,17 @@
         state: absent
       register: _remove
 
+    - name: Remove multi trust
+      microsoft.ad.fs_trust:
+        name: TestTrustMultiAcs
+        state: absent
+      register: _remove_multi
+
     - name: Assert removed
       ansible.builtin.assert:
         that:
           - _remove is changed
+          - _remove_multi is changed
 
     - name: Remove trust again - idempotency
       microsoft.ad.fs_trust:
@@ -121,10 +362,17 @@
         state: absent
       register: _remove_idem
 
+    - name: Remove multi trust again - idempotency
+      microsoft.ad.fs_trust:
+        name: TestTrustMultiAcs
+        state: absent
+      register: _remove_multi_idem
+
     - name: Assert no change on idempotent removal
       ansible.builtin.assert:
         that:
           - _remove_idem is not changed
+          - _remove_multi_idem is not changed
 
     - name: Remove non-existent trust - no error
       microsoft.ad.fs_trust:
@@ -142,4 +390,8 @@
       microsoft.ad.fs_trust:
         name: TestTrust
         state: absent
-      ignore_errors: true
+
+    - name: Cleanup - remove TestTrustMultiAcs
+      microsoft.ad.fs_trust:
+        name: TestTrustMultiAcs
+        state: absent

--- a/tests/integration/targets/fs_trust/tasks/main.yml
+++ b/tests/integration/targets/fs_trust/tasks/main.yml
@@ -207,8 +207,8 @@
       ansible.builtin.assert:
         that:
           - _remove_endpoint is changed
-          - (_endpoints_after_remove.stdout | from_json) | length == 1
-          - "'https://test.example.com/saml/acs-second' not in (_endpoints_after_remove.stdout | from_json | map(attribute='Location') | list)"
+          - (_endpoints_after_remove.stdout | from_json) is mapping
+          - (_endpoints_after_remove.stdout | from_json).Location == 'https://test.example.com/saml/acs'
 
     - name: Remove second SAML endpoint on update again - idempotency
       microsoft.ad.fs_trust:

--- a/tests/integration/targets/fs_trust/tasks/main.yml
+++ b/tests/integration/targets/fs_trust/tasks/main.yml
@@ -56,6 +56,7 @@
           - _create is changed
           - _create.enabled == true
           - _create.identifier | length > 0
+          - _create.signature_algorithm == "rsa_sha256"
 
     - name: Create trust from identifier again - idempotency
       microsoft.ad.fs_trust:
@@ -69,6 +70,23 @@
       ansible.builtin.assert:
         that:
           - _create_idem is not changed
+
+    - name: Change trust secure hash algorithm to SHA1
+      microsoft.ad.fs_trust:
+        name: TestTrust
+        identifier:
+          - https://test.example.com/saml
+        saml_endpoint:
+          - https://test.example.com/saml/acs
+        enabled: true
+        signature_algorithm: rsa_sha1
+      register: _adjustment
+
+    - name: Assert that SHA has been adjusted
+      ansible.builtin.assert:
+        that:
+          - _adjustment is changed
+          - _adjustment.signature_algorithm == "rsa_sha1"
 
     - name: Create trust with multiple SAML endpoints
       microsoft.ad.fs_trust:


### PR DESCRIPTION
## IDEA
Currently the module doesn't update the SAML endpoints and also doesn't support multiple SAML endpoints.
Now with this change it is supported and the top SAML endpoint will be default.

## SUMMARY

Adds support for multiple SAML endpoints with drift detection/update, and hardens error handling and the update path.

### Feature: multi-endpoint SAML support
- Support multiple SAML endpoints, with the first URL marked IsDefault and list order determining index.
- Add logic to update SAML endpoints if they differ from current configuration (comparing Uri, Binding, Protocol, and IsDefault).
- Refactor SAML endpoint creation to use `for` loops instead of `foreach` for consistency and index tracking.

### Fixes: implicit remoting / PowerShell 7 compatibility
- Add `Get-AdfsRelyingPartyTrustDetail`, a wrapper around `Get-AdfsRelyingPartyTrust` that flattens the trust into a plain object inside the native Windows PowerShell session before it crosses the implicit-remoting proxy. Under PowerShell 7 (WinPS Compatibility), nested `SamlEndpoints` objects do not survive CliXml serialization intact — they silently collapse to their `ToString()` type name instead of retaining `Location`/`Binding`/`Protocol`/`IsDefault`, which previously caused a null-reference exception on read (`Cannot call a method on a null-valued expression`).
- Replace all direct `$existing.SamlEndpoints` access with the pre-flattened result from the new helper. This also fixes a silent idempotency bug: under implicit remoting, the update path was comparing against stringified garbage rather than real endpoint values, so any trust with `saml_endpoint` configured would have reported `changed: true` on every single run.
- Extract implicit-remoting-safe logic for both writing (`Invoke-AdfsTrustSamlEndpoint`) and reading (`Get-AdfsRelyingPartyTrustDetail`) relying party trust data into dedicated helper functions, so both call paths handle the remoting boundary consistently.

### Fixes: error handling & update path
- Mutating cmdlet calls (Set/Enable/Disable/Remove-AdfsRelyingPartyTrust) now use `-ErrorAction Stop`, so failures trigger `FailJson` instead of being silently swallowed and reported as a successful change.
- Add `-Confirm:$false` to Set/Enable/Disable to avoid hanging on an interactive prompt in unattended runs.
- `identifier` and `wsfed_endpoint` are now applied on update, not just at creation (previously silently ignored on existing trusts).
- Remove the manual `Invoke-WebRequest` reachability check for `metadata_url` — duplicated what `Add-AdfsRelyingPartyTrust` already does and could fail differently than the real call.
- Rewrite `Test-AdfsValueChanged` to use `HashSet.SetEquals` instead of `Compare-Object`. `Compare-Object` throws `Cannot bind argument to parameter 'ReferenceObject' because it is null` when passed a genuinely empty array, due to a PowerShell parameter-binding quirk — this crashed any update where a previously-unset property (e.g. `notes`) was being set for the first time. The rewrite also gives correct unordered-set comparison semantics for `identifier`, rather than `Compare-Object`'s default order/multiset-sensitive behavior.
- `module.Result` now returns all manageable properties instead of three, useful for verification/debugging.
- Remove redundant `no_log = $false` from `token_lifetime`.

### Feature: check-mode result fidelity
- In check mode, populate `module.Result` from the desired parameters (create path), or an overlay of desired params on top of the real current state (update path), instead of leaving result fields at their empty/null defaults. Previously, check-mode runs correctly reported `changed: true`, but every other result field (`identifier`, `notes`, `saml_endpoints`, etc.) came back empty/null since no real object exists yet to read back from.

### Tests & cleanup
- Add tests for multi-URL SAML endpoints and changing them.
- Add integration coverage asserting check-mode result fields are populated, not just `changed`.
- Add integration coverage for `saml_endpoint` create/update specifically under an implicit-remoting (PowerShell 7 / `pwsh`) context, since that configuration was previously silently broken (false `changed: true` on every run) and would not necessarily be caught by tests run only under native `powershell.exe` 5.1.
- Remove `ignore_errors: true` from cleanup tasks — the module shouldn't fail on `state: absent`.

### Docs
- Update option descriptions (`metadata_url`, `identifier`, `wsfed_endpoint`) to match the above.
- Add examples for the newly-supported update paths.
- Add RETURN entries for the newly-returned fields.

## Testing
- [ ] Verified create path (metadata_url / metadata_file / identifier)
- [ ] Verified update path, including identifier and wsfed_endpoint changes
- [ ] Verified SAML endpoint replacement and drift detection
- [ ] Verified check_mode reports changes without applying them
- [ ] Tested against ADFS module loaded via implicit remoting

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
fs_trust