### PR TITLE
fix: add missing infra_type and infra_bucket taxonomy fields

### DIFF
--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -74,6 +74,8 @@ microsoft.ad.computer:
         sid: ($data.sid // null)
       },
       facts: {
+        infra_type: "private_cloud",
+        infra_bucket: "compute",
         device_type: "virtual_machine",
         platform: "microsoft_ad",
         distinguished_name: $data.distinguished_name


### PR DESCRIPTION
## Summary

The `event_query.yml` audit filter for `microsoft.ad.computer` is missing the required `infra_type` and `infra_bucket` fields from the Ansible Normalized Resource Taxonomy v1.0. Without these fields, indirect node records cannot be categorized in cross-vendor reporting.

**Before:** Only `device_type` and `platform` present in facts
**After:** `infra_type` and `infra_bucket` added

### Change

Added to the `microsoft.ad.computer` entry:

```yaml
infra_type: "private_cloud"
infra_bucket: "compute"
```

The existing `device_type: "virtual_machine"` already conforms to the taxonomy and is unchanged. No changes to JQ query logic, guards, or canonical_facts.

## Test Plan

- [x] YAML validates with `yaml.safe_load()`
- [x] No changes to query logic or deduplication guards
- [ ] Integration test with AAP telemetry pipeline (post-merge)

Signed-off-by: Steve Fulmer <sfulmer@redhat.com> (Red Hat)