### PR TITLE
group - Fix identity lookup logic

### DIFF
--- a/changelogs/fragments/group-identity-lookup.yml
+++ b/changelogs/fragments/group-identity-lookup.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    group - Treat the ``name`` value as part of the object's distinguished name to avoid any false matches for a
+    ``userPrincipalName`` or ``sAMAccountName`` pattern -
+    https://github.com/ansible-collections/microsoft.ad/issues/198

--- a/plugins/module_utils/_ADObject.psm1
+++ b/plugins/module_utils/_ADObject.psm1
@@ -670,6 +670,10 @@ Function Get-AnsibleADObject {
 
     .PARAMETER GetCommand
     The Get-AD* cmdlet to use to get the AD object. Defaults to Get-ADObject.
+
+    .PARAMETER IdentityPassThru
+    Use the -Identity as the -Identity value for the GetCommand command. This
+    skips the preparse logic and is useful for when the -Identity is a DN/GUID.
     #>
     [OutputType([Microsoft.ActiveDirectory.Management.ADObject])]
     [CmdletBinding()]
@@ -691,7 +695,11 @@ Function Get-AnsibleADObject {
 
         [Parameter()]
         [System.Management.Automation.CommandInfo]
-        $GetCommand = $null
+        $GetCommand = $null,
+
+        [Parameter()]
+        [switch]
+        $IdentityPassThru
     )
 
     $getParams = @{}
@@ -705,14 +713,34 @@ Function Get-AnsibleADObject {
         $getParams.Credential = $Credential
     }
 
+    if ($GetCommand) {
+        $null = $getParams.Remove('GetCommand')
+    }
+    else {
+        $GetCommand = Get-Command -Name Get-ADObject -Module ActiveDirectory
+    }
+
+    # Not all LDAP objects support userPrincipalName or sAMAccount, we only try
+    # and filter by that if we know it is supported.
+    $tryUPN = $GetCommand.Name -in @(
+        'Get-ADComputer'
+        'Get-ADObject'
+        'Get-ADUser'
+        'Get-ADServiceAccount'
+    )
+    $trySAM = $tryUPN -or $GetCommand.Name -in @('Get-ADGroup')
+
     # The -Identity parameter is used where possible as LDAPFilter is limited
     # to just the defaultNamingContext as defined by -SearchBase.
     $objectGuid = [Guid]::Empty
     $tryDollarFallback = $false
-    if ([System.Guid]::TryParse($Identity, [ref]$objectGuid)) {
+    if ($IdentityPassThru -and $false) {
+        $getParams.Identity = $Identity
+    }
+    elseif ([System.Guid]::TryParse($Identity, [ref]$objectGuid)) {
         $getParams.Identity = $objectGuid
     }
-    elseif ($Identity -match '^.*\@.*\..*$') {
+    elseif ($tryUPN -and $Identity -match '^.*\@.*\..*$') {
         $getParams.LDAPFilter = "(userPrincipalName=$($Matches[0]))"
     }
     else {
@@ -727,7 +755,7 @@ Function Get-AnsibleADObject {
             $getParams.LDAPFilter = "(objectSid=$value)"
         }
         catch [System.ArgumentException] {
-            if ($Identity -match '^(?:[^:*?""<>|\/\\]+\\)?(?<username>[^;:""<>|?,=\*\+\\\(\)]+)$') {
+            if ($trySAM -and $Identity -match '^(?:[^:*?""<>|\/\\]+\\)?(?<username>[^;:""<>|?,=\*\+\\\(\)]+)$') {
                 $tryDollarFallback = -not $Matches.username.EndsWith('$')
                 $getParams.LDAPFilter = "(sAMAccountName=$($Matches.username))"
             }
@@ -738,12 +766,6 @@ Function Get-AnsibleADObject {
         }
     }
 
-    if ($GetCommand) {
-        $null = $getParams.Remove('GetCommand')
-    }
-    else {
-        $GetCommand = Get-Command -Name Get-ADObject -Module ActiveDirectory
-    }
     try {
         $obj = & $GetCommand @getParams | Select-Object -First 1
     }
@@ -1101,7 +1123,11 @@ Function Invoke-AnsibleADObject {
         $namePrefix = 'OU'
     }
 
-    $identity = if ($module.Params.identity) {
+    $getParams = @{
+        GetCommand = $getCommand
+        Properties = $requestedAttributes
+    }
+    $getParams.Identity = if ($module.Params.identity) {
         $module.Params.identity
     }
     else {
@@ -1110,13 +1136,13 @@ Function Invoke-AnsibleADObject {
             $ouPath = $module.Params.path
         }
         "$namePrefix=$($Module.Params.name -replace ',', '\,'),$ouPath"
+
+        # To avoid any ambiguity we tell the underlying lookup this is a DN
+        # and to use it directly as the -Identity parameter value.
+        # https://github.com/ansible-collections/microsoft.ad/issues/198
+        $getParams.IdentityPassThru = $true
     }
 
-    $getParams = @{
-        GetCommand = $getCommand
-        Identity = $identity
-        Properties = $requestedAttributes
-    }
     $adObject = Get-AnsibleADObject @getParams @adParams
     if ($adObject) {
         $module.Result.object_guid = $adObject.ObjectGUID

--- a/tests/integration/targets/group/tasks/tests.yml
+++ b/tests/integration/targets/group/tasks/tests.yml
@@ -648,3 +648,76 @@
       name: MyOU
       state: absent
       identity: '{{ ou_info.object_guid }}'
+
+# Various identity/name lookup tests for object CN that looks like a UPN but
+# object does not support userPrincipalName.
+# https://github.com/ansible-collections/microsoft.ad/issues/198
+- block:
+  - name: create group with upn like name
+    group:
+      name: MyGroup@domain
+      state: present
+      scope: global
+    register: group_like_upn
+
+  - name: get result of create group with upn like name
+    object_info:
+      identity: '{{ group_like_upn.object_guid }}'
+      properties:
+      - objectSid
+      - sAMAccountName
+    register: group_like_upn_actual
+
+  - name: assert create group with upn like name
+    assert:
+      that:
+      - group_like_upn is changed
+      - group_like_upn_actual.objects | length == 1
+      - group_like_upn_actual.objects[0].DistinguishedName == group_like_upn.distinguished_name
+      - group_like_upn_actual.objects[0].ObjectGUID == group_like_upn.object_guid
+      - group_like_upn_actual.objects[0].objectSid.Sid == group_like_upn.sid
+      - group_like_upn_actual.objects[0].sAMAccountName == 'MyGroup@domain'
+
+  - name: create group with upn like name - idempotent
+    group:
+      name: MyGroup@domain
+      state: present
+      scope: global
+    register: group_like_upn_again
+
+  - name: assert create group with upn like name - idempotent
+    assert:
+      that:
+      - not group_like_upn_again is changed
+
+  - name: verify group can be found by identity option that looks like a UPN
+    group:
+      identity: MyGroup@domain
+      state: present
+      scope: global
+    register: group_like_upn_identity
+
+  - name: assert verify group can be found by identity option
+    assert:
+      that:
+      - not group_like_upn_identity is changed
+      - group_like_upn_identity.object_guid == group_like_upn.object_guid
+
+  always:
+  - name: remove temp group
+    group:
+      name: MyGroup@domain
+      identity: '{{ group_like_upn.object_guid | default(omit) }}'
+      state: absent
+    register: remove_group_like_upn
+
+- name: get result of remove temp group
+  object_info:
+    identity: '{{ group_like_upn.object_guid }}'
+  register: remove_group_like_upn_actual
+
+- name: assert remove temp group
+  assert:
+    that:
+    - remove_group_like_upn is changed
+    - remove_group_like_upn_actual.objects == []


### PR DESCRIPTION
##### SUMMARY
Fix the AD object identity lookup logic to always find by DN/-Identity when we build the identity based on the module's `name` value. Also adds selective logic to only search by userPrincipalName or sAMAccountName on specific object types we know support those attributes.

Fixes: https://github.com/ansible-collections/microsoft.ad/issues/198

##### ISSUE TYPE
- Bugfix Pull Request