### PR TITLE
Fix lookup logic for identity

### DIFF
--- a/plugins/module_utils/_ADObject.psm1
+++ b/plugins/module_utils/_ADObject.psm1
@@ -734,7 +734,7 @@ Function Get-AnsibleADObject {
     # to just the defaultNamingContext as defined by -SearchBase.
     $objectGuid = [Guid]::Empty
     $tryDollarFallback = $false
-    if ($IdentityPassThru -and $false) {
+    if ($IdentityPassThru) {
         $getParams.Identity = $Identity
     }
     elseif ([System.Guid]::TryParse($Identity, [ref]$objectGuid)) {


### PR DESCRIPTION
##### SUMMARY
This `-and $false` was a leftover from testing and wasn't removed before the merge. While it's technically not needed it is cleaner to do this bypass if the caller has specified the identity value should be used directly and not interpreted as something else.

##### ISSUE TYPE
- Bugfix Pull Request